### PR TITLE
Update edit links to point to asciidoc source

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -35,55 +35,55 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-s3_plain,s3_plain>> | Provides backwards compatibility with earlier versions of S3 Output  | https://github.com/logstash-plugins/logstash-codec-s3_plain[logstash-codec-s3_plain]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/master/lib/logstash/codecs/avro.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/master/docs/index.asciidoc
 include::codecs/avro.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/master/lib/logstash/codecs/cef.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/master/docs/index.asciidoc
 include::codecs/cef.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/lib/logstash/codecs/cloudfront.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/docs/index.asciidoc
 include::codecs/cloudfront.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/lib/logstash/codecs/cloudtrail.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/docs/index.asciidoc
 include::codecs/cloudtrail.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/lib/logstash/codecs/collectd.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-compress_spooler/edit/master/lib/logstash/codecs/compress_spooler.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-compress_spooler/edit/master/docs/index.asciidoc
 include::codecs/compress_spooler.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/lib/logstash/codecs/dots.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/docs/index.asciidoc
 include::codecs/dots.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/master/lib/logstash/codecs/edn.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/master/docs/index.asciidoc
 include::codecs/edn.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/master/lib/logstash/codecs/edn_lines.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/master/docs/index.asciidoc
 include::codecs/edn_lines.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/master/lib/logstash/codecs/es_bulk.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/master/docs/index.asciidoc
 include::codecs/es_bulk.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/master/lib/logstash/codecs/fluent.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/master/docs/index.asciidoc
 include::codecs/fluent.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/master/lib/logstash/codecs/graphite.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/master/docs/index.asciidoc
 include::codecs/graphite.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/lib/logstash/codecs/gzip_lines.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/lib/logstash/codecs/json.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/docs/index.asciidoc
 include::codecs/json.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/master/lib/logstash/codecs/json_lines.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/master/docs/index.asciidoc
 include::codecs/json_lines.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/master/lib/logstash/codecs/line.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/master/docs/index.asciidoc
 include::codecs/line.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/master/lib/logstash/codecs/msgpack.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/master/docs/index.asciidoc
 include::codecs/msgpack.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/master/lib/logstash/codecs/multiline.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/master/docs/index.asciidoc
 include::codecs/multiline.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/master/lib/logstash/codecs/netflow.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/master/docs/index.asciidoc
 include::codecs/netflow.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/master/lib/logstash/codecs/nmap.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/master/docs/index.asciidoc
 include::codecs/nmap.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-oldlogstashjson/edit/master/lib/logstash/codecs/oldlogstashjson.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-oldlogstashjson/edit/master/docs/index.asciidoc
 include::codecs/oldlogstashjson.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/lib/logstash/codecs/plain.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/docs/index.asciidoc
 include::codecs/plain.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/lib/logstash/codecs/protobuf.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/docs/index.asciidoc
 include::codecs/protobuf.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/lib/logstash/codecs/rubydebug.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/docs/index.asciidoc
 include::codecs/rubydebug.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-codec-s3_plain/edit/master/lib/logstash/codecs/s3_plain.rb
