### PR TITLE
Update plugin docs for 5.5 - patched versions

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -24,7 +24,7 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-json,json>> | Reads JSON formatted content, creating one event per element in a JSON array | https://github.com/logstash-plugins/logstash-codec-json[logstash-codec-json]
 | <<plugins-codecs-json_lines,json_lines>> | Reads newline-delimited JSON | https://github.com/logstash-plugins/logstash-codec-json_lines[logstash-codec-json_lines]
 | <<plugins-codecs-line,line>> | Reads line-oriented text data | https://github.com/logstash-plugins/logstash-codec-line[logstash-codec-line]
-| <<plugins-codecs-msgpack,msgpack>> |  | https://github.com/logstash-plugins/logstash-codec-msgpack[logstash-codec-msgpack]
+| <<plugins-codecs-msgpack,msgpack>> | Reads MessagePack encoded content | https://github.com/logstash-plugins/logstash-codec-msgpack[logstash-codec-msgpack]
 | <<plugins-codecs-multiline,multiline>> | Merges multiline messages into a single event | https://github.com/logstash-plugins/logstash-codec-multiline[logstash-codec-multiline]
 | <<plugins-codecs-netflow,netflow>> | Reads Netflow v5 and Netflow v9 data | https://github.com/logstash-plugins/logstash-codec-netflow[logstash-codec-netflow]
 | <<plugins-codecs-nmap,nmap>> | Reads Nmap data in XML format | https://github.com/logstash-plugins/logstash-codec-nmap[logstash-codec-nmap]

--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -37,53 +37,78 @@ The following codec plugins are available below. For a list of Elastic supported
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/master/docs/index.asciidoc
 include::codecs/avro.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/master/docs/index.asciidoc
 include::codecs/cef.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/docs/index.asciidoc
 include::codecs/cloudfront.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/docs/index.asciidoc
 include::codecs/cloudtrail.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-compress_spooler/edit/master/docs/index.asciidoc
 include::codecs/compress_spooler.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/docs/index.asciidoc
 include::codecs/dots.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/master/docs/index.asciidoc
 include::codecs/edn.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/master/docs/index.asciidoc
 include::codecs/edn_lines.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/master/docs/index.asciidoc
 include::codecs/es_bulk.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/master/docs/index.asciidoc
 include::codecs/fluent.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/master/docs/index.asciidoc
 include::codecs/graphite.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/docs/index.asciidoc
 include::codecs/json.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/master/docs/index.asciidoc
 include::codecs/json_lines.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/master/docs/index.asciidoc
 include::codecs/line.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/master/docs/index.asciidoc
 include::codecs/msgpack.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/master/docs/index.asciidoc
 include::codecs/multiline.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/master/docs/index.asciidoc
 include::codecs/netflow.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/master/docs/index.asciidoc
 include::codecs/nmap.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-oldlogstashjson/edit/master/docs/index.asciidoc
 include::codecs/oldlogstashjson.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/docs/index.asciidoc
 include::codecs/plain.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-protobuf/edit/master/docs/index.asciidoc
 include::codecs/protobuf.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/docs/index.asciidoc
 include::codecs/rubydebug.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-codec-s3_plain/edit/master/docs/index.asciidoc
 include::codecs/s3_plain.asciidoc[]
+
 
 :edit_url: 

--- a/docs/plugins/codecs/avro.asciidoc
+++ b/docs/plugins/codecs/avro.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Avro codec plugin
 

--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Cef codec plugin
 

--- a/docs/plugins/codecs/cloudfront.asciidoc
+++ b/docs/plugins/codecs/cloudfront.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Cloudfront codec plugin
 

--- a/docs/plugins/codecs/collectd.asciidoc
+++ b/docs/plugins/codecs/collectd.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Collectd codec plugin
 

--- a/docs/plugins/codecs/dots.asciidoc
+++ b/docs/plugins/codecs/dots.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Dots codec plugin
 

--- a/docs/plugins/codecs/dots.asciidoc
+++ b/docs/plugins/codecs/dots.asciidoc
@@ -20,12 +20,5 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+Sends 1 dot per event to stdout for performance tracking.
 
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Dots Codec Configuration Options
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================

--- a/docs/plugins/codecs/edn.asciidoc
+++ b/docs/plugins/codecs/edn.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Edn codec plugin
 

--- a/docs/plugins/codecs/edn.asciidoc
+++ b/docs/plugins/codecs/edn.asciidoc
@@ -21,13 +21,3 @@ include::{include_path}/plugin_header.asciidoc[]
 ==== Description
 
 
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Edn Codec Configuration Options
-
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================

--- a/docs/plugins/codecs/edn.asciidoc
+++ b/docs/plugins/codecs/edn.asciidoc
@@ -20,4 +20,4 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-
+Reads EDN format data.

--- a/docs/plugins/codecs/edn_lines.asciidoc
+++ b/docs/plugins/codecs/edn_lines.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Edn_lines codec plugin
 

--- a/docs/plugins/codecs/edn_lines.asciidoc
+++ b/docs/plugins/codecs/edn_lines.asciidoc
@@ -21,11 +21,3 @@ include::{include_path}/plugin_header.asciidoc[]
 ==== Description
 
 
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Edn_lines Codec Configuration Options
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================

--- a/docs/plugins/codecs/edn_lines.asciidoc
+++ b/docs/plugins/codecs/edn_lines.asciidoc
@@ -20,4 +20,4 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-
+Reads newline-delimited EDN format data.

--- a/docs/plugins/codecs/es_bulk.asciidoc
+++ b/docs/plugins/codecs/es_bulk.asciidoc
@@ -25,11 +25,3 @@ into individual events, plus metadata into the `@metadata` field.
 
 Encoding is not supported at this time as the Elasticsearch
 output submits Logstash events in bulk format.
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Es_bulk Codec Configuration Options
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================

--- a/docs/plugins/codecs/es_bulk.asciidoc
+++ b/docs/plugins/codecs/es_bulk.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Es_bulk codec plugin
 

--- a/docs/plugins/codecs/fluent.asciidoc
+++ b/docs/plugins/codecs/fluent.asciidoc
@@ -40,12 +40,3 @@ Notes:
 
 * the fluent uses a second-precision time for events, so you will never see
   subsecond precision on events processed by this codec.
-
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Fluent Codec Configuration Options
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================

--- a/docs/plugins/codecs/fluent.asciidoc
+++ b/docs/plugins/codecs/fluent.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Fluent codec plugin
 

--- a/docs/plugins/codecs/graphite.asciidoc
+++ b/docs/plugins/codecs/graphite.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Graphite codec plugin
 

--- a/docs/plugins/codecs/gzip_lines.asciidoc
+++ b/docs/plugins/codecs/gzip_lines.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Gzip_lines codec plugin
 

--- a/docs/plugins/codecs/json.asciidoc
+++ b/docs/plugins/codecs/json.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Json codec plugin
 

--- a/docs/plugins/codecs/json_lines.asciidoc
+++ b/docs/plugins/codecs/json_lines.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Json_lines codec plugin
 

--- a/docs/plugins/codecs/line.asciidoc
+++ b/docs/plugins/codecs/line.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Line codec plugin
 

--- a/docs/plugins/codecs/msgpack.asciidoc
+++ b/docs/plugins/codecs/msgpack.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Msgpack codec plugin
 

--- a/docs/plugins/codecs/msgpack.asciidoc
+++ b/docs/plugins/codecs/msgpack.asciidoc
@@ -20,7 +20,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-
+This codec reads MessagePack encoded content.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Msgpack Codec Configuration Options

--- a/docs/plugins/codecs/multiline.asciidoc
+++ b/docs/plugins/codecs/multiline.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Multiline codec plugin
 

--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Netflow codec plugin
 

--- a/docs/plugins/codecs/nmap.asciidoc
+++ b/docs/plugins/codecs/nmap.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Nmap codec plugin
 

--- a/docs/plugins/codecs/plain.asciidoc
+++ b/docs/plugins/codecs/plain.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Plain codec plugin
 

--- a/docs/plugins/codecs/protobuf.asciidoc
+++ b/docs/plugins/codecs/protobuf.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Protobuf codec plugin
 

--- a/docs/plugins/codecs/rubydebug.asciidoc
+++ b/docs/plugins/codecs/rubydebug.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Rubydebug codec plugin
 

