### PR TITLE
Add the space back

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -57,6 +57,7 @@ The following codec plugins are available:
 * <<plugins-codecs-s3_plain,s3_plain>>
 * <<plugins-codecs-spool,spool>>
 |&nbsp; 
+|&nbsp; 
 |=======================================================================
 
 include::codecs/compress_spooler.asciidoc[]


### PR DESCRIPTION
This was removed in https://github.com/elasticsearch/logstash-docs/commit/20a4cd9b7f04a373b03a59a23569e51bfd8ee724
