### PR TITLE
Fix edit url link

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -87,10 +87,10 @@ include::filters/date.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/docs/index.asciidoc
 include::filters/de_dot.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
 include::filters/dissect.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
 include::filters/dns.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/docs/index.asciidoc


### PR DESCRIPTION
Fixes edit URLs for dissect and dns plugins.

Addresses the issue identified in https://github.com/logstash-plugins/logstash-filter-dissect/issues/43