### PR TITLE
This addresses #73

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/html_docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,12 +1,13 @@
 [[logstash-reference]]
 = Reference
 
-:logstash_version: 1.5.0.beta1
-:elasticsearch_version: 1.4.1
+:logstash_version: 1.5.0.RC2
+:elasticsearch_version: 1.4.4
 :jdk:     1.7.0_60
 
 include::static/getting-started-with-logstash.asciidoc[]
 
+include::static/repositories.asciidoc[]
 include::static/command-line-flags.asciidoc[]
 
 include::static/configuration.asciidoc[]

--- a/docs/static/repositories.asciidoc
+++ b/docs/static/repositories.asciidoc
@@ -1,7 +1,7 @@
 :branch: 1.4
 
-[[setup-repositories]]
-== Repositories
+[[package-repositories]]
+== Package Repositories
 
 We also have repositories available for APT and YUM based distributions. Note
 that we only provide binary packages, but no source packages, as the packages

--- a/docs/static/repositories.asciidoc
+++ b/docs/static/repositories.asciidoc
@@ -1,0 +1,88 @@
+:branch: 1.4
+
+[[setup-repositories]]
+== Repositories
+
+We also have repositories available for APT and YUM based distributions. Note
+that we only provide binary packages, but no source packages, as the packages
+are created as part of the Logstash build.
+
+We have split the major versions in separate urls to avoid accidental upgrades
+across major version. For all 1.4.x releases use 1.4 as version number, for
+1.3.x use 1.3, etc.
+
+We use the PGP key
+http://pgp.mit.edu/pks/lookup?op=vindex&search=0xD27D666CD88E42B4[D88E42B4],
+Elasticsearch Signing Key, with fingerprint
+
+    4609 5ACC 8548 582C 1A26 99A9 D27D 666C D88E 42B4
+
+to sign all our packages. It is available from http://pgp.mit.edu.
+
+[float]
+=== APT
+
+Download and install the Public Signing Key:
+
+[source,sh]
+--------------------------------------------------
+wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+--------------------------------------------------
+
+Add the repository definition to your `/etc/apt/sources.list` file:
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+echo "deb http://packages.elasticsearch.org/logstash/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list
+--------------------------------------------------
+
+[WARNING]
+==================================================
+Use the `echo` method described above to add the Logstash repository.  Do not
+use `add-apt-repository` as it will add a `deb-src` entry as well, but we do not
+provide a source package. If you have added the `deb-src` entry, you will see an
+error like the following:
+
+    Unable to find expected entry 'main/source/Sources' in Release file (Wrong sources.list entry or malformed file)
+
+Just delete the `deb-src` entry from the `/etc/apt/sources.list` file and the
+installation should work as expected.
+==================================================
+
+Run `sudo apt-get update` and the repository is ready for use. You can install
+it with:
+
+[source,sh]
+--------------------------------------------------
+sudo apt-get update && sudo apt-get install logstash
+--------------------------------------------------
+
+[float]
+=== YUM
+
+Download and install the public signing key:
+
+[source,sh]
+--------------------------------------------------
+rpm --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+--------------------------------------------------
+
+Add the following in your `/etc/yum.repos.d/` directory
+in a file with a `.repo` suffix, for example `logstash.repo`
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+[logstash-{branch}]
+name=Logstash repository for {branch}.x packages
+baseurl=http://packages.elasticsearch.org/logstash/{branch}/centos
+gpgcheck=1
+gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+enabled=1
+--------------------------------------------------
+
+And your repository is ready for use. You can install it with:
+
+[source,sh]
+--------------------------------------------------
+yum install logstash
+--------------------------------------------------


### PR DESCRIPTION
Add repository information.

This also prevents the html_docs folder from being accidentally
merged by a `commit -a` by way of the `.gitignore`.