--- a/docs/plugins/codecs/s3_plain.asciidoc
+++ b/docs/plugins/codecs/s3_plain.asciidoc
@@ -2,7 +2,7 @@
 === s3_plain
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-codec-s3_plain`.
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 The "s3_plain" codec is used for backward compatibility with previous version of the S3 Output

--- a/docs/plugins/codecs/spool.asciidoc
+++ b/docs/plugins/codecs/spool.asciidoc
@@ -2,8 +2,7 @@
 === spool
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-codec-spool`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -59,97 +59,144 @@ The following filter plugins are available below. For a list of Elastic supporte
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/docs/index.asciidoc
 include::filters/aggregate.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/docs/index.asciidoc
 include::filters/alter.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-anonymize/edit/master/docs/index.asciidoc
 include::filters/anonymize.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/docs/index.asciidoc
 include::filters/cidr.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/master/docs/index.asciidoc
 include::filters/cipher.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/master/docs/index.asciidoc
 include::filters/clone.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-collate/edit/master/docs/index.asciidoc
 include::filters/collate.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/master/docs/index.asciidoc
 include::filters/csv.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/master/docs/index.asciidoc
 include::filters/date.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/docs/index.asciidoc
 include::filters/de_dot.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
 include::filters/dissect.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
 include::filters/dns.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/docs/index.asciidoc
 include::filters/drop.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/master/docs/index.asciidoc
 include::filters/elapsed.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/master/docs/index.asciidoc
 include::filters/elasticsearch.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/master/docs/index.asciidoc
 include::filters/environment.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/master/docs/index.asciidoc
 include::filters/extractnumbers.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/master/docs/index.asciidoc
 include::filters/fingerprint.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/master/docs/index.asciidoc
 include::filters/geoip.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/docs/index.asciidoc
 include::filters/grok.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/master/docs/index.asciidoc
 include::filters/jdbc_streaming.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/docs/index.asciidoc
 include::filters/json.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/master/docs/index.asciidoc
 include::filters/json_encode.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/docs/index.asciidoc
 include::filters/kv.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-metaevent/edit/master/docs/index.asciidoc
 include::filters/metaevent.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/docs/index.asciidoc
 include::filters/metricize.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/master/docs/index.asciidoc
 include::filters/metrics.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/master/docs/index.asciidoc
 include::filters/mutate.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-oui/edit/master/docs/index.asciidoc
 include::filters/oui.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/master/docs/index.asciidoc
 include::filters/prune.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-punct/edit/master/docs/index.asciidoc
 include::filters/punct.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/master/docs/index.asciidoc
 include::filters/range.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/master/docs/index.asciidoc
 include::filters/ruby.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/master/docs/index.asciidoc
 include::filters/sleep.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/master/docs/index.asciidoc
 include::filters/split.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/docs/index.asciidoc
 include::filters/syslog_pri.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/docs/index.asciidoc
 include::filters/throttle.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/master/docs/index.asciidoc
 include::filters/tld.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/master/docs/index.asciidoc
 include::filters/translate.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-truncate/edit/master/docs/index.asciidoc
 include::filters/truncate.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/master/docs/index.asciidoc
 include::filters/urldecode.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/master/docs/index.asciidoc
 include::filters/useragent.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/master/docs/index.asciidoc
 include::filters/uuid.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/master/docs/index.asciidoc
 include::filters/xml.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-yaml/edit/master/docs/index.asciidoc
 include::filters/yaml.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-zeromq/edit/master/docs/index.asciidoc
 include::filters/zeromq.asciidoc[]
+
 
 :edit_url: 

--- a/docs/plugins/filters/age.asciidoc
+++ b/docs/plugins/filters/age.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Age filter plugin
 

--- a/docs/plugins/filters/aggregate.asciidoc
+++ b/docs/plugins/filters/aggregate.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Aggregate filter plugin
 

--- a/docs/plugins/filters/alter.asciidoc
+++ b/docs/plugins/filters/alter.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Alter filter plugin
 

--- a/docs/plugins/filters/anonymize.asciidoc
+++ b/docs/plugins/filters/anonymize.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Anonymize filter plugin
 

--- a/docs/plugins/filters/checksum.asciidoc
+++ b/docs/plugins/filters/checksum.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Checksum filter plugin
 

--- a/docs/plugins/filters/cidr.asciidoc
+++ b/docs/plugins/filters/cidr.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Cidr filter plugin
 

--- a/docs/plugins/filters/cipher.asciidoc
+++ b/docs/plugins/filters/cipher.asciidoc
@@ -2,8 +2,7 @@
 === cipher
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-cipher`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 This filter parses a source and apply a cipher or decipher before
 storing it in the target.

--- a/docs/plugins/filters/clone.asciidoc
+++ b/docs/plugins/filters/clone.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Clone filter plugin
 

--- a/docs/plugins/filters/collate.asciidoc
+++ b/docs/plugins/filters/collate.asciidoc
@@ -2,8 +2,7 @@
 === collate
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-collate`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 Collate events by time or count.
 

--- a/docs/plugins/filters/csv.asciidoc
+++ b/docs/plugins/filters/csv.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Csv filter plugin
 

--- a/docs/plugins/filters/date.asciidoc
+++ b/docs/plugins/filters/date.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Date filter plugin
 

--- a/docs/plugins/filters/de_dot.asciidoc
+++ b/docs/plugins/filters/de_dot.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === De_dot filter plugin
 

--- a/docs/plugins/filters/dissect.asciidoc
+++ b/docs/plugins/filters/dissect.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Dissect filter plugin
 

--- a/docs/plugins/filters/dns.asciidoc
+++ b/docs/plugins/filters/dns.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Dns filter plugin
 

--- a/docs/plugins/filters/drop.asciidoc
+++ b/docs/plugins/filters/drop.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Drop filter plugin
 

--- a/docs/plugins/filters/elapsed.asciidoc
+++ b/docs/plugins/filters/elapsed.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Elapsed filter plugin
 

--- a/docs/plugins/filters/elasticsearch.asciidoc
+++ b/docs/plugins/filters/elasticsearch.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Elasticsearch filter plugin
 

--- a/docs/plugins/filters/environment.asciidoc
+++ b/docs/plugins/filters/environment.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Environment filter plugin
 

--- a/docs/plugins/filters/extractnumbers.asciidoc
+++ b/docs/plugins/filters/extractnumbers.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Extractnumbers filter plugin
 

--- a/docs/plugins/filters/fingerprint.asciidoc
+++ b/docs/plugins/filters/fingerprint.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Fingerprint filter plugin
 

--- a/docs/plugins/filters/geoip.asciidoc
+++ b/docs/plugins/filters/geoip.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Geoip filter plugin
 

--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Grok filter plugin
 

--- a/docs/plugins/filters/hashid.asciidoc
+++ b/docs/plugins/filters/hashid.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Hashid filter plugin
 

--- a/docs/plugins/filters/i18n.asciidoc
+++ b/docs/plugins/filters/i18n.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === I18n filter plugin
 

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Jdbc_streaming filter plugin
 

--- a/docs/plugins/filters/json.asciidoc
+++ b/docs/plugins/filters/json.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Json filter plugin
 

--- a/docs/plugins/filters/json_encode.asciidoc
+++ b/docs/plugins/filters/json_encode.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Json_encode filter plugin
 

--- a/docs/plugins/filters/kv.asciidoc
+++ b/docs/plugins/filters/kv.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Kv filter plugin
 

--- a/docs/plugins/filters/metaevent.asciidoc
+++ b/docs/plugins/filters/metaevent.asciidoc
@@ -2,8 +2,7 @@
 === metaevent
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-metaevent`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 

--- a/docs/plugins/filters/metricize.asciidoc
+++ b/docs/plugins/filters/metricize.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Metricize filter plugin
 

--- a/docs/plugins/filters/metrics.asciidoc
+++ b/docs/plugins/filters/metrics.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Metrics filter plugin
 

--- a/docs/plugins/filters/multiline.asciidoc
+++ b/docs/plugins/filters/multiline.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Multiline filter plugin
 

--- a/docs/plugins/filters/mutate.asciidoc
+++ b/docs/plugins/filters/mutate.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Mutate filter plugin
 

--- a/docs/plugins/filters/oui.asciidoc
+++ b/docs/plugins/filters/oui.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Oui filter plugin
 

--- a/docs/plugins/filters/prune.asciidoc
+++ b/docs/plugins/filters/prune.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Prune filter plugin
 

--- a/docs/plugins/filters/punct.asciidoc
+++ b/docs/plugins/filters/punct.asciidoc
@@ -2,8 +2,7 @@
 === punct
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-punct`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 Strip everything but punctuation from a field and store the remainder in the
 a separate field. This is often used for fingerprinting log events.

--- a/docs/plugins/filters/range.asciidoc
+++ b/docs/plugins/filters/range.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Range filter plugin
 

--- a/docs/plugins/filters/ruby.asciidoc
+++ b/docs/plugins/filters/ruby.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Ruby filter plugin
 

--- a/docs/plugins/filters/sleep.asciidoc
+++ b/docs/plugins/filters/sleep.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Sleep filter plugin
 

--- a/docs/plugins/filters/split.asciidoc
+++ b/docs/plugins/filters/split.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Split filter plugin
 