+:edit_url: https://github.com/logstash-plugins/logstash-codec-s3_plain/edit/master/docs/index.asciidoc
 include::codecs/s3_plain.asciidoc[]
 
 :edit_url: 

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -58,101 +58,101 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-zeromq,zeromq>> | Sends an event to ZeroMQ | https://github.com/logstash-plugins/logstash-filter-zeromq[logstash-filter-zeromq]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-age/edit/master/lib/logstash/filters/age.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-age/edit/master/docs/index.asciidoc
 include::filters/age.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/lib/logstash/filters/aggregate.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/docs/index.asciidoc
 include::filters/aggregate.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/lib/logstash/filters/alter.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/docs/index.asciidoc
 include::filters/alter.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-anonymize/edit/master/lib/logstash/filters/anonymize.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-anonymize/edit/master/docs/index.asciidoc
 include::filters/anonymize.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/lib/logstash/filters/cidr.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/docs/index.asciidoc
 include::filters/cidr.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/master/lib/logstash/filters/cipher.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/master/docs/index.asciidoc
 include::filters/cipher.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/master/lib/logstash/filters/clone.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/master/docs/index.asciidoc
 include::filters/clone.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-collate/edit/master/lib/logstash/filters/collate.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-collate/edit/master/docs/index.asciidoc
 include::filters/collate.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/master/lib/logstash/filters/csv.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/master/docs/index.asciidoc
 include::filters/csv.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/master/lib/logstash/filters/date.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/master/docs/index.asciidoc
 include::filters/date.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/lib/logstash/filters/de_dot.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/docs/index.asciidoc
 include::filters/de_dot.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/lib/logstash/filters/dns.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
 include::filters/dissect.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/lib/logstash/filters/dissect.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
 include::filters/dns.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/lib/logstash/filters/drop.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/docs/index.asciidoc
 include::filters/drop.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/master/lib/logstash/filters/elapsed.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/master/docs/index.asciidoc
 include::filters/elapsed.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/master/lib/logstash/filters/elasticsearch.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/master/docs/index.asciidoc
 include::filters/elasticsearch.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-emoji/edit/master/lib/logstash/filters/emoji.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-emoji/edit/master/docs/index.asciidoc
 include::filters/emoji.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/master/lib/logstash/filters/environment.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/master/docs/index.asciidoc
 include::filters/environment.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/master/lib/logstash/filters/extractnumbers.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/master/docs/index.asciidoc
 include::filters/extractnumbers.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/master/lib/logstash/filters/fingerprint.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/master/docs/index.asciidoc
 include::filters/fingerprint.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/master/lib/logstash/filters/geoip.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/master/docs/index.asciidoc
 include::filters/geoip.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/lib/logstash/filters/grok.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/docs/index.asciidoc
 include::filters/grok.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/lib/logstash/filters/i18n.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/master/lib/logstash/filters/jdbc_streaming.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/master/docs/index.asciidoc
 include::filters/jdbc_streaming.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/lib/logstash/filters/json.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/docs/index.asciidoc
 include::filters/json.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/master/lib/logstash/filters/json_encode.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/master/docs/index.asciidoc
 include::filters/json_encode.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/lib/logstash/filters/kv.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/docs/index.asciidoc
 include::filters/kv.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metaevent/edit/master/lib/logstash/filters/metaevent.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metaevent/edit/master/docs/index.asciidoc
 include::filters/metaevent.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/lib/logstash/filters/metricize.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/docs/index.asciidoc
 include::filters/metricize.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/master/lib/logstash/filters/metrics.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/master/docs/index.asciidoc
 include::filters/metrics.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/master/lib/logstash/filters/mutate.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/master/docs/index.asciidoc
 include::filters/mutate.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-oui/edit/master/lib/logstash/filters/oui.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-oui/edit/master/docs/index.asciidoc
 include::filters/oui.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/master/lib/logstash/filters/prune.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/master/docs/index.asciidoc
 include::filters/prune.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-punct/edit/master/lib/logstash/filters/punct.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-punct/edit/master/docs/index.asciidoc
 include::filters/punct.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/master/lib/logstash/filters/range.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/master/docs/index.asciidoc
 include::filters/range.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/master/lib/logstash/filters/ruby.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/master/docs/index.asciidoc
 include::filters/ruby.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/master/lib/logstash/filters/sleep.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/master/docs/index.asciidoc
 include::filters/sleep.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/master/lib/logstash/filters/split.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/master/docs/index.asciidoc
 include::filters/split.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/lib/logstash/filters/syslog_pri.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/docs/index.asciidoc
 include::filters/syslog_pri.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/lib/logstash/filters/throttle.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/docs/index.asciidoc
 include::filters/throttle.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/master/lib/logstash/filters/tld.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/master/docs/index.asciidoc
 include::filters/tld.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/master/lib/logstash/filters/translate.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/master/docs/index.asciidoc
 include::filters/translate.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/master/lib/logstash/filters/urldecode.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/master/docs/index.asciidoc
 include::filters/urldecode.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/master/lib/logstash/filters/useragent.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/master/docs/index.asciidoc
 include::filters/useragent.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/master/lib/logstash/filters/uuid.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/master/docs/index.asciidoc
 include::filters/uuid.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/master/lib/logstash/filters/xml.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/master/docs/index.asciidoc
 include::filters/xml.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-yaml/edit/master/lib/logstash/filters/yaml.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-yaml/edit/master/docs/index.asciidoc
 include::filters/yaml.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-filter-zeromq/edit/master/lib/logstash/filters/zeromq.rb
