### PR TITLE
Bump product versions for alpha5

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,8 +2,8 @@
 = Reference
 
 :branch:                5.0
-:logstash_version:      5.0.0-alpha4
-:elasticsearch_version: 5.0.0-alpha4
+:logstash_version:      5.0.0-alpha5
+:elasticsearch_version: 5.0.0-alpha5
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
 :ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/current/


### PR DESCRIPTION
Don't merge this until the morning of the alpha5 release.

bump versions in index.asciidoc to 5.0.