--- a/docs/plugins/filters/syslog_pri.asciidoc
+++ b/docs/plugins/filters/syslog_pri.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Syslog_pri filter plugin
 

--- a/docs/plugins/filters/throttle.asciidoc
+++ b/docs/plugins/filters/throttle.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Throttle filter plugin
 

--- a/docs/plugins/filters/tld.asciidoc
+++ b/docs/plugins/filters/tld.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Tld filter plugin
 

--- a/docs/plugins/filters/translate.asciidoc
+++ b/docs/plugins/filters/translate.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Translate filter plugin
 

--- a/docs/plugins/filters/truncate.asciidoc
+++ b/docs/plugins/filters/truncate.asciidoc
@@ -1,18 +1,22 @@
-[[plugins-filters-truncate]]
-=== truncate
+:plugin: truncate
+:type: filter
 
-* Version: 1.0.0
-* Released on: 2016-11-29
-* https://github.com/logstash-plugins/logstash-filter-truncate/blob/master/CHANGELOG.md#100[Changelog]
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.0.2
+:release_date: 2017-06-23
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-truncate/blob/v1.0.2/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
 
-==== Installation
+[id="plugins-{type}s-{plugin}"]
 
-For plugins not bundled by default, it is easy to install by running `bin/logstash-plugin install logstash-filter-truncate`. See <<working-with-plugins>> for more details.
+=== Truncate filter plugin
 
-==== Getting Help
-
-For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an issue in https://github.com/elastic/logstash[Github].
-For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#show_logstash_plugins[Elastic Support Matrix].
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
@@ -22,115 +26,24 @@ This truncates on bytes values, not character count.  In practice, this
 should mean that the truncated length is somewhere between `length_bytes` and
 `length_bytes - 6` (UTF-8 supports up to 6-byte characters).
 
-&nbsp;
+[id="plugins-{type}s-{plugin}-options"]
+==== Truncate Filter Configuration Options
 
-==== Synopsis
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
-This plugin supports the following configuration options:
-
-Required configuration options:
-
-[source,json]
---------------------------
-truncate {
-    length_bytes => ...
-}
---------------------------
-
-
-
-Available configuration options:
-
-[cols="<,<,<,<m",options="header",]
+[cols="<,<,<",options="header",]
 |=======================================================================
-|Setting |Input type|Required|Default value
-| <<plugins-filters-truncate-add_field>> |<<hash,hash>>|No|`{}`
-| <<plugins-filters-truncate-add_tag>> |<<array,array>>|No|`[]`
-| <<plugins-filters-truncate-enable_metric>> |<<boolean,boolean>>|No|`true`
-| <<plugins-filters-truncate-fields>> |<<string,string>>|No|
-| <<plugins-filters-truncate-id>> |<<string,string>>|No|
-| <<plugins-filters-truncate-length_bytes>> |<<number,number>>|Yes|
-| <<plugins-filters-truncate-periodic_flush>> |<<boolean,boolean>>|No|`false`
-| <<plugins-filters-truncate-remove_field>> |<<array,array>>|No|`[]`
-| <<plugins-filters-truncate-remove_tag>> |<<array,array>>|No|`[]`
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-fields>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-length_bytes>> |<<number,number>>|Yes
 |=======================================================================
 
-
-==== Details
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
 
 &nbsp;
 
