### PR TITLE
Add note to use fingerprint filter instead of anonymize

### DIFF
--- a/docs/plugins/filters/anonymize.asciidoc
+++ b/docs/plugins/filters/anonymize.asciidoc
@@ -1,9 +1,9 @@
 [[plugins-filters-anonymize]]
 === anonymize
 
+NOTE: We recommend that you use the <<plugins-filters-fingerprint,fingerprint filter plugin>> instead of anonymize.
 
-
-Anonymize fields using by replacing values with a consistent hash.
+Anonymize fields by replacing values with a consistent hash.
 
 &nbsp;
 


### PR DESCRIPTION
The actual deprecation statement (https://github.com/logstash-plugins/logstash-filter-anonymize/pull/13) won't show up in the docs until we generate them for the next release, so I'm adding a note with our recommendation so users will know to use the fingerprint filter.
