### PR TITLE
Remove spool from list of codecs

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -54,7 +54,6 @@ at Elastic, and the broader community.
 | <<plugins-codecs-nmap,nmap>> | Reads Nmap data in XML format | https://github.com/logstash-plugins/logstash-codec-nmap[logstash-codec-nmap]
 | <<plugins-codecs-oldlogstashjson,oldlogstashjson>> | Reads Logstash JSON in the schema used by Logstash versions earlier than 1.2.0 | https://github.com/logstash-plugins/logstash-codec-oldlogstashjson[logstash-codec-oldlogstashjson]
 | <<plugins-codecs-s3_plain,s3_plain>> | Provides backwards compatibility with earlier versions of S3 Output  | https://github.com/logstash-plugins/logstash-codec-s3_plain[logstash-codec-s3_plain]
-| <<plugins-codecs-spool,spool>> | Collects events and transmits in batches | https://github.com/logstash-plugins/logstash-codec-spool[logstash-codec-spool]
 |=======================================================================
 
 pass::[<?edit_url https://github.com/logstash-plugins/logstash-codec-avro/edit/master/lib/logstash/codecs/avro.rb ?>]
@@ -105,7 +104,5 @@ pass::[<?edit_url https://github.com/logstash-plugins/logstash-codec-rubydebug/e
 include::codecs/rubydebug.asciidoc[]
 pass::[<?edit_url https://github.com/logstash-plugins/logstash-codec-s3_plain/edit/master/lib/logstash/codecs/s3_plain.rb ?>]
 include::codecs/s3_plain.asciidoc[]
-pass::[<?edit_url https://github.com/logstash-plugins/logstash-codec-spool/edit/master/lib/logstash/codecs/spool.rb ?>]
-include::codecs/spool.asciidoc[]
 
 pass::[<?edit_url?>]


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/5643 by removing spool from the list of available codecs.