-[[plugins-filters-truncate-add_field]]
-===== `add_field` 
-
-  * Value type is <<hash,hash>>
-  * Default value is `{}`
-
-If this filter is successful, add any arbitrary fields to this event.
-Field names can be dynamic and include parts of the event using the `%{field}`.
-
-Example:
-[source,ruby]
-    filter {
-      truncate {
-        add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
-      }
-    }
-[source,ruby]
-    # You can also add multiple fields at once:
-    filter {
-      truncate {
-        add_field => {
-          "foo_%{somefield}" => "Hello world, from %{host}"
-          "new_field" => "new_static_value"
-        }
-      }
-    }
-
-If the event has field `"somefield" == "hello"` this filter, on success,
-would add field `foo_hello` if it is present, with the
-value above and the `%{host}` piece replaced with that value from the
-event. The second example would also add a hardcoded field.
-
-[[plugins-filters-truncate-add_tag]]
-===== `add_tag` 
-
-  * Value type is <<array,array>>
-  * Default value is `[]`
-
-If this filter is successful, add arbitrary tags to the event.
-Tags can be dynamic and include parts of the event using the `%{field}`
-syntax.
-
-Example:
-[source,ruby]
-    filter {
-      truncate {
-        add_tag => [ "foo_%{somefield}" ]
-      }
-    }
-[source,ruby]
-    # You can also add multiple tags at once:
-    filter {
-      truncate {
-        add_tag => [ "foo_%{somefield}", "taggedy_tag"]
-      }
-    }
-
-If the event has field `"somefield" == "hello"` this filter, on success,
-would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
-
-[[plugins-filters-truncate-enable_metric]]
-===== `enable_metric` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-Disable or enable metric logging for this specific plugin instance
-by default we record all the metrics we can, but you can disable metrics collection
-for a specific plugin.
-
-[[plugins-filters-truncate-fields]]
+[id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 
 
   * Value type is <<string,string>>
@@ -150,26 +63,7 @@ Special behaviors for non-string fields:
 * Hash: truncate will try all values of the hash (recursively, if this hash
 contains other hashes).
 
-[[plugins-filters-truncate-id]]
-===== `id` 
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-Add a unique `ID` to the plugin instance, this `ID` is used for tracking
-information for a specific configuration of the plugin.
-
-```
-output {
- stdout {
-   id => "ABC"
- }
-}
-```
-
-If you don't explicitely set this variable Logstash will generate a unique name.
-
-[[plugins-filters-truncate-length_bytes]]
+[id="plugins-{type}s-{plugin}-length_bytes"]
 ===== `length_bytes` 
 
   * This is a required setting.
@@ -184,69 +78,7 @@ As an example, if you set `length_bytes => 10` and a field contains "hello
 world, how are you?", then this field will be truncated and have this value:
 "hello worl"
 
-[[plugins-filters-truncate-periodic_flush]]
-===== `periodic_flush` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
-
-Call the filter flush method at regular interval.
-Optional.
-
-[[plugins-filters-truncate-remove_field]]
-===== `remove_field` 
-
-  * Value type is <<array,array>>
-  * Default value is `[]`
-
-If this filter is successful, remove arbitrary fields from this event.
-Fields names can be dynamic and include parts of the event using the %{field}
-Example:
-[source,ruby]
-    filter {
-      truncate {
-        remove_field => [ "foo_%{somefield}" ]
-      }
-    }
-[source,ruby]
-    # You can also remove multiple fields at once:
-    filter {
-      truncate {
-        remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
-      }
-    }
-
-If the event has field `"somefield" == "hello"` this filter, on success,
-would remove the field with name `foo_hello` if it is present. The second
-example would remove an additional, non-dynamic field.
-
-[[plugins-filters-truncate-remove_tag]]
-===== `remove_tag` 
-
-  * Value type is <<array,array>>
-  * Default value is `[]`
-
-If this filter is successful, remove arbitrary tags from the event.
-Tags can be dynamic and include parts of the event using the `%{field}`
-syntax.
-
-Example:
-[source,ruby]
-    filter {
-      truncate {
-        remove_tag => [ "foo_%{somefield}" ]
-      }
-    }
-[source,ruby]
-    # You can also remove multiple tags at once:
-    filter {
-      truncate {
-        remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
-      }
-    }
-
-If the event has field `"somefield" == "hello"` this filter, on success,
-would remove the tag `foo_hello` if it is present. The second example
-would remove a sad, unwanted tag as well.
 
 
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/filters/urldecode.asciidoc
+++ b/docs/plugins/filters/urldecode.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Urldecode filter plugin
 

--- a/docs/plugins/filters/useragent.asciidoc
+++ b/docs/plugins/filters/useragent.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Useragent
 

--- a/docs/plugins/filters/useragent.asciidoc
+++ b/docs/plugins/filters/useragent.asciidoc
@@ -7,7 +7,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v3.1.1
 :release_date: 2017-05-15
 :changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.1.1/CHANGELOG.md
-:include_path: ../../../logstash/docs/include
+:include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/filters/useragent.asciidoc
+++ b/docs/plugins/filters/useragent.asciidoc
@@ -32,7 +32,7 @@ ua-parser with an Apache 2.0 license. For more details on ua-parser, see
 [id="plugins-{type}s-{plugin}-options"]
 ==== Useragent Filter Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-common-options>> described later.
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -44,7 +44,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
-Also see <<plugins-{type}s-common-options>> for a list of options supported by all
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 filter plugins.
 
 &nbsp;
@@ -113,5 +113,5 @@ The name of the field to assign user agent data into.
 If not specified user agent data will be stored in the root of the event.
 
 
-
+[id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/filters/uuid.asciidoc
+++ b/docs/plugins/filters/uuid.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Uuid filter plugin
 

--- a/docs/plugins/filters/xml.asciidoc
+++ b/docs/plugins/filters/xml.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Xml filter plugin
 

--- a/docs/plugins/filters/yaml.asciidoc
+++ b/docs/plugins/filters/yaml.asciidoc
@@ -1,8 +1,7 @@
 [[plugins-filters-yaml]]
 === yaml
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-yaml`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 This is a YAML parsing filter. It takes an existing field which contains YAML and
 expands it into an actual data structure within the Logstash event.

--- a/docs/plugins/filters/zeromq.asciidoc
+++ b/docs/plugins/filters/zeromq.asciidoc
@@ -2,8 +2,7 @@
 === zeromq
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-filter-zeromq`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 ZeroMQ filter. This is the best way to send an event externally for filtering
 It works much like an exec filter would by sending the event "offsite"

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -64,109 +64,162 @@ The following input plugins are available below. For a list of Elastic supported
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/master/docs/index.asciidoc
 include::inputs/beats.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-cloudwatch/edit/master/docs/index.asciidoc
 include::inputs/cloudwatch.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/master/docs/index.asciidoc
 include::inputs/couchdb_changes.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-drupal_dblog/edit/master/docs/index.asciidoc
 include::inputs/drupal_dblog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/edit/master/docs/index.asciidoc
 include::inputs/elasticsearch.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-eventlog/edit/master/docs/index.asciidoc
 include::inputs/eventlog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-exec/edit/master/docs/index.asciidoc
 include::inputs/exec.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-file/edit/master/docs/index.asciidoc
 include::inputs/file.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-ganglia/edit/master/docs/index.asciidoc
 include::inputs/ganglia.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-gelf/edit/master/docs/index.asciidoc
 include::inputs/gelf.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-gemfire/edit/master/docs/index.asciidoc
 include::inputs/gemfire.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-generator/edit/master/docs/index.asciidoc
 include::inputs/generator.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/docs/index.asciidoc
 include::inputs/github.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/docs/index.asciidoc
 include::inputs/google_pubsub.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-graphite/edit/master/docs/index.asciidoc
 include::inputs/graphite.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-heartbeat/edit/master/docs/index.asciidoc
 include::inputs/heartbeat.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-heroku/edit/master/docs/index.asciidoc
 include::inputs/heroku.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-http/edit/master/docs/index.asciidoc
 include::inputs/http.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-http_poller/edit/master/docs/index.asciidoc
 include::inputs/http_poller.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-imap/edit/master/docs/index.asciidoc
 include::inputs/imap.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/master/docs/index.asciidoc
 include::inputs/irc.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
 include::inputs/jdbc.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/docs/index.asciidoc
 include::inputs/jmx.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/master/docs/index.asciidoc
 include::inputs/kafka.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/master/docs/index.asciidoc
 include::inputs/kinesis.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/master/docs/index.asciidoc
 include::inputs/log4j.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-lumberjack/edit/master/docs/index.asciidoc
 include::inputs/lumberjack.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-meetup/edit/master/docs/index.asciidoc
 include::inputs/meetup.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-pipe/edit/master/docs/index.asciidoc
 include::inputs/pipe.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/master/docs/index.asciidoc
 include::inputs/puppet_facter.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/master/docs/index.asciidoc
 include::inputs/rabbitmq.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-rackspace/edit/master/docs/index.asciidoc
 include::inputs/rackspace.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/master/docs/index.asciidoc
 include::inputs/redis.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-relp/edit/master/docs/index.asciidoc
 include::inputs/relp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-rss/edit/master/docs/index.asciidoc
 include::inputs/rss.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/master/docs/index.asciidoc
 include::inputs/s3.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/master/docs/index.asciidoc
 include::inputs/salesforce.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-snmptrap/edit/master/docs/index.asciidoc
 include::inputs/snmptrap.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-sqlite/edit/master/docs/index.asciidoc
 include::inputs/sqlite.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-sqs/edit/master/docs/index.asciidoc
 include::inputs/sqs.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-stdin/edit/master/docs/index.asciidoc
 include::inputs/stdin.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-stomp/edit/master/docs/index.asciidoc
 include::inputs/stomp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-syslog/edit/master/docs/index.asciidoc
 include::inputs/syslog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-tcp/edit/master/docs/index.asciidoc
 include::inputs/tcp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-twitter/edit/master/docs/index.asciidoc
 include::inputs/twitter.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-udp/edit/master/docs/index.asciidoc
 include::inputs/udp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-unix/edit/master/docs/index.asciidoc
 include::inputs/unix.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-varnishlog/edit/master/docs/index.asciidoc
 include::inputs/varnishlog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-websocket/edit/master/docs/index.asciidoc
 include::inputs/websocket.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-wmi/edit/master/docs/index.asciidoc
 include::inputs/wmi.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-xmpp/edit/master/docs/index.asciidoc
 include::inputs/xmpp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-zenoss/edit/master/docs/index.asciidoc
 include::inputs/zenoss.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-input-zeromq/edit/master/docs/index.asciidoc
 include::inputs/zeromq.asciidoc[]
+
 
 :edit_url: 

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -10,6 +10,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-beats,beats>> | Receives events from the Elastic Beats framework | https://github.com/logstash-plugins/logstash-input-beats[logstash-input-beats]
 | <<plugins-inputs-cloudwatch,cloudwatch>> | Pulls events from the Amazon Web Services CloudWatch API  | https://github.com/logstash-plugins/logstash-input-cloudwatch[logstash-input-cloudwatch]
 | <<plugins-inputs-couchdb_changes,couchdb_changes>> | Streams events from CouchDB's `_changes` URI | https://github.com/logstash-plugins/logstash-input-couchdb_changes[logstash-input-couchdb_changes]
+| <<plugins-inputs-dead_letter_queue,dead_letter_queue>> | read events from Logstash's dead letter queue | https://github.com/logstash-plugins/logstash-input-dead_letter_queue[logstash-input-dead_letter_queue]
 | <<plugins-inputs-drupal_dblog,drupal_dblog>> | Retrieves watchdog log events from Drupal installations with DBLog enabled | https://github.com/logstash-plugins/logstash-input-drupal_dblog[logstash-input-drupal_dblog]
 | <<plugins-inputs-elasticsearch,elasticsearch>> | Reads query results from an Elasticsearch cluster | https://github.com/logstash-plugins/logstash-input-elasticsearch[logstash-input-elasticsearch]
 | <<plugins-inputs-eventlog,eventlog>> | Pulls events from the Windows Event Log | https://github.com/logstash-plugins/logstash-input-eventlog[logstash-input-eventlog]
@@ -29,6 +30,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-imap,imap>> | Reads mail from an IMAP server | https://github.com/logstash-plugins/logstash-input-imap[logstash-input-imap]
 | <<plugins-inputs-irc,irc>> | Reads events from an IRC server | https://github.com/logstash-plugins/logstash-input-irc[logstash-input-irc]
 | <<plugins-inputs-jdbc,jdbc>> | Creates events from JDBC data | https://github.com/logstash-plugins/logstash-input-jdbc[logstash-input-jdbc]
+| <<plugins-inputs-jms,jms>> | Reads events from a Jms Broker | https://github.com/logstash-plugins/logstash-input-jms[logstash-input-jms]
 | <<plugins-inputs-jmx,jmx>> | Retrieves metrics from remote Java applications over JMX | https://github.com/logstash-plugins/logstash-input-jmx[logstash-input-jmx]
 | <<plugins-inputs-kafka,kafka>> | Reads events from a Kafka topic | https://github.com/logstash-plugins/logstash-input-kafka[logstash-input-kafka]
 | <<plugins-inputs-kinesis,kinesis>> | Receives events through an AWS Kinesis stream | https://github.com/logstash-plugins/logstash-input-kinesis[logstash-input-kinesis]
@@ -70,6 +72,9 @@ include::inputs/cloudwatch.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/master/docs/index.asciidoc
 include::inputs/couchdb_changes.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-input-dead_letter_queue/edit/master/docs/index.asciidoc
+include::inputs/dead_letter_queue.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-drupal_dblog/edit/master/docs/index.asciidoc
 include::inputs/drupal_dblog.asciidoc[]
@@ -127,6 +132,9 @@ include::inputs/irc.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
 include::inputs/jdbc.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-input-jms/edit/master/docs/index.asciidoc
+include::inputs/jms.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/docs/index.asciidoc
 include::inputs/jmx.asciidoc[]

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Beats input plugin
 

--- a/docs/plugins/inputs/cloudwatch.asciidoc
+++ b/docs/plugins/inputs/cloudwatch.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Cloudwatch input plugin
 

--- a/docs/plugins/inputs/couchdb_changes.asciidoc
+++ b/docs/plugins/inputs/couchdb_changes.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Couchdb_changes input plugin
 

--- a/docs/plugins/inputs/dead_letter_queue.asciidoc
+++ b/docs/plugins/inputs/dead_letter_queue.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Dead_letter_queue input plugin
 

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Elasticsearch input plugin
 

--- a/docs/plugins/inputs/eventlog.asciidoc
+++ b/docs/plugins/inputs/eventlog.asciidoc
@@ -1,9 +1,29 @@
-[[plugins-inputs-eventlog]]
-=== eventlog
+:plugin: eventlog
+:type: input
 
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v4.1.1
+:release_date: 2017-06-23
+:changelog_url: https://github.com/logstash-plugins/logstash-input-eventlog/blob/v4.1.1/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
 
+[id="plugins-{type}s-{plugin}"]
 
-This input will pull events from a http://msdn.microsoft.com/en-us/library/windows/desktop/bb309026%28v=vs.85%29.aspx[Windows Event Log]. Note that Windows Event Logs are stored on disk in a binary format and are only accessible from the Win32 API. This means Losgtash needs to be running as an agent on Windows servers where you wish to collect logs from, and will not be accesible across the network.
+=== Eventlog output plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input will pull events from a http://msdn.microsoft.com/en-us/library/windows/desktop/bb309026%28v=vs.85%29.aspx[Windows Event Log].
+Note that Windows Event Logs are stored on disk in a binary format and are only accessible from the Win32 API.
+This means Losgtash needs to be running as an agent on Windows servers where you wish to collect logs 
+from, and will not be accesible across the network.
 
 To collect Events from the System Event Log, use a config like:
 [source,ruby]
@@ -14,102 +34,41 @@ To collect Events from the System Event Log, use a config like:
       }
     }
 