+:edit_url: https://github.com/logstash-plugins/logstash-filter-zeromq/edit/master/docs/index.asciidoc
 include::filters/zeromq.asciidoc[]
 
 :edit_url: 

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -62,111 +62,111 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-zeromq,zeromq>> | Reads events from a ZeroMQ SUB socket | https://github.com/logstash-plugins/logstash-input-zeromq[logstash-input-zeromq]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/master/lib/logstash/inputs/beats.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/master/docs/index.asciidoc
 include::inputs/beats.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-cloudwatch/edit/master/lib/logstash/inputs/cloudwatch.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-cloudwatch/edit/master/docs/index.asciidoc
 include::inputs/cloudwatch.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/master/lib/logstash/inputs/couchdb_changes.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/master/docs/index.asciidoc
 include::inputs/couchdb_changes.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-drupal_dblog/edit/master/lib/logstash/inputs/drupal_dblog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-drupal_dblog/edit/master/docs/index.asciidoc
 include::inputs/drupal_dblog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/edit/master/lib/logstash/inputs/elasticsearch.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/edit/master/docs/index.asciidoc
 include::inputs/elasticsearch.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-eventlog/edit/master/lib/logstash/inputs/eventlog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-eventlog/edit/master/docs/index.asciidoc
 include::inputs/eventlog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-exec/edit/master/lib/logstash/inputs/exec.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-exec/edit/master/docs/index.asciidoc
 include::inputs/exec.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-file/edit/master/lib/logstash/inputs/file.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-file/edit/master/docs/index.asciidoc
 include::inputs/file.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-ganglia/edit/master/lib/logstash/inputs/ganglia.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-ganglia/edit/master/docs/index.asciidoc
 include::inputs/ganglia.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-gelf/edit/master/lib/logstash/inputs/gelf.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-gelf/edit/master/docs/index.asciidoc
 include::inputs/gelf.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-gemfire/edit/master/lib/logstash/inputs/gemfire.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-gemfire/edit/master/docs/index.asciidoc
 include::inputs/gemfire.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-generator/edit/master/lib/logstash/inputs/generator.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-generator/edit/master/docs/index.asciidoc
 include::inputs/generator.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/lib/logstash/inputs/github.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/docs/index.asciidoc
 include::inputs/github.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-graphite/edit/master/lib/logstash/inputs/google_pubsub.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-graphite/edit/master/docs/index.asciidoc
 include::inputs/google_pubsub.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/lib/logstash/inputs/graphite.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/docs/index.asciidoc
 include::inputs/graphite.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-heartbeat/edit/master/lib/logstash/inputs/heartbeat.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-heartbeat/edit/master/docs/index.asciidoc
 include::inputs/heartbeat.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-heroku/edit/master/lib/logstash/inputs/heroku.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-heroku/edit/master/docs/index.asciidoc
 include::inputs/heroku.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-http/edit/master/lib/logstash/inputs/http.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-http/edit/master/docs/index.asciidoc
 include::inputs/http.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-http_poller/edit/master/lib/logstash/inputs/http_poller.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-http_poller/edit/master/docs/index.asciidoc
 include::inputs/http_poller.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-imap/edit/master/lib/logstash/inputs/imap.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-imap/edit/master/docs/index.asciidoc
 include::inputs/imap.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/master/lib/logstash/inputs/irc.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/master/docs/index.asciidoc
 include::inputs/irc.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/lib/logstash/inputs/jdbc.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
 include::inputs/jdbc.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/lib/logstash/inputs/jmx.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/docs/index.asciidoc
 include::inputs/jmx.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/master/lib/logstash/inputs/kafka.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/master/docs/index.asciidoc
 include::inputs/kafka.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/master/lib/logstash/inputs/kinesis.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/master/docs/index.asciidoc
 include::inputs/kinesis.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/master/lib/logstash/inputs/log4j.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/master/docs/index.asciidoc
 include::inputs/log4j.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-lumberjack/edit/master/lib/logstash/inputs/lumberjack.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-lumberjack/edit/master/docs/index.asciidoc
 include::inputs/lumberjack.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-meetup/edit/master/lib/logstash/inputs/meetup.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-meetup/edit/master/docs/index.asciidoc
 include::inputs/meetup.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-pipe/edit/master/lib/logstash/inputs/pipe.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-pipe/edit/master/docs/index.asciidoc
 include::inputs/pipe.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/master/lib/logstash/inputs/puppet_facter.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/master/docs/index.asciidoc
 include::inputs/puppet_facter.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/master/lib/logstash/inputs/rabbitmq.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/master/docs/index.asciidoc
 include::inputs/rabbitmq.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-rackspace/edit/master/lib/logstash/inputs/rackspace.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-rackspace/edit/master/docs/index.asciidoc
 include::inputs/rackspace.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/master/lib/logstash/inputs/redis.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/master/docs/index.asciidoc
 include::inputs/redis.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-relp/edit/master/lib/logstash/inputs/relp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-relp/edit/master/docs/index.asciidoc
 include::inputs/relp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-rss/edit/master/lib/logstash/inputs/rss.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-rss/edit/master/docs/index.asciidoc
 include::inputs/rss.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/master/lib/logstash/inputs/s3.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/master/docs/index.asciidoc
 include::inputs/s3.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/master/lib/logstash/inputs/salesforce.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/master/docs/index.asciidoc
 include::inputs/salesforce.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-snmptrap/edit/master/lib/logstash/inputs/snmptrap.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-snmptrap/edit/master/docs/index.asciidoc
 include::inputs/snmptrap.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-sqlite/edit/master/lib/logstash/inputs/sqlite.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-sqlite/edit/master/docs/index.asciidoc
 include::inputs/sqlite.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-sqs/edit/master/lib/logstash/inputs/sqs.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-sqs/edit/master/docs/index.asciidoc
 include::inputs/sqs.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-stdin/edit/master/lib/logstash/inputs/stdin.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-stdin/edit/master/docs/index.asciidoc
 include::inputs/stdin.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-stomp/edit/master/lib/logstash/inputs/stomp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-stomp/edit/master/docs/index.asciidoc
 include::inputs/stomp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-syslog/edit/master/lib/logstash/inputs/syslog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-syslog/edit/master/docs/index.asciidoc
 include::inputs/syslog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-tcp/edit/master/lib/logstash/inputs/tcp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-tcp/edit/master/docs/index.asciidoc
 include::inputs/tcp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-twitter/edit/master/lib/logstash/inputs/twitter.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-twitter/edit/master/docs/index.asciidoc
 include::inputs/twitter.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-udp/edit/master/lib/logstash/inputs/udp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-udp/edit/master/docs/index.asciidoc
 include::inputs/udp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-unix/edit/master/lib/logstash/inputs/unix.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-unix/edit/master/docs/index.asciidoc
 include::inputs/unix.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-varnishlog/edit/master/lib/logstash/inputs/varnishlog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-varnishlog/edit/master/docs/index.asciidoc
 include::inputs/varnishlog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-websocket/edit/master/lib/logstash/inputs/websocket.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-websocket/edit/master/docs/index.asciidoc
 include::inputs/websocket.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-wmi/edit/master/lib/logstash/inputs/wmi.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-wmi/edit/master/docs/index.asciidoc
 include::inputs/wmi.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-xmpp/edit/master/lib/logstash/inputs/xmpp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-xmpp/edit/master/docs/index.asciidoc
 include::inputs/xmpp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-zenoss/edit/master/lib/logstash/inputs/zenoss.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-zenoss/edit/master/docs/index.asciidoc
 include::inputs/zenoss.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-input-zeromq/edit/master/lib/logstash/inputs/zeromq.rb
