### PR TITLE
Update docs for S3 input to reflect the realities of the code.

### DIFF
--- a/docs/plugins/inputs/s3.asciidoc
+++ b/docs/plugins/inputs/s3.asciidoc
@@ -233,7 +233,7 @@ The AWS Session token for temporary credentials
 ===== `sincedb_path` 
 
   * Value type is <<string,string>>
-  * Default value is `nil`
+  * Default value is `$HOME/.sincedb_{MD5(bucket + prefix)}`
 
 Where to write the since database (keeps track of the date
 the last handled file was added to S3). The default will write


### PR DESCRIPTION
The [docblock](https://github.com/logstash-plugins/logstash-input-s3/blob/master/lib/logstash/inputs/s3.rb#L27-L31) on `sincedb_path` suggests the default isn't `nil`. [Here's where the default is set](https://github.com/logstash-plugins/logstash-input-s3/blob/master/lib/logstash/inputs/s3.rb#L273-L275) to `$HOME/.sincedb_{hash}`.