### PR TITLE
Update to match what's in zabbix output plugin

### DIFF
--- a/docs/plugins/outputs/zabbix.asciidoc
+++ b/docs/plugins/outputs/zabbix.asciidoc
@@ -178,6 +178,8 @@ A single field name which holds the value you intend to use as the Zabbix
 item key. This can be a sub-field of the @metadata field.
 This directive will be ignored if using `multi_value`
 
+IMPORTANT: `zabbix_key` is required if not using `multi_value`.
+
 [[plugins-outputs-zabbix-zabbix_server_host]]
 ===== `zabbix_server_host` 
 


### PR DESCRIPTION
This adds a tiny line of ASCIIDOC to ensure people know that `zabbix_key` is required if not using `multi_value`.