### PR TITLE
Add protobuf to the index

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -30,6 +30,7 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-nmap,nmap>> | Reads Nmap data in XML format | https://github.com/logstash-plugins/logstash-codec-nmap[logstash-codec-nmap]
 | <<plugins-codecs-oldlogstashjson,oldlogstashjson>> | Reads Logstash JSON in the schema used by Logstash versions earlier than 1.2.0 | https://github.com/logstash-plugins/logstash-codec-oldlogstashjson[logstash-codec-oldlogstashjson]
 | <<plugins-codecs-plain,plain>> | Reads plaintext with no delimiting between events | https://github.com/logstash-plugins/logstash-codec-plain[logstash-codec-plain]
+| <<plugins-codecs-protobuf,protobuf>> | Reads protobuf messages and converts to Logstash Events | https://github.com/logstash-plugins/logstash-codec-protobuf[logstash-codec-protobuf]
 | <<plugins-codecs-rubydebug,rubydebug>> | Applies the Ruby Awesome Print library to Logstash events | https://github.com/logstash-plugins/logstash-codec-rubydebug[logstash-codec-rubydebug]
 | <<plugins-codecs-s3_plain,s3_plain>> | Provides backwards compatibility with earlier versions of S3 Output  | https://github.com/logstash-plugins/logstash-codec-s3_plain[logstash-codec-s3_plain]
 |=======================================================================
@@ -78,6 +79,8 @@ include::codecs/nmap.asciidoc[]
 include::codecs/oldlogstashjson.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/lib/logstash/codecs/plain.rb
 include::codecs/plain.asciidoc[]
+dit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/lib/logstash/codecs/protobuf.rb
+include::codecs/protobuf.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/lib/logstash/codecs/rubydebug.rb
 include::codecs/rubydebug.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-codec-s3_plain/edit/master/lib/logstash/codecs/s3_plain.rb


### PR DESCRIPTION
Adds TOC entry for protobuf codec added in https://github.com/elastic/logstash-docs/pull/375