### PR TITLE
Fixes macro override by edit_url tags

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,10 +45,15 @@ include::plugins/codecs.asciidoc[]
 pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/asciidoc/static/contributing-to-logstash.asciidoc ?>]
 include::static/contributing-to-logstash.asciidoc[]
 
-pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/asciidoc/static/include/pluginbody.asciidoc ?>]
+// A space is necessary here ^^^
+pass::[<?edit_url?>]
+
+// This is in the pluginbody.asciidoc itself
+// pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/asciidoc/static/include/pluginbody.asciidoc ?>]
 include::static/input.asciidoc[]
 include::static/codec.asciidoc[]
 include::static/filter.asciidoc[]
 include::static/output.asciidoc[]
 
-pass::[<?edit_url?>]
+// This is in the pluginbody.asciidoc itself
+// pass::[<?edit_url?>]

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -1,3 +1,4 @@
+pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/asciidoc/static/include/pluginbody.asciidoc ?>]
 == How to write a Logstash {plugintype} plugin
 
 To develop a new {plugintype} for Logstash, you build a self-contained Ruby gem
@@ -1300,3 +1301,5 @@ https://github.com/elastic/logstash/issues[issue] in
 the Logstash repository. When the acceptance guidelines are completed, we will
 facilitate the move to the logstash-plugins organization using the recommended
 https://help.github.com/articles/transferring-a-repository/#transferring-from-a-user-to-an-organization[github process].
+
+pass::[<?edit_url?>]


### PR DESCRIPTION
Putting the tags in the file instead of in the index.asciidoc with
the "include" fixes this.