### PR TITLE
remove mention of post 2.3 releases

### DIFF
--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -14,9 +14,7 @@ of Logstash and the Kafka input plugin:
 |==========================================================
 |Kafka Broker Version |Kafka Client Version |Logstash Version |Plugin Version |Why?
 |0.8       |0.8       |2.0.0 - 2.x.x   |<3.0.0 |Legacy, 0.8 is still popular 
-|0.9       |0.9       |2.0.0 - 2.3.x   | 3.x.x |Works with the old Ruby Event API (`event['product']['price'] = 10`)  
-|0.9       |0.9       |2.4.0 - 5.0.x   | 4.x.x |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-|0.10      |0.10      |2.4.0 - 5.0.x   | 5.x.x |Not compatible with the 0.9 broker 
+|0.9       |0.9       |2.0.0 - 2.3.x   | 3.x.x |  
 |==========================================================
 
 NOTE: It's a good idea to upgrade brokers before consumers/producers because brokers target backwards compatibility.

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -11,9 +11,7 @@ of Logstash and the Kafka output plugin:
 |==========================================================
 |Kafka Broker Version |Kafka Client Version |Logstash Version |Plugin Version |Why?
 |0.8       |0.8       |2.0.0 - 2.x.x   |<3.0.0 |Legacy, 0.8 is still popular 
-|0.9       |0.9       |2.0.0 - 2.3.x   | 3.x.x |Works with the old Ruby Event API (`event['product']['price'] = 10`)  
-|0.9       |0.9       |2.4.0 - 5.0.x   | 4.x.x |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-|0.10      |0.10      |2.4.0 - 5.0.x   | 5.x.x |Not compatible with the 0.9 broker 
+|0.9       |0.9       |2.0.0 - 2.3.x   | 3.x.x |
 |==========================================================
 
 NOTE: It's a good idea to upgrade brokers before consumers/producers because brokers target backwards compatibility.


### PR DESCRIPTION
@suyograo Alvin thought we should remove mention of 2.4 and 5.0 LS releases from the LS 2.3 docs. When I did that, I also removed mention of the ruby event because it doesn't seem relevant in the context. 

I'm merging this, but you can always revert if you disagree with Alvin.

@acchen97 FYI