### PR TITLE
[Docs] Remove links that are causing display issues

### DIFF
--- a/docs/plugins/filters/aggregate.asciidoc
+++ b/docs/plugins/filters/aggregate.asciidoc
@@ -19,17 +19,6 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 include::{include_path}/plugin_header.asciidoc[]
 
 
-<<plugins-{type}s-{plugin}-description>> +
-<<plugins-{type}s-{plugin}-example1>> +
-<<plugins-{type}s-{plugin}-example2>> +
-<<plugins-{type}s-{plugin}-example3>> +
-<<plugins-{type}s-{plugin}-example4>> +
-<<plugins-{type}s-{plugin}-example5>> +
-<<plugins-{type}s-{plugin}-howitworks>> +
-<<plugins-{type}s-{plugin}-usecases>> +
-<<plugins-{type}s-{plugin}-options>> +
-
-
 [id="plugins-{type}s-{plugin}-description"]
 ==== Description
 


### PR DESCRIPTION
These links are causing funky display issues and are not necessary because they duplicate the link info that is already available under "On this Page"