-&nbsp;
+[id="plugins-{type}s-{plugin}-options"]
+==== Eventlog Input Configuration Options
 
-==== Synopsis
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
-This plugin supports the following configuration options:
-
-
-Required configuration options:
-
-[source,json]
---------------------------
-eventlog {
-}
---------------------------
-
-
-
-Available configuration options:
-
-[cols="<,<,<,<m",options="header",]
+[cols="<,<,<",options="header",]
 |=======================================================================
-|Setting |Input type|Required|Default value
-| <<plugins-inputs-eventlog-add_field>> |<<hash,hash>>|No|`{}`
-| <<plugins-inputs-eventlog-codec>> |<<codec,codec>>|No|`"plain"`
-| <<plugins-inputs-eventlog-logfile>> |<<string,string>>|No|`"Application"`
-| <<plugins-inputs-eventlog-interval>> |<<number,number>>|No|`1000`
-| <<plugins-inputs-eventlog-tags>> |<<array,array>>|No|
-| <<plugins-inputs-eventlog-type>> |<<string,string>>|No|
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-logfile>> |<<string,string>>, one of `["Application", "Security", "System"]`|No
 |=======================================================================
 
-
-
-==== Details
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
 
 &nbsp;
 
-[[plugins-inputs-eventlog-add_field]]
-===== `add_field` 
-
-  * Value type is <<hash,hash>>
-  * Default value is `{}`
-
-Add a field to an event
-
-[[plugins-inputs-eventlog-codec]]
-===== `codec` 
-
-  * Value type is <<codec,codec>>
-  * Default value is `"plain"`
-
-The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
-
-[[plugins-inputs-eventlog-logfile]]
-===== `logfile` 
-
-  * Value type is <<array,array>>
-  * Default value is `["Application", "Security", "System"]`
-
-Event Log Name. System and Security may require that privileges are given to the user running Logstash.
-For more information, see: https://social.technet.microsoft.com/forums/windowsserver/en-US/d2f813db-6142-4b5b-8d86-253ebb740473/easy-way-to-read-security-log
-
-[[plugins-inputs-eventlog-interval]]
+[id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 
 
   * Value type is <<number,number>>
   * Default value is `1000`
-  
-How frequently should tail check for new event logs in milliseconds
 
-[[plugins-inputs-eventlog-tags]]
-===== `tags` 
+How frequently should tail check for new event logs in ms (default: 1 second)
 
-  * Value type is <<array,array>>
-  * There is no default value for this setting.
+[id="plugins-{type}s-{plugin}-logfile"]
+===== `logfile` 
 
-Add any number of arbitrary tags to your event.
+  * Value can be any of: `Application`, `Security`, `System`
+  * Default value is `"Application"`
 
-This can help with processing later.
-
-[[plugins-inputs-eventlog-type]]
-===== `type` 
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-Add a `type` field to all events handled by this input.
-
-Types are used mainly for filter activation.
-
-The type is stored as part of the event itself, so you can
-also use the type to search for it in Kibana.
-
-If you try to set a type on an event that already has one (for
-example when you send an event from a shipper to an indexer) then
-a new input will not override the existing type. A type set at
-the shipper stays with that event for its life even
-when sent to another Logstash server.
+Event Log Name
+System and Security may require that privileges are given to the user running logstash.
+see more at: https://social.technet.microsoft.com/forums/windowsserver/en-US/d2f813db-6142-4b5b-8d86-253ebb740473/easy-way-to-read-security-log
 
 
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/exec.asciidoc
+++ b/docs/plugins/inputs/exec.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Exec input plugin
 

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === File input plugin
 

--- a/docs/plugins/inputs/ganglia.asciidoc
+++ b/docs/plugins/inputs/ganglia.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Ganglia input plugin
 

--- a/docs/plugins/inputs/gelf.asciidoc
+++ b/docs/plugins/inputs/gelf.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Gelf input plugin
 

--- a/docs/plugins/inputs/gelf.asciidoc
+++ b/docs/plugins/inputs/gelf.asciidoc
@@ -4,9 +4,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: 3.0.5
-:release_date: 2017-06-27
-:changelog_url: https://raw.githubusercontent.com/logstash-plugins/logstash-input-gelf/v3.0.5/CHANGELOG.md
+:version: 3.0.4
+:release_date: 2017-06-23
+:changelog_url: https://raw.githubusercontent.com/logstash-plugins/logstash-input-gelf/v3.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/gemfire.asciidoc
+++ b/docs/plugins/inputs/gemfire.asciidoc
@@ -1,6 +1,8 @@
 [[plugins-inputs-gemfire]]
 === gemfire
 
+NOTE: This plugin cannot be installed on the current version of Logstash.
+
 Push events to a GemFire region.
 
 GemFire is an object database.

--- a/docs/plugins/inputs/generator.asciidoc
+++ b/docs/plugins/inputs/generator.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Generator input plugin
 

--- a/docs/plugins/inputs/github.asciidoc
+++ b/docs/plugins/inputs/github.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Github input plugin
 

--- a/docs/plugins/inputs/google_pubsub.asciidoc
+++ b/docs/plugins/inputs/google_pubsub.asciidoc
@@ -88,7 +88,7 @@ here:
   - Creating Service Accounts https://cloud.google.com/iam/docs/creating-managing-service-accounts[overview]
   - Granting Roles https://cloud.google.com/iam/docs/granting-roles-to-service-accounts[overview]
 
-1. If you are running Logstash on a Google Compute Engine instance, you may opt 
+2. If you are running Logstash on a Google Compute Engine instance, you may opt 
 to use Application Default Credentials. In this case, you will not need to 
 specify a JSON private key file in your config.
 

--- a/docs/plugins/inputs/google_pubsub.asciidoc
+++ b/docs/plugins/inputs/google_pubsub.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Google_pubsub input plugin
 

--- a/docs/plugins/inputs/graphite.asciidoc
+++ b/docs/plugins/inputs/graphite.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Graphite input plugin
 

--- a/docs/plugins/inputs/heartbeat.asciidoc
+++ b/docs/plugins/inputs/heartbeat.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Heartbeat input plugin
 

--- a/docs/plugins/inputs/http.asciidoc
+++ b/docs/plugins/inputs/http.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Http input plugin
 

--- a/docs/plugins/inputs/http_poller.asciidoc
+++ b/docs/plugins/inputs/http_poller.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Http_poller input plugin
 

--- a/docs/plugins/inputs/imap.asciidoc
+++ b/docs/plugins/inputs/imap.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Imap input plugin
 

--- a/docs/plugins/inputs/irc.asciidoc
+++ b/docs/plugins/inputs/irc.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Irc input plugin
 

--- a/docs/plugins/inputs/jdbc.asciidoc
+++ b/docs/plugins/inputs/jdbc.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Jdbc input plugin
 

--- a/docs/plugins/inputs/jms.asciidoc
+++ b/docs/plugins/inputs/jms.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Jms input plugin
 

--- a/docs/plugins/inputs/jmx.asciidoc
+++ b/docs/plugins/inputs/jmx.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Jmx input plugin
 

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Kafka
 

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -14,7 +14,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Kafka
+=== Kafka input plugin
 
 include::{include_path}/plugin_header.asciidoc[]
 

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -7,7 +7,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v5.1.8
 :release_date: 2017-06-23
 :changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v5.1.8/CHANGELOG.md
-:include_path: ../../../logstash/docs/include
+:include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/inputs/kinesis.asciidoc
+++ b/docs/plugins/inputs/kinesis.asciidoc
@@ -14,7 +14,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Kinesis input plugin
 

--- a/docs/plugins/inputs/kinesis.asciidoc
+++ b/docs/plugins/inputs/kinesis.asciidoc
@@ -1,5 +1,3 @@
-Sending Logstash's logs to  which is now configured via log4j2.properties
-~~~ASCIIDOC_DOCUMENT~~~
 :plugin: kinesis
 :type: input
 

--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -18,18 +18,6 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 include::{include_path}/plugin_header.asciidoc[]
 
-==== Description
-
-This output lets you send events to a generic HTTP(S) endpoint
-
-This output will execute up to 'pool_max' requests in parallel for performance.
-Consider this when tuning this plugin for performance.
-
-Additionally, note that when parallel execution is used strict ordering of events is not
-guaranteed!
-
-Beware, this gem does not yet support codecs. Please use the 'format' option for now.
-
 ==== Deprecation Notice
 
 NOTE: This plugin is deprecated. It is recommended that you use filebeat to collect logs from log4j.

--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Log4j input plugin
 

--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -20,6 +20,16 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output lets you send events to a generic HTTP(S) endpoint
+
+This output will execute up to 'pool_max' requests in parallel for performance.
+Consider this when tuning this plugin for performance.
+
+Additionally, note that when parallel execution is used strict ordering of events is not
+guaranteed!
+
+Beware, this gem does not yet support codecs. Please use the 'format' option for now.
+
 ==== Deprecation Notice
 
 NOTE: This plugin is deprecated. It is recommended that you use filebeat to collect logs from log4j.

--- a/docs/plugins/inputs/lumberjack.asciidoc
+++ b/docs/plugins/inputs/lumberjack.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Lumberjack input plugin
 

--- a/docs/plugins/inputs/meetup.asciidoc
+++ b/docs/plugins/inputs/meetup.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Meetup input plugin
 

--- a/docs/plugins/inputs/pipe.asciidoc
+++ b/docs/plugins/inputs/pipe.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Pipe input plugin
 

--- a/docs/plugins/inputs/puppet_facter.asciidoc
+++ b/docs/plugins/inputs/puppet_facter.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Puppet_facter input plugin
 

--- a/docs/plugins/inputs/rabbitmq.asciidoc
+++ b/docs/plugins/inputs/rabbitmq.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Rabbitmq input plugin
 

--- a/docs/plugins/inputs/rackspace.asciidoc
+++ b/docs/plugins/inputs/rackspace.asciidoc
@@ -2,8 +2,7 @@
 === rackspace
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-input-rackspace`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 

--- a/docs/plugins/inputs/redis.asciidoc
+++ b/docs/plugins/inputs/redis.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Redis input plugin
 

--- a/docs/plugins/inputs/relp.asciidoc
+++ b/docs/plugins/inputs/relp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Relp input plugin
 

--- a/docs/plugins/inputs/rss.asciidoc
+++ b/docs/plugins/inputs/rss.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Rss input plugin
 

--- a/docs/plugins/inputs/s3.asciidoc
+++ b/docs/plugins/inputs/s3.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === S3 input plugin
 

--- a/docs/plugins/inputs/salesforce.asciidoc
+++ b/docs/plugins/inputs/salesforce.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Salesforce input plugin
 

--- a/docs/plugins/inputs/snmptrap.asciidoc
+++ b/docs/plugins/inputs/snmptrap.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Snmptrap input plugin
 

--- a/docs/plugins/inputs/sqlite.asciidoc
+++ b/docs/plugins/inputs/sqlite.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Sqlite input plugin
 

--- a/docs/plugins/inputs/sqs.asciidoc
+++ b/docs/plugins/inputs/sqs.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Sqs input plugin
 

--- a/docs/plugins/inputs/stdin.asciidoc
+++ b/docs/plugins/inputs/stdin.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Stdin input plugin
 

--- a/docs/plugins/inputs/stdin.asciidoc
+++ b/docs/plugins/inputs/stdin.asciidoc
@@ -28,12 +28,8 @@ want to join lines, you'll want to use the multiline codec.
 [id="plugins-{type}s-{plugin}-options"]
 ==== Stdin Input Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================
+There are no special configuration options for this plugin,
+but it does support the <<plugins-{type}s-{plugin}-common-options>>.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/stomp.asciidoc
+++ b/docs/plugins/inputs/stomp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Stomp input plugin
 

--- a/docs/plugins/inputs/syslog.asciidoc
+++ b/docs/plugins/inputs/syslog.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Syslog input plugin
 

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Tcp input plugin
 

--- a/docs/plugins/inputs/twitter.asciidoc
+++ b/docs/plugins/inputs/twitter.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Twitter input plugin
 

--- a/docs/plugins/inputs/udp.asciidoc
+++ b/docs/plugins/inputs/udp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Udp input plugin
 

--- a/docs/plugins/inputs/unix.asciidoc
+++ b/docs/plugins/inputs/unix.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Unix input plugin
 

--- a/docs/plugins/inputs/varnishlog.asciidoc
+++ b/docs/plugins/inputs/varnishlog.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Varnishlog input plugin
 

--- a/docs/plugins/inputs/websocket.asciidoc
+++ b/docs/plugins/inputs/websocket.asciidoc
@@ -2,8 +2,7 @@
 === websocket
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-input-websocket`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 Read events over the websocket protocol.
 

--- a/docs/plugins/inputs/wmi.asciidoc
+++ b/docs/plugins/inputs/wmi.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Wmi input plugin
 

--- a/docs/plugins/inputs/xmpp.asciidoc
+++ b/docs/plugins/inputs/xmpp.asciidoc
@@ -4,9 +4,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: 3.1.4
-:release_date: 2017-06-27
-:changelog_url: https://raw.githubusercontent.com/logstash-plugins/logstash-input-xmpp/v3.1.4/CHANGELOG.md
+:version: 3.1.3
+:release_date: 2017-06-23
+:changelog_url: https://raw.githubusercontent.com/logstash-plugins/logstash-input-xmpp/v3.1.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/xmpp.asciidoc
+++ b/docs/plugins/inputs/xmpp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Xmpp input plugin
 

--- a/docs/plugins/inputs/zenoss.asciidoc
+++ b/docs/plugins/inputs/zenoss.asciidoc
@@ -2,8 +2,7 @@
 === zenoss
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-input-zenoss`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 

--- a/docs/plugins/inputs/zeromq.asciidoc
+++ b/docs/plugins/inputs/zeromq.asciidoc
@@ -1,7 +1,7 @@
 [[plugins-inputs-zeromq]]
 === zeromq
 
-NOTE: This is a community-maintained plugin!
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 Read events over a 0MQ SUB socket.
 

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -66,113 +66,168 @@ The following output plugins are available below. For a list of Elastic supporte
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/docs/index.asciidoc
 include::outputs/boundary.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/master/docs/index.asciidoc
 include::outputs/circonus.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/master/docs/index.asciidoc
 include::outputs/cloudwatch.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/master/docs/index.asciidoc
 include::outputs/csv.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/master/docs/index.asciidoc
 include::outputs/datadog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/master/docs/index.asciidoc
 include::outputs/elasticsearch.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/master/docs/index.asciidoc
 include::outputs/email.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/master/docs/index.asciidoc
 include::outputs/exec.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/master/docs/index.asciidoc
 include::outputs/file.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/master/docs/index.asciidoc
 include::outputs/ganglia.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/master/docs/index.asciidoc
 include::outputs/gelf.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/docs/index.asciidoc
 include::outputs/google_bigquery.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/edit/master/docs/index.asciidoc
 include::outputs/google_cloud_storage.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/docs/index.asciidoc
 include::outputs/graphite.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/master/docs/index.asciidoc
 include::outputs/graphtastic.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-hipchat/edit/master/docs/index.asciidoc
 include::outputs/hipchat.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/master/docs/index.asciidoc
 include::outputs/http.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/master/docs/index.asciidoc
 include::outputs/influxdb.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/docs/index.asciidoc
 include::outputs/irc.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-jira/edit/master/docs/index.asciidoc
 include::outputs/jira.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/master/docs/index.asciidoc
 include::outputs/kafka.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/docs/index.asciidoc
 include::outputs/librato.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/master/docs/index.asciidoc
 include::outputs/loggly.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/master/docs/index.asciidoc
 include::outputs/lumberjack.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/master/docs/index.asciidoc
 include::outputs/metriccatcher.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/master/docs/index.asciidoc
 include::outputs/mongodb.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/master/docs/index.asciidoc
 include::outputs/nagios.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/master/docs/index.asciidoc
 include::outputs/nagios_nsca.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-newrelic/edit/master/docs/index.asciidoc
 include::outputs/newrelic.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/master/docs/index.asciidoc
 include::outputs/opentsdb.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/master/docs/index.asciidoc
 include::outputs/pagerduty.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/docs/index.asciidoc
 include::outputs/pipe.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/master/docs/index.asciidoc
 include::outputs/rabbitmq.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-rackspace/edit/master/docs/index.asciidoc
 include::outputs/rackspace.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/docs/index.asciidoc
 include::outputs/redis.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/master/docs/index.asciidoc
 include::outputs/redmine.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/master/docs/index.asciidoc
 include::outputs/riak.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/master/docs/index.asciidoc
 include::outputs/riemann.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/master/docs/index.asciidoc
 include::outputs/s3.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/master/docs/index.asciidoc
 include::outputs/sns.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/master/docs/index.asciidoc
 include::outputs/solr_http.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/master/docs/index.asciidoc
 include::outputs/sqs.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/master/docs/index.asciidoc
 include::outputs/statsd.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/master/docs/index.asciidoc
 include::outputs/stdout.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/master/docs/index.asciidoc
 include::outputs/stomp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/master/docs/index.asciidoc
 include::outputs/syslog.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/master/docs/index.asciidoc
 include::outputs/tcp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/master/docs/index.asciidoc
 include::outputs/udp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/master/docs/index.asciidoc
 include::outputs/webhdfs.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/master/docs/index.asciidoc
 include::outputs/websocket.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/master/docs/index.asciidoc
 include::outputs/xmpp.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/master/docs/index.asciidoc
 include::outputs/zabbix.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-zeromq/edit/master/docs/index.asciidoc
 include::outputs/zeromq.asciidoc[]
+
 
 :edit_url: 

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -28,6 +28,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-influxdb,influxdb>> | Writes metrics to InfluxDB | https://github.com/logstash-plugins/logstash-output-influxdb[logstash-output-influxdb]
 | <<plugins-outputs-irc,irc>> | Writes events to IRC | https://github.com/logstash-plugins/logstash-output-irc[logstash-output-irc]
 | <<plugins-outputs-jira,jira>> | Writes strutured JSON events to JIRA | https://github.com/logstash-plugins/logstash-output-jira[logstash-output-jira]
+| <<plugins-outputs-jms,jms>> | Writes events to a Jms Broker | https://github.com/logstash-plugins/logstash-output-jms[logstash-output-jms]
 | <<plugins-outputs-juggernaut,juggernaut>> | Pushes messages to the Juggernaut websockets server | https://github.com/logstash-plugins/logstash-output-juggernaut[logstash-output-juggernaut]
 | <<plugins-outputs-kafka,kafka>> | Writes events to a Kafka topic | https://github.com/logstash-plugins/logstash-output-kafka[logstash-output-kafka]
 | <<plugins-outputs-librato,librato>> | Sends metrics, annotations, and alerts to Librato based on Logstash events | https://github.com/logstash-plugins/logstash-output-librato[logstash-output-librato]
@@ -126,6 +127,9 @@ include::outputs/irc.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-jira/edit/master/docs/index.asciidoc
 include::outputs/jira.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-output-jms/edit/master/docs/index.asciidoc
+include::outputs/jms.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]

--- a/docs/plugins/outputs/boundary.asciidoc
+++ b/docs/plugins/outputs/boundary.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Boundary output plugin
 

--- a/docs/plugins/outputs/circonus.asciidoc
+++ b/docs/plugins/outputs/circonus.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Circonus output plugin
 

--- a/docs/plugins/outputs/circonus.asciidoc
+++ b/docs/plugins/outputs/circonus.asciidoc
@@ -20,6 +20,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output sends annotations to Circonus based on Logstash events.
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -67,9 +68,6 @@ or
   * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
-
-This output lets you send annotations to
-Circonus based on Logstash events
 
 Your Circonus API Token
 

--- a/docs/plugins/outputs/cloudwatch.asciidoc
+++ b/docs/plugins/outputs/cloudwatch.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Cloudwatch output plugin
 

--- a/docs/plugins/outputs/csv.asciidoc
+++ b/docs/plugins/outputs/csv.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Csv output plugin
 

--- a/docs/plugins/outputs/datadog.asciidoc
+++ b/docs/plugins/outputs/datadog.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Datadog output plugin
 

--- a/docs/plugins/outputs/datadog.asciidoc
+++ b/docs/plugins/outputs/datadog.asciidoc
@@ -20,6 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output sends events to DataDogHQ based on Logstash events.
+
+Note that since Logstash maintains no state
+these will be one-shot events
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -59,12 +63,6 @@ Alert type
   * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
-
-This output lets you send events (for now. soon metrics) to
-DataDogHQ based on Logstash events
-
-Note that since Logstash maintains no state
-these will be one-shot events
 
 Your DatadogHQ API key
 

--- a/docs/plugins/outputs/datadog_metrics.asciidoc
+++ b/docs/plugins/outputs/datadog_metrics.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Datadog_metrics output plugin
 

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Elasticsearch output plugin
 

--- a/docs/plugins/outputs/email.asciidoc
+++ b/docs/plugins/outputs/email.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Email output plugin
 

--- a/docs/plugins/outputs/email.asciidoc
+++ b/docs/plugins/outputs/email.asciidoc
@@ -20,6 +20,8 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+The output sends email when an output is received. Alternatively, you may include or
+exclude the email output execution using conditionals.
 
 ==== Usage Example
 [source,ruby]
@@ -37,8 +39,7 @@ output {
   }
 }
 ----------------------------------
-Send email when an output is received. Alternatively, you may include or
-exclude the email output execution using conditionals.
+
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Email Output Configuration Options

--- a/docs/plugins/outputs/exec.asciidoc
+++ b/docs/plugins/outputs/exec.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Exec output plugin
 

--- a/docs/plugins/outputs/file.asciidoc
+++ b/docs/plugins/outputs/file.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === File output plugin
 

--- a/docs/plugins/outputs/ganglia.asciidoc
+++ b/docs/plugins/outputs/ganglia.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Ganglia output plugin
 

--- a/docs/plugins/outputs/google_bigquery.asciidoc
+++ b/docs/plugins/outputs/google_bigquery.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Google_bigquery output plugin
 

--- a/docs/plugins/outputs/graphite.asciidoc
+++ b/docs/plugins/outputs/graphite.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Graphite output plugin
 

--- a/docs/plugins/outputs/graphtastic.asciidoc
+++ b/docs/plugins/outputs/graphtastic.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Graphtastic output plugin
 

--- a/docs/plugins/outputs/hipchat.asciidoc
+++ b/docs/plugins/outputs/hipchat.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Hipchat output plugin
 

--- a/docs/plugins/outputs/http.asciidoc
+++ b/docs/plugins/outputs/http.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Http output plugin
 

--- a/docs/plugins/outputs/http.asciidoc
+++ b/docs/plugins/outputs/http.asciidoc
@@ -20,7 +20,15 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output lets you send events to a generic HTTP(S) endpoint.
 
+This output will execute up to 'pool_max' requests in parallel for performance.
+Consider this when tuning this plugin for performance.
+
+Additionally, note that when parallel execution is used strict ordering of events is not
+guaranteed!
+
+Beware, this gem does not yet support codecs. Please use the 'format' option for now.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http Output Configuration Options

--- a/docs/plugins/outputs/influxdb.asciidoc
+++ b/docs/plugins/outputs/influxdb.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Influxdb output plugin
 

--- a/docs/plugins/outputs/irc.asciidoc
+++ b/docs/plugins/outputs/irc.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Irc output plugin
 

--- a/docs/plugins/outputs/jms.asciidoc
+++ b/docs/plugins/outputs/jms.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Jms output plugin
 

--- a/docs/plugins/outputs/juggernaut.asciidoc
+++ b/docs/plugins/outputs/juggernaut.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Juggernaut output plugin
 

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Kafka
 

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -7,7 +7,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v5.1.7
 :release_date: 2017-06-23
 :changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v5.1.7/CHANGELOG.md
-:include_path: ../../../logstash/docs/include
+:include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -14,7 +14,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Kafka
+=== Kafka output plugin
 
 include::{include_path}/plugin_header.asciidoc[]
 

--- a/docs/plugins/outputs/librato.asciidoc
+++ b/docs/plugins/outputs/librato.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Librato output plugin
 

--- a/docs/plugins/outputs/librato.asciidoc
+++ b/docs/plugins/outputs/librato.asciidoc
@@ -20,6 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output lets you send metrics, annotations, and alerts to
+Librato based on Logstash events
+
+This is VERY experimental and inefficient right now.
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -50,10 +54,6 @@ output plugins.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-This output lets you send metrics, annotations and alerts to
-Librato based on Logstash events
-
-This is VERY experimental and inefficient right now.
 Your Librato account
 usually an email address
 

--- a/docs/plugins/outputs/loggly.asciidoc
+++ b/docs/plugins/outputs/loggly.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Loggly output plugin
 

--- a/docs/plugins/outputs/lumberjack.asciidoc
+++ b/docs/plugins/outputs/lumberjack.asciidoc
@@ -20,6 +20,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
+This output sends events using the lumberjack protocol.
 
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/docs/plugins/outputs/lumberjack.asciidoc
+++ b/docs/plugins/outputs/lumberjack.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Lumberjack output plugin
 

--- a/docs/plugins/outputs/metriccatcher.asciidoc
+++ b/docs/plugins/outputs/metriccatcher.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Metriccatcher output plugin
 

--- a/docs/plugins/outputs/mongodb.asciidoc
+++ b/docs/plugins/outputs/mongodb.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Mongodb output plugin
 

--- a/docs/plugins/outputs/nagios.asciidoc
+++ b/docs/plugins/outputs/nagios.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Nagios output plugin
 

--- a/docs/plugins/outputs/nagios_nsca.asciidoc
+++ b/docs/plugins/outputs/nagios_nsca.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Nagios_nsca output plugin
 

--- a/docs/plugins/outputs/null.asciidoc
+++ b/docs/plugins/outputs/null.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Null output plugin
 

--- a/docs/plugins/outputs/opentsdb.asciidoc
+++ b/docs/plugins/outputs/opentsdb.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Opentsdb output plugin
 

--- a/docs/plugins/outputs/pagerduty.asciidoc
+++ b/docs/plugins/outputs/pagerduty.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Pagerduty output plugin
 

--- a/docs/plugins/outputs/pipe.asciidoc
+++ b/docs/plugins/outputs/pipe.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Pipe output plugin
 

--- a/docs/plugins/outputs/rabbitmq.asciidoc
+++ b/docs/plugins/outputs/rabbitmq.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Rabbitmq output plugin
 

--- a/docs/plugins/outputs/rackspace.asciidoc
+++ b/docs/plugins/outputs/rackspace.asciidoc
@@ -2,8 +2,7 @@
 === rackspace
 
 
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-output-rackspace`.
-
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 
 

--- a/docs/plugins/outputs/redis.asciidoc
+++ b/docs/plugins/outputs/redis.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Redis output plugin
 

--- a/docs/plugins/outputs/redmine.asciidoc
+++ b/docs/plugins/outputs/redmine.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Redmine output plugin
 

--- a/docs/plugins/outputs/riak.asciidoc
+++ b/docs/plugins/outputs/riak.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Riak output plugin
 

--- a/docs/plugins/outputs/riemann.asciidoc
+++ b/docs/plugins/outputs/riemann.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Riemann output plugin
 

--- a/docs/plugins/outputs/s3.asciidoc
+++ b/docs/plugins/outputs/s3.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === S3 output plugin
 

--- a/docs/plugins/outputs/sns.asciidoc
+++ b/docs/plugins/outputs/sns.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Sns output plugin
 

--- a/docs/plugins/outputs/solr_http.asciidoc
+++ b/docs/plugins/outputs/solr_http.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Solr_http output plugin
 

--- a/docs/plugins/outputs/sqs.asciidoc
+++ b/docs/plugins/outputs/sqs.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Sqs output plugin
 

--- a/docs/plugins/outputs/statsd.asciidoc
+++ b/docs/plugins/outputs/statsd.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Statsd output plugin
 

--- a/docs/plugins/outputs/stdout.asciidoc
+++ b/docs/plugins/outputs/stdout.asciidoc
@@ -53,12 +53,8 @@ http://rubygems.org/gems/awesome_print[library]
 [id="plugins-{type}s-{plugin}-options"]
 ==== Stdout Output Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================
+There are no special configuration options for this plugin,
+but it does support the <<plugins-{type}s-{plugin}-common-options>>.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/outputs/stdout.asciidoc
+++ b/docs/plugins/outputs/stdout.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Stdout output plugin
 

--- a/docs/plugins/outputs/stomp.asciidoc
+++ b/docs/plugins/outputs/stomp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Stomp output plugin
 

--- a/docs/plugins/outputs/stomp.asciidoc
+++ b/docs/plugins/outputs/stomp.asciidoc
@@ -20,7 +20,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-
+This output writes events using the STOMP protocol.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Stomp Output Configuration Options

--- a/docs/plugins/outputs/syslog.asciidoc
+++ b/docs/plugins/outputs/syslog.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Syslog output plugin
 

--- a/docs/plugins/outputs/tcp.asciidoc
+++ b/docs/plugins/outputs/tcp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Tcp output plugin
 

--- a/docs/plugins/outputs/udp.asciidoc
+++ b/docs/plugins/outputs/udp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Udp output plugin
 

--- a/docs/plugins/outputs/webhdfs.asciidoc
+++ b/docs/plugins/outputs/webhdfs.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Webhdfs output plugin
 

--- a/docs/plugins/outputs/websocket.asciidoc
+++ b/docs/plugins/outputs/websocket.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Websocket output plugin
 

--- a/docs/plugins/outputs/xmpp.asciidoc
+++ b/docs/plugins/outputs/xmpp.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Xmpp output plugin
 

--- a/docs/plugins/outputs/zabbix.asciidoc
+++ b/docs/plugins/outputs/zabbix.asciidoc
@@ -12,7 +12,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
-[id="plugins-{type}-{plugin}"]
+[id="plugins-{type}s-{plugin}"]
 
 === Zabbix output plugin
 

--- a/docs/plugins/outputs/zeromq.asciidoc
+++ b/docs/plugins/outputs/zeromq.asciidoc
@@ -1,7 +1,7 @@
 [[plugins-outputs-zeromq]]
 === zeromq
 
-NOTE: This is a community-maintained plugin!
+NOTE: This plugin cannot be installed on the current version of Logstash.
 
 Write events to a 0MQ PUB socket.
 


### PR DESCRIPTION
Here's a "patched" version of the plugin docs based on the docs that were generated two days ago. I've verified that all the version info matches the installed plugins for 5.5. I propose that we use this version of the plugin content if we cannot regenerate the docs in time for the 5.5 release. We can quickly release a new version of the doc, but I think this gets us pretty close. If the docs reflect incorrect details about the community-maintained plugins, I think that's OK...for now.

I've created lots of commits intentionally so I can cherry-pick any relevant changes if we do get the docgen to work successfully tomorrow.

TO DO: If we use these files, I'll make all the topic titles consistent. 

There were still quite a few files that were old, so here's a description of what I did with content that wasn't quite right:

* Updated asciidoc in the following plugins:

logstash-input-eventlog -  content was very old. I was able to install v4.1.1 on 5.5, so I updated the docs to reflect that version.
logstash-filter-truncate - content was old - I was able to install v1.0.2 on 5.5, so I updated the docs to reflect that version.
logstash-input-gelf - changed version - docs showed version as 3.0.5, but should be v3.0.4, so I changed the version 
logstash-input-xmpp - changed version - docs showed version as 3.1.4, but should be 3.1.3, so I changed the version

* Old docs that still  had the old community maintainer note. I handled these differently based on the install issues that I encountered:

When install resulted in errors about incompatible versions, I changed the community maintainer note in these plugins to indicate that the plugin could not be installed on the current version of logstash. If a note didn't exist, I added one. Was this the right thing to do?

logstash-input-gemfire
logstash-input-rackspace
logstash-input-websocket
logstash-input-zenoss
logstash-input-zeromq
logstash-filter-cipher
logstash-filter-collate
logstash-filter-metaevent
logstash-filter-punct
logstash-filter-yaml
logstash-filter-zeromq
logstash-codec-oldlogstashjson
logstash-output-rackspace
logstash-output-zeromq


When install failed with "error occurred while installing net-ssh",  I left the community-maintainer note as it was. What should I do here?

logstash-input-heroku
logstash-codec-cloudtrail
logstash-codec-compress_spooler - 
logstash-output-gelf
logstash-output-google_cloud_storage
logstash-output-jira
logstash-output-newrelic


- The following plugin installed, but it was an old version, so I  left the community-maintainer note. What should I do here?

drupal_dblog input - old formatting - didn't update because latest installable version was 2.0.3 - March 18, 2016 java (905 KB) 


- The following plugin does not exist, so I need someone to confirm that I should delete it from the index and overview table:

logstash-codec-s3_plain  

- This file exists, but it's not in the TOC. Should I delete it:

logstash-codec-spool 

