### PR TITLE
Remove relnotes from branch because 5.x is pre-release version

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -138,6 +138,3 @@ include::static/submitting-a-plugin.asciidoc[]
 pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/static/glossary.asciidoc ?>]
 include::static/glossary.asciidoc[]
 
-// Release Notes
-pass::[<?edit_url https://github.com/elastic/logstash/edit/master/docs/static/releasenotes.asciidoc ?>]
-include::static/releasenotes.asciidoc[]


### PR DESCRIPTION
Removed from the index.asciidoc. Removal of the file will happen when I sync up the branches.