### PR TITLE
Make vars used for doc links consistent

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -8,7 +8,7 @@
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
 :ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/5.0/
-:xpack:                 https://www.elastic.co/guide/en/x-pack/5.0
+:xpack:                 https://www.elastic.co/guide/en/x-pack/5.0/
 :logstash:              https://www.elastic.co/guide/en/logstash/5.0/
 :lsissue:               https://github.com/elastic/logstash/issues/
 :security:              X-Pack Security

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -16,7 +16,7 @@ consistent with other Elastic products. Full directory layout is described in <<
 (in core and plugins) were too noisy at INFO level, so we had to audit log messages and switch some of them to DEBUG
 level.
 
-**Index Template:** The index template for 5.0 has been changed to reflect {ref}/breaking_50_mapping_changes.html[Elasticsearch's mapping changes]. Most
+**Index Template:** The index template for 5.0 has been changed to reflect {ref}breaking_50_mapping_changes.html[Elasticsearch's mapping changes]. Most
 importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match Elasticsearch's default
 behavior. The impact of this change to various user groups is detailed below:
 
@@ -25,7 +25,7 @@ behavior. The impact of this change to various user groups is detailed below:
 * Existing users with custom templates - most of you won't be impacted because you use a custom template.
 * Existing users with default template - Logstash does not force you to upgrade templates if one already exists. If you
 intend to move to the new template and want to use `.keyword`, you'll have to reindex existing data. Elasticsearch's
- {ref}/docs-reindex.html[reindexing API] can help move your data from using `.raw` subfields to `.keyword`.
+ {ref}docs-reindex.html[reindexing API] can help move your data from using `.raw` subfields to `.keyword`.
 
 **Command Line Interface:** Most of the long form <<command-line-flags,options>> have been renamed 
 to adhere to the yml dot notation to be used in the settings file. Short form options have not been changed.

--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -63,7 +63,7 @@ nodes. By default, Logstash uses the HTTP protocol to move data into the cluster
 You can use the Elasticsearch HTTP REST APIs to index data into the Elasticsearch cluster. These APIs represent the
 indexed data in JSON. Using the REST APIs does not require the Java client classes or any additional JAR
 files and has no performance disadvantages compared to the transport or node protocols. You can secure communications
-that use the HTTP REST APIs by using {xpack}/xpack-security.html[{security}], which supports SSL and HTTP basic authentication.
+that use the HTTP REST APIs by using {xpack}xpack-security.html[{security}], which supports SSL and HTTP basic authentication.
 
 When you use the HTTP protocol, you can configure the Logstash Elasticsearch output plugin to automatically
 load-balance indexing requests across a


### PR DESCRIPTION
Minor tweak so that we use the same format to refer to vars that resolve to links in the build.