+:edit_url: https://github.com/logstash-plugins/logstash-input-zeromq/edit/master/docs/index.asciidoc
 include::inputs/zeromq.asciidoc[]
 
 :edit_url: 

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -64,115 +64,115 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-zeromq,zeromq>> | Writes events to a ZeroMQ PUB socket | https://github.com/logstash-plugins/logstash-output-zeromq[logstash-output-zeromq]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/lib/logstash/outputs/boundary.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/docs/index.asciidoc
 include::outputs/boundary.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/master/lib/logstash/outputs/circonus.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/master/docs/index.asciidoc
 include::outputs/circonus.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/master/lib/logstash/outputs/cloudwatch.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/master/docs/index.asciidoc
 include::outputs/cloudwatch.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/master/lib/logstash/outputs/csv.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/master/docs/index.asciidoc
 include::outputs/csv.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/master/lib/logstash/outputs/datadog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/master/docs/index.asciidoc
 include::outputs/datadog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/lib/logstash/outputs/datadog_metrics.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/master/lib/logstash/outputs/elasticsearch.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/master/docs/index.asciidoc
 include::outputs/elasticsearch.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/master/lib/logstash/outputs/email.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/master/docs/index.asciidoc
 include::outputs/email.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/master/lib/logstash/outputs/exec.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/master/docs/index.asciidoc
 include::outputs/exec.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/master/lib/logstash/outputs/file.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/master/docs/index.asciidoc
 include::outputs/file.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/master/lib/logstash/outputs/ganglia.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/master/docs/index.asciidoc
 include::outputs/ganglia.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/master/lib/logstash/outputs/gelf.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/master/docs/index.asciidoc
 include::outputs/gelf.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/lib/logstash/outputs/google_bigquery.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/docs/index.asciidoc
 include::outputs/google_bigquery.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/edit/master/lib/logstash/outputs/google_cloud_storage.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/edit/master/docs/index.asciidoc
 include::outputs/google_cloud_storage.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/lib/logstash/outputs/graphite.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/docs/index.asciidoc
 include::outputs/graphite.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/master/lib/logstash/outputs/graphtastic.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/master/docs/index.asciidoc
 include::outputs/graphtastic.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-hipchat/edit/master/lib/logstash/outputs/hipchat.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-hipchat/edit/master/docs/index.asciidoc
 include::outputs/hipchat.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/master/lib/logstash/outputs/http.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/master/docs/index.asciidoc
 include::outputs/http.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/master/lib/logstash/outputs/influxdb.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/master/docs/index.asciidoc
 include::outputs/influxdb.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/lib/logstash/outputs/irc.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/docs/index.asciidoc
 include::outputs/irc.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-jira/edit/master/lib/logstash/outputs/jira.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-jira/edit/master/docs/index.asciidoc
 include::outputs/jira.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/lib/logstash/outputs/juggernaut.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/master/lib/logstash/outputs/kafka.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/master/docs/index.asciidoc
 include::outputs/kafka.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/lib/logstash/outputs/librato.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/docs/index.asciidoc
 include::outputs/librato.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/master/lib/logstash/outputs/loggly.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/master/docs/index.asciidoc
 include::outputs/loggly.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/master/lib/logstash/outputs/lumberjack.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/master/docs/index.asciidoc
 include::outputs/lumberjack.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/master/lib/logstash/outputs/metriccatcher.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/master/docs/index.asciidoc
 include::outputs/metriccatcher.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/master/lib/logstash/outputs/mongodb.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/master/docs/index.asciidoc
 include::outputs/mongodb.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/master/lib/logstash/outputs/nagios.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/master/docs/index.asciidoc
 include::outputs/nagios.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/master/lib/logstash/outputs/nagios_nsca.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/master/docs/index.asciidoc
 include::outputs/nagios_nsca.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-newrelic/edit/master/lib/logstash/outputs/newrelic.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-newrelic/edit/master/docs/index.asciidoc
 include::outputs/newrelic.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/master/lib/logstash/outputs/opentsdb.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/master/docs/index.asciidoc
 include::outputs/opentsdb.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/master/lib/logstash/outputs/pagerduty.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/master/docs/index.asciidoc
 include::outputs/pagerduty.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/lib/logstash/outputs/pipe.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/docs/index.asciidoc
 include::outputs/pipe.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/master/lib/logstash/outputs/rabbitmq.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/master/docs/index.asciidoc
 include::outputs/rabbitmq.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-rackspace/edit/master/lib/logstash/outputs/rackspace.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-rackspace/edit/master/docs/index.asciidoc
 include::outputs/rackspace.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/lib/logstash/outputs/redis.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/docs/index.asciidoc
 include::outputs/redis.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/master/lib/logstash/outputs/redmine.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/master/docs/index.asciidoc
 include::outputs/redmine.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/master/lib/logstash/outputs/riak.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/master/docs/index.asciidoc
 include::outputs/riak.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/master/lib/logstash/outputs/riemann.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/master/docs/index.asciidoc
 include::outputs/riemann.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/master/lib/logstash/outputs/s3.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/master/docs/index.asciidoc
 include::outputs/s3.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/master/lib/logstash/outputs/sns.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/master/docs/index.asciidoc
 include::outputs/sns.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/master/lib/logstash/outputs/solr_http.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/master/docs/index.asciidoc
 include::outputs/solr_http.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/master/lib/logstash/outputs/sqs.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/master/docs/index.asciidoc
 include::outputs/sqs.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/master/lib/logstash/outputs/statsd.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/master/docs/index.asciidoc
 include::outputs/statsd.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/master/lib/logstash/outputs/stdout.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/master/docs/index.asciidoc
 include::outputs/stdout.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/master/lib/logstash/outputs/stomp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/master/docs/index.asciidoc
 include::outputs/stomp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/master/lib/logstash/outputs/syslog.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/master/docs/index.asciidoc
 include::outputs/syslog.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/master/lib/logstash/outputs/tcp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/master/docs/index.asciidoc
 include::outputs/tcp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/master/lib/logstash/outputs/udp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/master/docs/index.asciidoc
 include::outputs/udp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/master/lib/logstash/outputs/webhdfs.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/master/docs/index.asciidoc
 include::outputs/webhdfs.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/master/lib/logstash/outputs/websocket.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/master/docs/index.asciidoc
 include::outputs/websocket.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/master/lib/logstash/outputs/xmpp.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/master/docs/index.asciidoc
 include::outputs/xmpp.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/master/lib/logstash/outputs/zabbix.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/master/docs/index.asciidoc
 include::outputs/zabbix.asciidoc[]
-:edit_url: https://github.com/logstash-plugins/logstash-output-zeromq/edit/master/lib/logstash/outputs/zeromq.rb
+:edit_url: https://github.com/logstash-plugins/logstash-output-zeromq/edit/master/docs/index.asciidoc
 include::outputs/zeromq.asciidoc[]
 
 :edit_url: 


### PR DESCRIPTION
@ph Please review. Updated the Edit URLs to point to the asciidoc files instead of the Ruby source code. 