### PR TITLE
Create prototype of versioned plugin docs

### DIFF
--- a/docs/versioned-plugins/codecs.asciidoc
+++ b/docs/versioned-plugins/codecs.asciidoc
@@ -1,0 +1,6 @@
+:type: codec
+:type_uc: Codec
+
+include::include/plugin-intro.asciidoc[]
+
+include::codecs/rubydebug-index.asciidoc[]

--- a/docs/versioned-plugins/codecs/rubydebug-index.asciidoc
+++ b/docs/versioned-plugins/codecs/rubydebug-index.asciidoc
@@ -1,0 +1,14 @@
+:plugin: rubydebug
+:type: codec
+
+include::{include_path}/version-list-intro.asciidoc[]
+
+|=======================================================================
+| Version | Release Date 
+| <<v3.0.4-plugins-codecs-rubydebug,v3.0.4>> | Aug 21, 2017 (latest)
+| <<v3.0.3-plugins-codecs-rubydebug,v3.0.3>> | Aug 21, 2017
+|=======================================================================
+
+
+include::rubydebug-v3.0.4.asciidoc[]
+include::rubydebug-v3.0.3.asciidoc[]

--- a/docs/versioned-plugins/codecs/rubydebug-v3.0.3.asciidoc
+++ b/docs/versioned-plugins/codecs/rubydebug-v3.0.3.asciidoc
@@ -1,0 +1,47 @@
+:plugin: rubydebug
+:type: codec
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.0.3
+:release_date: 2017-08-21
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/blob/v3.0.4/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Rubydebug codec plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The rubydebug codec will output your Logstash event data using
+the Ruby Awesome Print library.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Rubydebug Codec Configuration Options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-metadata>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+|=======================================================================
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-metadata"]
+===== `metadata` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Should the event's metadata be included?
+
+

--- a/docs/versioned-plugins/codecs/rubydebug-v3.0.4.asciidoc
+++ b/docs/versioned-plugins/codecs/rubydebug-v3.0.4.asciidoc
@@ -1,0 +1,47 @@
+:plugin: rubydebug
+:type: codec
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.0.4
+:release_date: 2017-08-21
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/blob/v3.0.4/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Rubydebug codec plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The rubydebug codec will output your Logstash event data using
+the Ruby Awesome Print library.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Rubydebug Codec Configuration Options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-metadata>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+|=======================================================================
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-metadata"]
+===== `metadata` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Should the event's metadata be included?
+
+

--- a/docs/versioned-plugins/filters.asciidoc
+++ b/docs/versioned-plugins/filters.asciidoc
@@ -1,0 +1,7 @@
+:type: filter
+:type_uc: Filter
+
+include::include/plugin-intro.asciidoc[]
+
+include::filters/multiline-index.asciidoc[]
+

--- a/docs/versioned-plugins/filters/multiline-index.asciidoc
+++ b/docs/versioned-plugins/filters/multiline-index.asciidoc
@@ -1,0 +1,14 @@
+:plugin: multiline
+:type: filter
+
+include::{include_path}/version-list-intro.asciidoc[]
+
+|=======================================================================
+| Version | Release Date 
+| <<v3.0.4-plugins-filters-multiline,v3.0.4>> | Aug 15, 2017 (latest)
+| <<v3.0.3-plugins-filters-multiline,v3.0.3>> | Aug 15, 2017
+|=======================================================================
+
+
+include::multiline-v3.0.4.asciidoc[]
+include::multiline-v3.0.3.asciidoc[]

--- a/docs/versioned-plugins/filters/multiline-v3.0.3.asciidoc
+++ b/docs/versioned-plugins/filters/multiline-v3.0.3.asciidoc
@@ -1,0 +1,194 @@
+:plugin: multiline
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.0.3
+:release_date: 2017-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-multiline/blob/v3.0.4/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Multiline filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This filter will collapse multiline messages from a single source into one Logstash event.
+
+The original goal of this filter was to allow joining of multi-line messages
+from files into a single event. For example - joining java exception and
+stacktrace messages into a single event.
+
+NOTE: This filter will not work with multiple worker threads `-w 2` on the logstash command line.
+
+The config looks like this:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "pattern, a regexp"
+        negate => boolean
+        what => "previous" or "next"
+      }
+    }
+
+The `pattern` should be a regexp ({logstash-ref}/plugins-filters-grok.html[grok] patterns are
+supported) which matches what you believe to be an indicator that the field
+is part of an event consisting of multiple lines of log data.
+
+The `what` must be `previous` or `next` and indicates the relation
+to the multi-line event.
+
+The `negate` can be `true` or `false` (defaults to `false`). If `true`, a
+message not matching the pattern will constitute a match of the multiline
+filter and the `what` will be applied. (vice-versa is also true)
+
+For example, Java stack traces are multiline and usually have the message
+starting at the far-left, with each subsequent line indented. Do this:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "^\s"
+        what => "previous"
+      }
+    }
+
+This says that any line starting with whitespace belongs to the previous line.
+
+Another example is C line continuations (backslash). Here's how to do that:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "\\$"
+        what => "next"
+      }
+    }
+
+This says that any line ending with a backslash should be combined with the
+following line.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Multiline Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-allow_duplicates>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-max_age>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-negate>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-pattern>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-patterns_dir>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-source>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-stream_identity>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-what>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["previous", "next"]`|Yes
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-allow_duplicates"]
+===== `allow_duplicates` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Allow duplcate values on the source field.
+
+[id="{version}-plugins-{type}s-{plugin}-max_age"]
+===== `max_age` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+The maximum age an event can be (in seconds) before it is automatically
+flushed.
+
+[id="{version}-plugins-{type}s-{plugin}-negate"]
+===== `negate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Negate the regexp pattern ('if not matched')
+
+[id="{version}-plugins-{type}s-{plugin}-pattern"]
+===== `pattern` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The expression to match. The same matching engine as the
+{logstash-ref}/plugins-filters-grok.html[grok] filter is used, so the expression can contain
+a plain regular expression or one that also contains grok patterns.
+
+[id="{version}-plugins-{type}s-{plugin}-patterns_dir"]
+===== `patterns_dir` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Logstash ships by default with a bunch of patterns, so you don't
+necessarily need to define this yourself unless you are adding additional
+patterns.
+
+Pattern files are plain text with format:
+[source,ruby]
+    NAME PATTERN
+
+For example:
+[source,ruby]
+    NUMBER \d+
+
+[id="{version}-plugins-{type}s-{plugin}-source"]
+===== `source` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"message"`
+
+The field name to execute the pattern match on.
+
+[id="{version}-plugins-{type}s-{plugin}-stream_identity"]
+===== `stream_identity` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"%{host}.%{path}.%{type}"`
+
+The stream identity is how the multiline filter determines which stream an
+event belongs to. This is generally used for differentiating, say, events
+coming from multiple files in the same file input, or multiple connections
+coming from a tcp input.
+
+The default value here is usually what you want, but there are some cases
+where you want to change it. One such example is if you are using a tcp
+input with only one client connecting at any time. If that client
+reconnects (due to error or client restart), then logstash will identify
+the new connection as a new stream and break any multiline goodness that
+may have occurred between the old and new connection. To solve this use
+case, you can use `%{@source_host}.%{@type}` instead.
+
+[id="{version}-plugins-{type}s-{plugin}-what"]
+===== `what` 
+
+  * This is a required setting.
+  * Value can be any of: `previous`, `next`
+  * There is no default value for this setting.
+
+If the pattern matched, does event belong to the next or previous event?
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/multiline-v3.0.4.asciidoc
+++ b/docs/versioned-plugins/filters/multiline-v3.0.4.asciidoc
@@ -1,0 +1,195 @@
+:plugin: multiline
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.0.4
+:release_date: 2017-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-multiline/blob/v3.0.4/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Multiline filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+
+This filter will collapse multiline messages from a single source into one Logstash event.
+
+The original goal of this filter was to allow joining of multi-line messages
+from files into a single event. For example - joining java exception and
+stacktrace messages into a single event.
+
+NOTE: This filter will not work with multiple worker threads `-w 2` on the logstash command line.
+
+The config looks like this:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "pattern, a regexp"
+        negate => boolean
+        what => "previous" or "next"
+      }
+    }
+
+The `pattern` should be a regexp ({logstash-ref}/plugins-filters-grok.html[grok] patterns are
+supported) which matches what you believe to be an indicator that the field
+is part of an event consisting of multiple lines of log data.
+
+The `what` must be `previous` or `next` and indicates the relation
+to the multi-line event.
+
+The `negate` can be `true` or `false` (defaults to `false`). If `true`, a
+message not matching the pattern will constitute a match of the multiline
+filter and the `what` will be applied. (vice-versa is also true)
+
+For example, Java stack traces are multiline and usually have the message
+starting at the far-left, with each subsequent line indented. Do this:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "^\s"
+        what => "previous"
+      }
+    }
+
+This says that any line starting with whitespace belongs to the previous line.
+
+Another example is C line continuations (backslash). Here's how to do that:
+[source,ruby]
+    filter {
+      multiline {
+        pattern => "\\$"
+        what => "next"
+      }
+    }
+
+This says that any line ending with a backslash should be combined with the
+following line.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Multiline Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-allow_duplicates>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-max_age>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-negate>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-pattern>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-patterns_dir>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-source>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-stream_identity>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-what>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["previous", "next"]`|Yes
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-allow_duplicates"]
+===== `allow_duplicates` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Allow duplcate values on the source field.
+
+[id="{version}-plugins-{type}s-{plugin}-max_age"]
+===== `max_age` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+The maximum age an event can be (in seconds) before it is automatically
+flushed.
+
+[id="{version}-plugins-{type}s-{plugin}-negate"]
+===== `negate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Negate the regexp pattern ('if not matched')
+
+[id="{version}-plugins-{type}s-{plugin}-pattern"]
+===== `pattern` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The expression to match. The same matching engine as the
+{logstash-ref}/plugins-filters-grok.html[grok] filter is used, so the expression can contain
+a plain regular expression or one that also contains grok patterns.
+
+[id="{version}-plugins-{type}s-{plugin}-patterns_dir"]
+===== `patterns_dir` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Logstash ships by default with a bunch of patterns, so you don't
+necessarily need to define this yourself unless you are adding additional
+patterns.
+
+Pattern files are plain text with format:
+[source,ruby]
+    NAME PATTERN
+
+For example:
+[source,ruby]
+    NUMBER \d+
+
+[id="{version}-plugins-{type}s-{plugin}-source"]
+===== `source` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"message"`
+
+The field name to execute the pattern match on.
+
+[id="{version}-plugins-{type}s-{plugin}-stream_identity"]
+===== `stream_identity` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"%{host}.%{path}.%{type}"`
+
+The stream identity is how the multiline filter determines which stream an
+event belongs to. This is generally used for differentiating, say, events
+coming from multiple files in the same file input, or multiple connections
+coming from a tcp input.
+
+The default value here is usually what you want, but there are some cases
+where you want to change it. One such example is if you are using a tcp
+input with only one client connecting at any time. If that client
+reconnects (due to error or client restart), then logstash will identify
+the new connection as a new stream and break any multiline goodness that
+may have occurred between the old and new connection. To solve this use
+case, you can use `%{@source_host}.%{@type}` instead.
+
+[id="{version}-plugins-{type}s-{plugin}-what"]
+===== `what` 
+
+  * This is a required setting.
+  * Value can be any of: `previous`, `next`
+  * There is no default value for this setting.
+
+If the pattern matched, does event belong to the next or previous event?
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/include/filter.asciidoc
+++ b/docs/versioned-plugins/include/filter.asciidoc
@@ -1,0 +1,177 @@
+==== Common Options
+
+The following configuration options are supported by all filter plugins:
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-add_field>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-add_tag>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-periodic_flush>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-remove_field>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-remove_tag>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+|=======================================================================
+
+[id="{version}-plugins-{type}s-{plugin}-add_field"]
+===== `add_field`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+If this filter is successful, add any arbitrary fields to this event.
+Field names can be dynamic and include parts of the event using the `%{field}`.
+
+Example:
+
+["source","json",subs="attributes"]
+    filter {
+      {plugin} {
+        add_field => { "foo_%\{somefield\}" => "Hello world, from %\{host\}" }
+      }
+    }
+    
+["source","json",subs="attributes"]
+    # You can also add multiple fields at once:
+    filter {
+      {plugin} {
+        add_field => {
+          "foo_%\{somefield\}" => "Hello world, from %\{host\}"
+          "new_field" => "new_static_value"
+        }
+      }
+    }
+
+If the event has field `"somefield" == "hello"` this filter, on success,
+would add field `foo_hello` if it is present, with the
+value above and the `%{host}` piece replaced with that value from the
+event. The second example would also add a hardcoded field.
+
+[id="{version}-plugins-{type}s-{plugin}-add_tag"]
+===== `add_tag`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+If this filter is successful, add arbitrary tags to the event.
+Tags can be dynamic and include parts of the event using the `%{field}`
+syntax.
+
+Example:
+
+["source","json",subs="attributes"]
+    filter {
+      {plugin} {
+        add_tag => [ "foo_%\{somefield\}" ]
+      }
+    }
+    
+["source","json",subs="attributes"]
+    # You can also add multiple tags at once:
+    filter {
+      {plugin} {
+        add_tag => [ "foo_%\{somefield\}", "taggedy_tag"]
+      }
+    }
+
+If the event has field `"somefield" == "hello"` this filter, on success,
+would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
+
+[id="{version}-plugins-{type}s-{plugin}-enable_metric"]
+===== `enable_metric`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Disable or enable metric logging for this specific plugin instance
+by default we record all the metrics we can, but you can disable metrics collection
+for a specific plugin.
+
+[id="{version}-plugins-{type}s-{plugin}-id"]
+===== `id`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Add a unique `ID` to the plugin configuration. If no ID is specified, Logstash will generate one.
+It is strongly recommended to set this ID in your configuration. This is particularly useful
+when you have two or more plugins of the same type, for example, if you have 2 {plugin} filters.
+Adding a named ID in this case will help in monitoring Logstash when using the monitoring APIs.
+
+
+["source","json",subs="attributes"]
+    filter {
+      {plugin} {
+        id => "ABC"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-periodic_flush"]
+===== `periodic_flush`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Call the filter flush method at regular interval.
+Optional.
+
+[id="{version}-plugins-{type}s-{plugin}-remove_field"]
+===== `remove_field`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+If this filter is successful, remove arbitrary fields from this event.
+Fields names can be dynamic and include parts of the event using the %{field}
+Example:
+
+["source","json",subs="attributes"]
+    filter {
+      {plugin} {
+        remove_field => [ "foo_%\{somefield\}" ]
+      }
+    }
+    
+["source","json",subs="attributes"]
+    # You can also remove multiple fields at once:
+    filter {
+      {plugin} {
+        remove_field => [ "foo_%\{somefield\}", "my_extraneous_field" ]
+      }
+    }
+
+If the event has field `"somefield" == "hello"` this filter, on success,
+would remove the field with name `foo_hello` if it is present. The second
+example would remove an additional, non-dynamic field.
+
+[id="{version}-plugins-{type}s-{plugin}-remove_tag"]
+===== `remove_tag`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+If this filter is successful, remove arbitrary tags from the event.
+Tags can be dynamic and include parts of the event using the `%{field}`
+syntax.
+
+Example:
+
+["source","json",subs="attributes"]
+    filter {
+      {plugin} {
+        remove_tag => [ "foo_%\{somefield\}" ]
+      }
+    }
+    
+["source","json",subs="attributes"]
+    # You can also remove multiple tags at once:
+    filter {
+      {plugin} {
+        remove_tag => [ "foo_%\{somefield\}", "sad_unwanted_tag"]
+      }
+    }
+
+If the event has field `"somefield" == "hello"` this filter, on success,
+would remove the tag `foo_hello` if it is present. The second example
+would remove a sad, unwanted tag as well.

--- a/docs/versioned-plugins/include/input.asciidoc
+++ b/docs/versioned-plugins/include/input.asciidoc
@@ -1,0 +1,104 @@
+==== Common Options
+
+The following configuration options are supported by all input plugins:
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-add_field>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+| <<{version}-plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-tags>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+
+==== Details
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-add_field"]
+===== `add_field`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+Add a field to an event
+
+[id="{version}-plugins-{type}s-{plugin}-codec"]
+===== `codec`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#codec[codec]
+  * Default value is `"plain"`
+
+The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
+
+
+[id="{version}-plugins-{type}s-{plugin}-enable_metric"]
+===== `enable_metric`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Disable or enable metric logging for this specific plugin instance
+by default we record all the metrics we can, but you can disable metrics collection
+for a specific plugin.
+
+[id="{version}-plugins-{type}s-{plugin}-id"]
+===== `id`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Add a unique `ID` to the plugin configuration. If no ID is specified, Logstash will generate one.
+It is strongly recommended to set this ID in your configuration. This is particularly useful
+when you have two or more plugins of the same type, for example, if you have 2 {plugin} inputs.
+Adding a named ID in this case will help in monitoring Logstash when using the monitoring APIs.
+
+["source","json",subs="attributes"]
+---------------------------------------------------------------------------------------------------
+input {
+  {plugin} {
+    id => "my_plugin_id"
+  }
+}
+---------------------------------------------------------------------------------------------------
+
+[id="{version}-plugins-{type}s-{plugin}-tags"]
+===== `tags`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * There is no default value for this setting.
+
+Add any number of arbitrary tags to your event.
+
+This can help with processing later.
+
+[id="{version}-plugins-{type}s-{plugin}-type"]
+===== `type`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Add a `type` field to all events handled by this input.
+
+Types are used mainly for filter activation.
+
+The type is stored as part of the event itself, so you can
+also use the type to search for it in Kibana.
+
+If you try to set a type on an event that already has one (for
+example when you send an event from a shipper to an indexer) then
+a new input will not override the existing type. A type set at
+the shipper stays with that event for its life even
+when sent to another Logstash server.
+
+ifeval::["{type}"=="input" and "{plugin}"=="beats"]
+
+NOTE: The Beats shipper automatically sets the `type` field on the event.
+You cannot override this setting in the Logstash config. If you specify
+a setting for the <<{version}-plugins-inputs-beats-type,`type`>> config option in
+Logstash, it is ignored.
+
+endif::[]
+

--- a/docs/versioned-plugins/include/output.asciidoc
+++ b/docs/versioned-plugins/include/output.asciidoc
@@ -1,0 +1,51 @@
+==== Common Options
+
+The following configuration options are supported by all output plugins:
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+| <<{version}-plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+[id="{version}-plugins-{type}s-{plugin}-codec"]
+===== `codec`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#codec[codec]
+  * Default value is `"plain"`
+
+The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output, without needing a separate filter in your Logstash pipeline.
+
+[id="{version}-plugins-{type}s-{plugin}-enable_metric"]
+===== `enable_metric`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Disable or enable metric logging for this specific plugin instance
+by default we record all the metrics we can, but you can disable metrics collection
+for a specific plugin.
+
+[id="{version}-plugins-{type}s-{plugin}-id"]
+===== `id`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Add a unique `ID` to the plugin configuration. If no ID is specified, Logstash will generate one.
+It is strongly recommended to set this ID in your configuration. This is particularly useful
+when you have two or more plugins of the same type, for example, if you have 2 {plugin} outputs.
+Adding a named ID in this case will help in monitoring Logstash when using the monitoring APIs.
+
+["source","json",subs="attributes"]
+---------------------------------------------------------------------------------------------------
+output {
+  {plugin} {
+    id => "my_plugin_id"
+  }
+}
+---------------------------------------------------------------------------------------------------
+
+

--- a/docs/versioned-plugins/include/plugin-intro.asciidoc
+++ b/docs/versioned-plugins/include/plugin-intro.asciidoc
@@ -1,0 +1,13 @@
+[id="{type}-plugins"]
+= {type_uc} plugins
+
+[partintro]
+--
+Looking for a specific version of the Logstash plugin docs? You've come to the
+right place. This section contains all available versions of the documentation
+for the Logstash {type} plugins.
+
+Want to learn how to use Logstash? See the
+{logstash-ref}/index.html[Logstash Reference].
+
+--

--- a/docs/versioned-plugins/include/plugin_header.asciidoc
+++ b/docs/versioned-plugins/include/plugin_header.asciidoc
@@ -1,0 +1,43 @@
+ifeval::["{versioned_docs}"!="true"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+endif::[]
+ifeval::["{versioned_docs}"=="true"]
+++++
+<titleabbrev>{plugin} {version}</titleabbrev>
+++++
+endif::[]
+
+* Plugin version: {version}
+* Released on: {release_date}
+* {changelog_url}[Changelog]
+
+ifeval::["{versioned_docs}"!="true"]
+
+For other plugin versions, see the
+<<{type}-{plugin}-index,Versioned {plugin} {type} plugin docs>>.
+
+endif::[]
+
+ifeval::["{versioned_docs}"=="true"]
+
+For other versions, see the <<{type}-{plugin}-index,overview list>>.
+
+To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
+
+endif::[]
+
+ifeval::[("{default_plugin}"=="0") and ("{versioned_docs}"!="true")]
+
+==== Installation
+
+For plugins not bundled by default, it is easy to install by running +bin/logstash-plugin install logstash-{type}-{plugin}+. See {logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
+
+endif::[]
+
+==== Getting Help
+
+For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-{type}-{plugin}[Github].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#show_logstash_plugins[Elastic Support Matrix].
+

--- a/docs/versioned-plugins/include/version-list-intro.asciidoc
+++ b/docs/versioned-plugins/include/version-list-intro.asciidoc
@@ -1,0 +1,13 @@
+[id="{type}-{plugin}-index"]
+
+== Versioned {plugin} {type} plugin docs
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+This page lists all available versions of the documentation for this plugin. 
+To see which version of the plugin you have installed, run `bin/logstash-plugin
+list --verbose`. 
+
+NOTE: Versioned plugin documentation is not available for plugins released prior
+to Logstash 6.0.

--- a/docs/versioned-plugins/index.asciidoc
+++ b/docs/versioned-plugins/index.asciidoc
@@ -1,0 +1,20 @@
+:versioned_docs: true
+
+// Set include path for static files that live in the logstash repo
+:include_path: ../include
+
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+// Override logstash-ref setting imported from shared/attributes.asciidoc
+:logstash-ref: http://www.elastic.co/guide/en/logstash/current
+
+[[logstash-plugin-reference]]
+= Versioned Plugin Reference
+
+include::inputs.asciidoc[]
+
+include::outputs.asciidoc[]
+
+include::filters.asciidoc[]
+
+include::codecs.asciidoc[]

--- a/docs/versioned-plugins/inputs.asciidoc
+++ b/docs/versioned-plugins/inputs.asciidoc
@@ -1,0 +1,8 @@
+:type: input
+:type_uc: Input
+
+include::include/plugin-intro.asciidoc[]
+
+include::inputs/beats-index.asciidoc[]
+
+include::inputs/dead_letter_queue-index.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-index.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-index.asciidoc
@@ -1,0 +1,14 @@
+:plugin: beats
+:type: input
+
+include::{include_path}/version-list-intro.asciidoc[]
+
+|=======================================================================
+| Version | Release Date 
+| <<v5.0.1-plugins-inputs-beats,v5.0.1>> | Aug 15, 2017 (latest)
+| <<v5.0.0-plugins-inputs-beats,v5.0.0>> | Aug 15, 2017
+|=======================================================================
+
+
+include::beats-v5.0.1.asciidoc[]
+include::beats-v5.0.0.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-v5.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-v5.0.0.asciidoc
@@ -1,0 +1,222 @@
+:plugin: beats
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v5.0.0
+:release_date: 2017-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.0.1/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+=== Beats input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input plugin enables Logstash to receive events from the
+https://www.elastic.co/products/beats[Elastic Beats] framework.
+
+The following example shows how to configure Logstash to listen on port
+5044 for incoming Beats connections and to index into Elasticsearch:
+
+[source,ruby]
+------------------------------------------------------------------------------
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "localhost:9200"
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+}
+------------------------------------------------------------------------------
+
+NOTE: The Beats shipper automatically sets the `type` field on the event.
+You cannot override this setting in the Logstash config. If you specify
+a setting for the <<{version}-plugins-inputs-beats-type,`type`>> config option in
+Logstash, it is ignored.
+
+IMPORTANT: If you are shipping events that span multiple lines, you need to
+use the https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html[configuration options available in Filebeat] to handle multiline events
+before sending the event data to Logstash. You cannot use the
+{logstash-ref}/plugins-codecs-multiline.html[multiline] codec to handle multiline events. Doing so will
+result in the failure to start Logstash.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Beats Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-cipher_suites>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-client_inactivity_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-host>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_codec_tag>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-port>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key_passphrase>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_verify_mode>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["none", "peer", "force_peer"]`|No
+| <<{version}-plugins-{type}s-{plugin}-tls_max_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-tls_min_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-cipher_suites"]
+===== `cipher_suites` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
+
+The list of ciphers suite to use, listed by priorities.
+
+[id="{version}-plugins-{type}s-{plugin}-client_inactivity_timeout"]
+===== `client_inactivity_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Close Idle clients after X seconds of inactivity.
+
+[id="{version}-plugins-{type}s-{plugin}-host"]
+===== `host` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"0.0.0.0"`
+
+The IP address to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-include_codec_tag"]
+===== `include_codec_tag` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-port"]
+===== `port` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * There is no default value for this setting.
+
+The port to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Events are by default sent in plain text. You can
+enable encryption by setting `ssl` to true and configuring
+the `ssl_certificate` and `ssl_key` options.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL certificate to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Validate client certificates against these authorities. 
+You can define multiple files or paths. All the certificates will
+be read and added to the trust store. You need to configure the `ssl_verify_mode`
+to `peer` or `force_peer` to enable the verification.
+
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+Time in milliseconds for an incomplete ssl handshake to timeout
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL key to use.
+NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
+for more information.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+SSL key passphrase to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_verify_mode"]
+===== `ssl_verify_mode` 
+
+  * Value can be any of: `none`, `peer`, `force_peer`
+  * Default value is `"none"`
+
+By default the server doesn't do any client verification.
+
+`peer` will make the server ask the client to provide a certificate. 
+If the client provides a certificate, it will be validated.
+
+`force_peer` will make the server ask the client to provide a certificate.
+If the client doesn't provide a certificate, the connection will be closed.
+
+This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="{version}-plugins-{type}s-{plugin}-tls_max_version"]
+===== `tls_max_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1.2`
+
+The maximum TLS version allowed for the encrypted connections. The value must be the one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+[id="{version}-plugins-{type}s-{plugin}-tls_min_version"]
+===== `tls_min_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The minimum TLS version allowed for the encrypted connections. The value must be one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-v5.0.1.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-v5.0.1.asciidoc
@@ -1,0 +1,222 @@
+:plugin: beats
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v5.0.1
+:release_date: 2017-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.0.1/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Beats input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input plugin enables Logstash to receive events from the
+https://www.elastic.co/products/beats[Elastic Beats] framework.
+
+The following example shows how to configure Logstash to listen on port
+5044 for incoming Beats connections and to index into Elasticsearch:
+
+[source,ruby]
+------------------------------------------------------------------------------
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "localhost:9200"
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+}
+------------------------------------------------------------------------------
+
+NOTE: The Beats shipper automatically sets the `type` field on the event.
+You cannot override this setting in the Logstash config. If you specify
+a setting for the <<{version}-plugins-inputs-beats-type,`type`>> config option in
+Logstash, it is ignored.
+
+IMPORTANT: If you are shipping events that span multiple lines, you need to
+use the https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html[configuration options available in Filebeat] to handle multiline events
+before sending the event data to Logstash. You cannot use the
+{logstash-ref}/plugins-codecs-multiline.html[multiline] codec to handle multiline events. Doing so will
+result in the failure to start Logstash.
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Beats Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-cipher_suites>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-client_inactivity_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-host>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_codec_tag>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-port>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key_passphrase>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_verify_mode>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["none", "peer", "force_peer"]`|No
+| <<{version}-plugins-{type}s-{plugin}-tls_max_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-tls_min_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-cipher_suites"]
+===== `cipher_suites` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
+
+The list of ciphers suite to use, listed by priorities.
+
+[id="{version}-plugins-{type}s-{plugin}-client_inactivity_timeout"]
+===== `client_inactivity_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Close Idle clients after X seconds of inactivity.
+
+[id="{version}-plugins-{type}s-{plugin}-host"]
+===== `host` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"0.0.0.0"`
+
+The IP address to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-include_codec_tag"]
+===== `include_codec_tag` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-port"]
+===== `port` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * There is no default value for this setting.
+
+The port to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Events are by default sent in plain text. You can
+enable encryption by setting `ssl` to true and configuring
+the `ssl_certificate` and `ssl_key` options.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL certificate to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Validate client certificates against these authorities. 
+You can define multiple files or paths. All the certificates will
+be read and added to the trust store. You need to configure the `ssl_verify_mode`
+to `peer` or `force_peer` to enable the verification.
+
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+Time in milliseconds for an incomplete ssl handshake to timeout
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL key to use.
+NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
+for more information.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+SSL key passphrase to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_verify_mode"]
+===== `ssl_verify_mode` 
+
+  * Value can be any of: `none`, `peer`, `force_peer`
+  * Default value is `"none"`
+
+By default the server doesn't do any client verification.
+
+`peer` will make the server ask the client to provide a certificate. 
+If the client provides a certificate, it will be validated.
+
+`force_peer` will make the server ask the client to provide a certificate.
+If the client doesn't provide a certificate, the connection will be closed.
+
+This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="{version}-plugins-{type}s-{plugin}-tls_max_version"]
+===== `tls_max_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1.2`
+
+The maximum TLS version allowed for the encrypted connections. The value must be the one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+[id="{version}-plugins-{type}s-{plugin}-tls_min_version"]
+===== `tls_min_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The minimum TLS version allowed for the encrypted connections. The value must be one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/dead_letter_queue-index.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-index.asciidoc
@@ -1,0 +1,15 @@
+:plugin: dead_letter_queue
+:type: input
+
+include::{include_path}/version-list-intro.asciidoc[]
+
+|=======================================================================
+| Version | Release Date 
+| <<v1.1.0-plugins-inputs-dead_letter_queue,v1.1.0>> | Aug 25, 2017 (latest)
+| <<v1.0.0-plugins-inputs-dead_letter_queue,v1.0.0>> | Aug 25, 2017
+|=======================================================================
+
+
+include::dead_letter_queue-v1.1.0.asciidoc[]
+include::dead_letter_queue-v1.0.0.asciidoc[]
+

--- a/docs/versioned-plugins/inputs/dead_letter_queue-v1.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-v1.0.0.asciidoc
@@ -1,0 +1,110 @@
+:plugin: dead_letter_queue
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.0.0
+:release_date: 2017-08-25
+:changelog_url: https://github.com/logstash-plugins/logstash-input-dead_letter_queue/blob/v1.1.0/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Dead_letter_queue input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Logstash input to read events from Logstash's dead letter queue.
+
+[source, sh]
+-----------------------------------------
+input {
+  dead_letter_queue {
+    path => "/var/logstash/data/dead_letter_queue"
+    start_timestamp => "2017-04-04T23:40:37"
+  }
+}
+-----------------------------------------
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Dead_letter_queue Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-commit_offsets>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-path>> |a valid filesystem path|Yes
+| <<{version}-plugins-{type}s-{plugin}-pipeline_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-sincedb_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-start_timestamp>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-commit_offsets"]
+===== `commit_offsets` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Specifies whether this input should commit offsets as it processes the events.
+Typically you specify `false` when you want to iterate multiple times over the
+events in the dead letter queue, but don't want to save state. This is when you
+are exploring the events in the dead letter queue. 
+
+[id="{version}-plugins-{type}s-{plugin}-path"]
+===== `path` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+Path to the dead letter queue directory that was created by a Logstash instance.
+This is the path from which "dead" events are read and is typically configured 
+in the original Logstash instance with the setting `path.dead_letter_queue`.
+
+[id="{version}-plugins-{type}s-{plugin}-pipeline_id"]
+===== `pipeline_id` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"main"`
+
+ID of the pipeline whose events you want to read from.
+
+[id="{version}-plugins-{type}s-{plugin}-sincedb_path"]
+===== `sincedb_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Path of the sincedb database file (keeps track of the current position of dead letter queue) that 
+will be written to disk. The default will write sincedb files to `<path.data>/plugins/inputs/dead_letter_queue`.
+
+NOTE: This value must be a file path and not a directory path.
+
+[id="{version}-plugins-{type}s-{plugin}-start_timestamp"]
+===== `start_timestamp` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Timestamp in ISO8601 format from when you want to start processing the events from. 
+For example, `2017-04-04T23:40:37`.
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.0.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.0.asciidoc
@@ -1,0 +1,110 @@
+:plugin: dead_letter_queue
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.1.0
+:release_date: 2017-08-25
+:changelog_url: https://github.com/logstash-plugins/logstash-input-dead_letter_queue/blob/v1.1.0/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Dead_letter_queue input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Logstash input to read events from Logstash's dead letter queue.
+
+[source, sh]
+-----------------------------------------
+input {
+  dead_letter_queue {
+    path => "/var/logstash/data/dead_letter_queue"
+    start_timestamp => "2017-04-04T23:40:37"
+  }
+}
+-----------------------------------------
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Dead_letter_queue Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-commit_offsets>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-path>> |a valid filesystem path|Yes
+| <<{version}-plugins-{type}s-{plugin}-pipeline_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-sincedb_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-start_timestamp>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-commit_offsets"]
+===== `commit_offsets` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Specifies whether this input should commit offsets as it processes the events.
+Typically you specify `false` when you want to iterate multiple times over the
+events in the dead letter queue, but don't want to save state. This is when you
+are exploring the events in the dead letter queue. 
+
+[id="{version}-plugins-{type}s-{plugin}-path"]
+===== `path` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+Path to the dead letter queue directory that was created by a Logstash instance.
+This is the path from which "dead" events are read and is typically configured 
+in the original Logstash instance with the setting `path.dead_letter_queue`.
+
+[id="{version}-plugins-{type}s-{plugin}-pipeline_id"]
+===== `pipeline_id` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"main"`
+
+ID of the pipeline whose events you want to read from.
+
+[id="{version}-plugins-{type}s-{plugin}-sincedb_path"]
+===== `sincedb_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Path of the sincedb database file (keeps track of the current position of dead letter queue) that 
+will be written to disk. The default will write sincedb files to `<path.data>/plugins/inputs/dead_letter_queue`.
+
+NOTE: This value must be a file path and not a directory path.
+
+[id="{version}-plugins-{type}s-{plugin}-start_timestamp"]
+===== `start_timestamp` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Timestamp in ISO8601 format from when you want to start processing the events from. 
+For example, `2017-04-04T23:40:37`.
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/outputs.asciidoc
+++ b/docs/versioned-plugins/outputs.asciidoc
@@ -1,0 +1,6 @@
+:type: output
+:type_uc: Output
+
+include::include/plugin-intro.asciidoc[]
+
+include::outputs/elasticsearch-index.asciidoc[]

--- a/docs/versioned-plugins/outputs/elasticsearch-index.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-index.asciidoc
@@ -1,0 +1,14 @@
+:plugin: elasticsearch
+:type: output
+
+include::{include_path}/version-list-intro.asciidoc[]
+
+|=======================================================================
+| Version | Release Date 
+| <<v8.1.1-plugins-outputs-elasticsearch,v8.1.1>> | Aug 21, 2017 (latest)
+| <<v8.1.0-plugins-outputs-elasticsearch,v8.1.1>> | Aug 21, 2017
+|=======================================================================
+
+
+include::elasticsearch-v8.1.1.asciidoc[]
+include::elasticsearch-v8.1.0.asciidoc[]

--- a/docs/versioned-plugins/outputs/elasticsearch-v8.1.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v8.1.0.asciidoc
@@ -1,0 +1,664 @@
+:plugin: elasticsearch
+:type: output
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v8.1.0
+:release_date: 2017-08-21
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v8.1.1/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Elasticsearch output plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+.Compatibility Note
+[NOTE]
+================================================================================
+Starting with Elasticsearch 5.3, there's an {ref}/modules-http.html[HTTP setting]
+called `http.content_type.required`. If this option is set to `true`, and you
+are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
+plugin to version 6.2.5 or higher.
+
+================================================================================
+
+This plugin is the recommended method of storing logs in Elasticsearch.
+If you plan on using the Kibana web interface, you'll want to use this output.
+
+This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
+We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
+yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
+to upgrade Logstash in lock-step. 
+
+You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
+
+==== Template management for Elasticsearch 5.x
+Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0.
+Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default
+behavior.
+
+** Users installing ES 5.x and LS 5.x **
+This change will not affect you and you will continue to use the ES defaults.
+
+** Users upgrading from LS 2.x to LS 5.x with ES 5.x **
+LS will not force upgrade the template, if `logstash` template already exists. This means you will still use
+`.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after
+the new template is installed.
+
+==== Retry Policy
+
+The retry policy has changed significantly in the 8.1.1 release.
+This plugin uses the Elasticsearch bulk API to optimize its imports into Elasticsearch. These requests may experience
+either partial or total failures. The bulk API sends batches of requests to an HTTP endpoint. Error codes for the HTTP
+request are handled differently than error codes for individual documents.
+
+HTTP requests to the bulk API are expected to return a 200 response code. All other response codes are retried indefinitely.
+
+The following document errors are handled as follows:
+- 400 and 404 errors are sent to the DLQ if enabled. If a DLQ is not enabled a log message will be emitted and the event will be dropped.
+- 409 errors (conflict) are logged as a warning and dropped. 
+
+Note that 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
+It is more performant for Elasticsearch to retry these exceptions than this plugin.
+
+==== Batch Sizes ====
+This plugin attempts to send batches of events as a single request. However, if
+a request exceeds 20MB we will break it up until multiple batch requests. If a single document exceeds 20MB it will be sent as a single request.
+
+==== DNS Caching
+
+This plugin uses the JVM to lookup DNS entries and is subject to the value of https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html[networkaddress.cache.ttl],
+a global setting for the JVM.
+
+As an example, to set your DNS TTL to 1 second you would set
+the `LS_JAVA_OPTS` environment variable to `-Dnetworkaddress.cache.ttl=1`.
+
+Keep in mind that a connection with keepalive enabled will
+not reevaluate its DNS value while the keepalive is in effect.
+
+==== HTTP Compression
+
+This plugin supports request and response compression. Response compression is enabled by default and 
+for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in 
+Elasticsearch[https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http] to take advantage of response compression when using this plugin
+
+For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
+setting in their Logstash config file.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Elasticsearch Output Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-action>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-bulk_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-doc_as_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-document_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-document_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-healthcheck_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-hosts>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-http_compression>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-index>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-keystore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-manage_template>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-parameters>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-parent>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pipeline>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max_per_route>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-proxy>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-resurrect_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_initial_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_max_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_on_conflict>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-routing>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_lang>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["inline", "indexed", "file"]`|No
+| <<{version}-plugins-{type}s-{plugin}-script_var_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-scripted_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_verification>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-template_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-template_overwrite>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-truststore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-upsert>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-user>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-validate_after_inactivity>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-version>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-version_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["internal", "external", "external_gt", "external_gte", "force"]`|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-action"]
+===== `action` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"index"`
+
+Protocol agnostic (i.e. non-http, non-java specific) configs go here
+Protocol agnostic methods
+The Elasticsearch action to perform. Valid actions are:
+
+- index: indexes a document (an event from Logstash).
+- delete: deletes a document by id (An id is required for this action)
+- create: indexes a document, fails if a document by that id already exists in the index.
+- update: updates a document by id. Update has a special case where you can upsert -- update a
+  document if not already present. See the `upsert` option. NOTE: This does not work and is not supported
+  in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
+- A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
+  would use the foo field for the action
+
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+
+[id="{version}-plugins-{type}s-{plugin}-bulk_path"]
+===== `bulk_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to perform the _bulk requests to
+this defaults to a concatenation of the path parameter and "_bulk"
+
+[id="{version}-plugins-{type}s-{plugin}-cacert"]
+===== `cacert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The .cer or .pem file to validate the server's certificate
+
+[id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
+===== `doc_as_upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Enable `doc_as_upsert` for update mode.
+Create a new document with source if `document_id` doesn't exist in Elasticsearch
+
+[id="{version}-plugins-{type}s-{plugin}-document_id"]
+===== `document_id` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The document ID for the index. Useful for overwriting existing entries in
+Elasticsearch with the same ID.
+
+[id="{version}-plugins-{type}s-{plugin}-document_type"]
+===== `document_type` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The document type to write events to. Generally you should try to write only
+similar events to the same 'type'. String expansion `%{foo}` works here.
+Unless you set 'document_type', the event 'type' will be used if it exists
+otherwise the document type will be assigned the value of 'logs'
+
+[id="{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist"]
+===== `failure_type_logging_whitelist` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Set the Elasticsearch errors in the whitelist that you don't want to log.
+A useful example is when you want to skip all 409 errors
+which are `document_already_exists_exception`.
+
+[id="{version}-plugins-{type}s-{plugin}-healthcheck_path"]
+===== `healthcheck_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path where a HEAD request is sent when a backend is marked down
+the request is sent in the background to see if it has come back again
+before it is once again eligible to service requests.
+If you have custom firewall rules you may need to change this
+
+[id="{version}-plugins-{type}s-{plugin}-hosts"]
+===== `hosts` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * Default value is `[//127.0.0.1]`
+
+Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+    `"127.0.0.1"`
+    `["127.0.0.1:9200","127.0.0.2:9200"]`
+    `["http://127.0.0.1"]`
+    `["https://127.0.0.1:9200"]`
+    `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
+
+Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
+
+[id="{version}-plugins-{type}s-{plugin}-http_compression"]
+===== `http_compression` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
+
+[id="{version}-plugins-{type}s-{plugin}-index"]
+===== `index` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"logstash-%{+YYYY.MM.dd}"`
+
+The index to write events to. This can be dynamic using the `%{foo}` syntax.
+The default value will partition your indices by day so you can more easily
+delete old data or only search specific date ranges.
+Indexes may not contain uppercase characters.
+For weekly indexes ISO 8601 format is recommended, eg. logstash-%{+xxxx.ww}.
+LS uses Joda to format the index pattern from event timestamp.
+Joda formats are defined http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[here].
+
+[id="{version}-plugins-{type}s-{plugin}-keystore"]
+===== `keystore` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either .jks or .p12
+
+[id="{version}-plugins-{type}s-{plugin}-keystore_password"]
+===== `keystore_password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the keystore password
+
+[id="{version}-plugins-{type}s-{plugin}-manage_template"]
+===== `manage_template` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+From Logstash 1.3 onwards, a template is applied to Elasticsearch during
+Logstash's startup if one with the name `template_name` does not already exist.
+By default, the contents of this template is the default template for
+`logstash-%{+YYYY.MM.dd}` which always matches indices based on the pattern
+`logstash-*`.  Should you require support for other index names, or would like
+to change the mappings in the template in general, a custom template can be
+specified by setting `template` to the path of a template file.
+
+Setting `manage_template` to false disables this feature.  If you require more
+control over template creation, (e.g. creating indices dynamically based on
+field names) you should set `manage_template` to false and use the REST
+API to apply your templates manually.
+
+[id="{version}-plugins-{type}s-{plugin}-parameters"]
+===== `parameters` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * There is no default value for this setting.
+
+Pass a set of key value pairs as the URL query string. This query string is added
+to every host listed in the 'hosts' configuration. If the 'hosts' list contains
+urls that already have query strings, the one specified here will be appended.
+
+[id="{version}-plugins-{type}s-{plugin}-parent"]
+===== `parent` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `nil`
+
+For child documents, ID of the associated parent.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-password"]
+===== `password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Password to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-path"]
+===== `path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path at which the Elasticsearch server lives. Use this if you must run Elasticsearch behind a proxy that remaps
+the root path for the Elasticsearch HTTP API lives.
+Note that if you use paths as components of URLs in the 'hosts' field you may
+not also set this field. That will raise an error at startup
+
+[id="{version}-plugins-{type}s-{plugin}-pipeline"]
+===== `pipeline` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `nil`
+
+Set which ingest pipeline you wish to execute for an event. You can also use event dependent configuration
+here like `pipeline => "%{INGEST_PIPELINE}"`
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max"]
+===== `pool_max` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1000`
+
+While the output tries to reuse connections efficiently we have a maximum.
+This sets the maximum number of open connections the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max_per_route"]
+===== `pool_max_per_route` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100`
+
+While the output tries to reuse connections efficiently we have a maximum per endpoint.
+This sets the maximum number of open connections per endpoint the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-proxy"]
+===== `proxy` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * There is no default value for this setting.
+
+Set the address of a forward HTTP proxy.
+This used to accept hashes as arguments but now only accepts
+arguments of the URI type to prevent leaking credentials.
+
+[id="{version}-plugins-{type}s-{plugin}-resurrect_delay"]
+===== `resurrect_delay` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How frequently, in seconds, to wait between resurrection attempts.
+Resurrection is the process by which backend endpoints marked 'down' are checked
+to see if they have come back to life
+
+[id="{version}-plugins-{type}s-{plugin}-retry_initial_interval"]
+===== `retry_initial_interval` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `2`
+
+Set initial interval in seconds between bulk retries. Doubled on each retry up to `retry_max_interval`
+
+[id="{version}-plugins-{type}s-{plugin}-retry_max_interval"]
+===== `retry_max_interval` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `64`
+
+Set max interval in seconds between bulk retries.
+
+[id="{version}-plugins-{type}s-{plugin}-retry_on_conflict"]
+===== `retry_on_conflict` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The number of times Elasticsearch should internally retry an update/upserted document
+See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+for more info
+
+[id="{version}-plugins-{type}s-{plugin}-routing"]
+===== `routing` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A routing override to be applied to all processed events.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-script"]
+===== `script` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set script name for scripted update mode
+
+[id="{version}-plugins-{type}s-{plugin}-script_lang"]
+===== `script_lang` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"painless"`
+
+Set the language of the used script. If not set, this defaults to painless in ES 5.0
+
+[id="{version}-plugins-{type}s-{plugin}-script_type"]
+===== `script_type` 
+
+  * Value can be any of: `inline`, `indexed`, `file`
+  * Default value is `["inline"]`
+
+Define the type of script referenced by "script" variable
+ inline : "script" contains inline script
+ indexed : "script" contains the name of script directly indexed in elasticsearch
+ file    : "script" contains the name of script stored in elasticseach's config directory
+
+[id="{version}-plugins-{type}s-{plugin}-script_var_name"]
+===== `script_var_name` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"event"`
+
+Set variable name passed to script (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-scripted_upsert"]
+===== `scripted_upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+if enabled, script is in charge of creating non-existent document (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing"]
+===== `sniffing` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+This setting asks Elasticsearch for the list of all cluster nodes and adds them to the hosts list.
+Note: This will return ALL nodes with HTTP enabled (including master nodes!). If you use
+this with master nodes, you probably want to disable HTTP on them by setting
+`http.enabled` to false in their elasticsearch.yml. You can either use the `sniffing` option or
+manually enter multiple Elasticsearch hosts using the `hosts` parameter.
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_delay"]
+===== `sniffing_delay` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How long to wait, in seconds, between sniffing attempts
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_path"]
+===== `sniffing_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to be used for the sniffing requests
+the default value is computed by concatenating the path value and "_nodes/http"
+if sniffing_path is set it will be used as an absolute path
+do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster. Leaving this unspecified will use whatever scheme
+is specified in the URLs listed in 'hosts'. If no explicit protocol is specified plain HTTP will be used.
+If SSL is explicitly disabled here the plugin will refuse to start if an HTTPS URL is given in 'hosts'
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Option to validate the server's certificate. Disabling this severely compromises security.
+For more information on disabling certificate verification please read
+https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="{version}-plugins-{type}s-{plugin}-template"]
+===== `template` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+You can set the path to your own template here, if you so desire.
+If not set, the included template will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-template_name"]
+===== `template_name` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"logstash"`
+
+This configuration option defines how the template is named inside Elasticsearch.
+Note that if you have used the template management features and subsequently
+change this, you will need to prune the old template manually, e.g.
+
+`curl -XDELETE <http://localhost:9200/_template/OldTemplateName?pretty>`
+
+where `OldTemplateName` is whatever the former setting was.
+
+[id="{version}-plugins-{type}s-{plugin}-template_overwrite"]
+===== `template_overwrite` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+The template_overwrite option will always overwrite the indicated template
+in Elasticsearch with either the one indicated by template or the included one.
+This option is set to false by default. If you always want to stay up to date
+with the template provided by Logstash, this option could be very useful to you.
+Likewise, if you have your own template file managed by puppet, for example, and
+you wanted to be able to update it regularly, this option could help there as well.
+
+Please note that if you are using your own customized version of the Logstash
+template (logstash), setting this to true will make Logstash to overwrite
+the "logstash" template (i.e. removing all customized settings)
+
+[id="{version}-plugins-{type}s-{plugin}-timeout"]
+===== `timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Set the timeout, in seconds, for network operations and requests sent Elasticsearch. If
+a timeout occurs, the request will be retried.
+
+[id="{version}-plugins-{type}s-{plugin}-truststore"]
+===== `truststore` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The JKS truststore to validate the server's certificate.
+Use either `:truststore` or `:cacert`
+
+[id="{version}-plugins-{type}s-{plugin}-truststore_password"]
+===== `truststore_password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the truststore password
+
+[id="{version}-plugins-{type}s-{plugin}-upsert"]
+===== `upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set upsert content for update mode.s
+Create a new document with this parameter as json string if `document_id` doesn't exists
+
+[id="{version}-plugins-{type}s-{plugin}-user"]
+===== `user` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Username to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-validate_after_inactivity"]
+===== `validate_after_inactivity` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
+You may want to set this lower, if you get connection errors regularly
+Quoting the Apache commons docs (this client is based Apache Commmons):
+'Defines period of inactivity in milliseconds after which persistent connections must
+be re-validated prior to being leased to the consumer. Non-positive value passed to
+this method disables connection validation. This check helps detect connections that
+have become stale (half-closed) while kept inactive in the pool.'
+See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+
+[id="{version}-plugins-{type}s-{plugin}-version"]
+===== `version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
+See https://www.elastic.co/blog/elasticsearch-versioning-support.
+
+[id="{version}-plugins-{type}s-{plugin}-version_type"]
+===== `version_type` 
+
+  * Value can be any of: `internal`, `external`, `external_gt`, `external_gte`, `force`
+  * There is no default value for this setting.
+
+The version_type to use for indexing.
+See https://www.elastic.co/blog/elasticsearch-versioning-support.
+See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/outputs/elasticsearch-v8.1.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v8.1.1.asciidoc
@@ -1,0 +1,664 @@
+:plugin: elasticsearch
+:type: output
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v8.1.1
+:release_date: 2017-08-21
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v8.1.1/CHANGELOG.md
+:include_path: ../include
+:logstash-ref: http://www.elastic.co/guide/en/logstash/6.0
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Elasticsearch output plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+.Compatibility Note
+[NOTE]
+================================================================================
+Starting with Elasticsearch 5.3, there's an {ref}/modules-http.html[HTTP setting]
+called `http.content_type.required`. If this option is set to `true`, and you
+are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
+plugin to version 6.2.5 or higher.
+
+================================================================================
+
+This plugin is the recommended method of storing logs in Elasticsearch.
+If you plan on using the Kibana web interface, you'll want to use this output.
+
+This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
+We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
+yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
+to upgrade Logstash in lock-step. 
+
+You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
+
+==== Template management for Elasticsearch 5.x
+Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0.
+Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default
+behavior.
+
+** Users installing ES 5.x and LS 5.x **
+This change will not affect you and you will continue to use the ES defaults.
+
+** Users upgrading from LS 2.x to LS 5.x with ES 5.x **
+LS will not force upgrade the template, if `logstash` template already exists. This means you will still use
+`.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after
+the new template is installed.
+
+==== Retry Policy
+
+The retry policy has changed significantly in the 8.1.1 release.
+This plugin uses the Elasticsearch bulk API to optimize its imports into Elasticsearch. These requests may experience
+either partial or total failures. The bulk API sends batches of requests to an HTTP endpoint. Error codes for the HTTP
+request are handled differently than error codes for individual documents.
+
+HTTP requests to the bulk API are expected to return a 200 response code. All other response codes are retried indefinitely.
+
+The following document errors are handled as follows:
+- 400 and 404 errors are sent to the DLQ if enabled. If a DLQ is not enabled a log message will be emitted and the event will be dropped.
+- 409 errors (conflict) are logged as a warning and dropped. 
+
+Note that 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
+It is more performant for Elasticsearch to retry these exceptions than this plugin.
+
+==== Batch Sizes ====
+This plugin attempts to send batches of events as a single request. However, if
+a request exceeds 20MB we will break it up until multiple batch requests. If a single document exceeds 20MB it will be sent as a single request.
+
+==== DNS Caching
+
+This plugin uses the JVM to lookup DNS entries and is subject to the value of https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html[networkaddress.cache.ttl],
+a global setting for the JVM.
+
+As an example, to set your DNS TTL to 1 second you would set
+the `LS_JAVA_OPTS` environment variable to `-Dnetworkaddress.cache.ttl=1`.
+
+Keep in mind that a connection with keepalive enabled will
+not reevaluate its DNS value while the keepalive is in effect.
+
+==== HTTP Compression
+
+This plugin supports request and response compression. Response compression is enabled by default and 
+for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in 
+Elasticsearch[https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http] to take advantage of response compression when using this plugin
+
+For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
+setting in their Logstash config file.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Elasticsearch Output Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-action>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-bulk_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-doc_as_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-document_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-document_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-healthcheck_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-hosts>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-http_compression>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-index>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-keystore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-manage_template>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-parameters>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-parent>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pipeline>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max_per_route>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-proxy>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-resurrect_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_initial_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_max_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_on_conflict>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-routing>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_lang>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["inline", "indexed", "file"]`|No
+| <<{version}-plugins-{type}s-{plugin}-script_var_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-scripted_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_verification>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-template_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-template_overwrite>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-truststore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-upsert>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-user>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-validate_after_inactivity>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-version>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-version_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["internal", "external", "external_gt", "external_gte", "force"]`|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-action"]
+===== `action` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"index"`
+
+Protocol agnostic (i.e. non-http, non-java specific) configs go here
+Protocol agnostic methods
+The Elasticsearch action to perform. Valid actions are:
+
+- index: indexes a document (an event from Logstash).
+- delete: deletes a document by id (An id is required for this action)
+- create: indexes a document, fails if a document by that id already exists in the index.
+- update: updates a document by id. Update has a special case where you can upsert -- update a
+  document if not already present. See the `upsert` option. NOTE: This does not work and is not supported
+  in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
+- A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
+  would use the foo field for the action
+
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+
+[id="{version}-plugins-{type}s-{plugin}-bulk_path"]
+===== `bulk_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to perform the _bulk requests to
+this defaults to a concatenation of the path parameter and "_bulk"
+
+[id="{version}-plugins-{type}s-{plugin}-cacert"]
+===== `cacert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The .cer or .pem file to validate the server's certificate
+
+[id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
+===== `doc_as_upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Enable `doc_as_upsert` for update mode.
+Create a new document with source if `document_id` doesn't exist in Elasticsearch
+
+[id="{version}-plugins-{type}s-{plugin}-document_id"]
+===== `document_id` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The document ID for the index. Useful for overwriting existing entries in
+Elasticsearch with the same ID.
+
+[id="{version}-plugins-{type}s-{plugin}-document_type"]
+===== `document_type` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The document type to write events to. Generally you should try to write only
+similar events to the same 'type'. String expansion `%{foo}` works here.
+Unless you set 'document_type', the event 'type' will be used if it exists
+otherwise the document type will be assigned the value of 'logs'
+
+[id="{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist"]
+===== `failure_type_logging_whitelist` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Set the Elasticsearch errors in the whitelist that you don't want to log.
+A useful example is when you want to skip all 409 errors
+which are `document_already_exists_exception`.
+
+[id="{version}-plugins-{type}s-{plugin}-healthcheck_path"]
+===== `healthcheck_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path where a HEAD request is sent when a backend is marked down
+the request is sent in the background to see if it has come back again
+before it is once again eligible to service requests.
+If you have custom firewall rules you may need to change this
+
+[id="{version}-plugins-{type}s-{plugin}-hosts"]
+===== `hosts` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * Default value is `[//127.0.0.1]`
+
+Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+    `"127.0.0.1"`
+    `["127.0.0.1:9200","127.0.0.2:9200"]`
+    `["http://127.0.0.1"]`
+    `["https://127.0.0.1:9200"]`
+    `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
+
+Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
+
+[id="{version}-plugins-{type}s-{plugin}-http_compression"]
+===== `http_compression` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
+
+[id="{version}-plugins-{type}s-{plugin}-index"]
+===== `index` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"logstash-%{+YYYY.MM.dd}"`
+
+The index to write events to. This can be dynamic using the `%{foo}` syntax.
+The default value will partition your indices by day so you can more easily
+delete old data or only search specific date ranges.
+Indexes may not contain uppercase characters.
+For weekly indexes ISO 8601 format is recommended, eg. logstash-%{+xxxx.ww}.
+LS uses Joda to format the index pattern from event timestamp.
+Joda formats are defined http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[here].
+
+[id="{version}-plugins-{type}s-{plugin}-keystore"]
+===== `keystore` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either .jks or .p12
+
+[id="{version}-plugins-{type}s-{plugin}-keystore_password"]
+===== `keystore_password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the keystore password
+
+[id="{version}-plugins-{type}s-{plugin}-manage_template"]
+===== `manage_template` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+From Logstash 1.3 onwards, a template is applied to Elasticsearch during
+Logstash's startup if one with the name `template_name` does not already exist.
+By default, the contents of this template is the default template for
+`logstash-%{+YYYY.MM.dd}` which always matches indices based on the pattern
+`logstash-*`.  Should you require support for other index names, or would like
+to change the mappings in the template in general, a custom template can be
+specified by setting `template` to the path of a template file.
+
+Setting `manage_template` to false disables this feature.  If you require more
+control over template creation, (e.g. creating indices dynamically based on
+field names) you should set `manage_template` to false and use the REST
+API to apply your templates manually.
+
+[id="{version}-plugins-{type}s-{plugin}-parameters"]
+===== `parameters` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * There is no default value for this setting.
+
+Pass a set of key value pairs as the URL query string. This query string is added
+to every host listed in the 'hosts' configuration. If the 'hosts' list contains
+urls that already have query strings, the one specified here will be appended.
+
+[id="{version}-plugins-{type}s-{plugin}-parent"]
+===== `parent` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `nil`
+
+For child documents, ID of the associated parent.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-password"]
+===== `password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Password to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-path"]
+===== `path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path at which the Elasticsearch server lives. Use this if you must run Elasticsearch behind a proxy that remaps
+the root path for the Elasticsearch HTTP API lives.
+Note that if you use paths as components of URLs in the 'hosts' field you may
+not also set this field. That will raise an error at startup
+
+[id="{version}-plugins-{type}s-{plugin}-pipeline"]
+===== `pipeline` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `nil`
+
+Set which ingest pipeline you wish to execute for an event. You can also use event dependent configuration
+here like `pipeline => "%{INGEST_PIPELINE}"`
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max"]
+===== `pool_max` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1000`
+
+While the output tries to reuse connections efficiently we have a maximum.
+This sets the maximum number of open connections the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max_per_route"]
+===== `pool_max_per_route` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100`
+
+While the output tries to reuse connections efficiently we have a maximum per endpoint.
+This sets the maximum number of open connections per endpoint the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-proxy"]
+===== `proxy` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * There is no default value for this setting.
+
+Set the address of a forward HTTP proxy.
+This used to accept hashes as arguments but now only accepts
+arguments of the URI type to prevent leaking credentials.
+
+[id="{version}-plugins-{type}s-{plugin}-resurrect_delay"]
+===== `resurrect_delay` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How frequently, in seconds, to wait between resurrection attempts.
+Resurrection is the process by which backend endpoints marked 'down' are checked
+to see if they have come back to life
+
+[id="{version}-plugins-{type}s-{plugin}-retry_initial_interval"]
+===== `retry_initial_interval` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `2`
+
+Set initial interval in seconds between bulk retries. Doubled on each retry up to `retry_max_interval`
+
+[id="{version}-plugins-{type}s-{plugin}-retry_max_interval"]
+===== `retry_max_interval` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `64`
+
+Set max interval in seconds between bulk retries.
+
+[id="{version}-plugins-{type}s-{plugin}-retry_on_conflict"]
+===== `retry_on_conflict` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The number of times Elasticsearch should internally retry an update/upserted document
+See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+for more info
+
+[id="{version}-plugins-{type}s-{plugin}-routing"]
+===== `routing` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A routing override to be applied to all processed events.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-script"]
+===== `script` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set script name for scripted update mode
+
+[id="{version}-plugins-{type}s-{plugin}-script_lang"]
+===== `script_lang` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"painless"`
+
+Set the language of the used script. If not set, this defaults to painless in ES 5.0
+
+[id="{version}-plugins-{type}s-{plugin}-script_type"]
+===== `script_type` 
+
+  * Value can be any of: `inline`, `indexed`, `file`
+  * Default value is `["inline"]`
+
+Define the type of script referenced by "script" variable
+ inline : "script" contains inline script
+ indexed : "script" contains the name of script directly indexed in elasticsearch
+ file    : "script" contains the name of script stored in elasticseach's config directory
+
+[id="{version}-plugins-{type}s-{plugin}-script_var_name"]
+===== `script_var_name` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"event"`
+
+Set variable name passed to script (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-scripted_upsert"]
+===== `scripted_upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+if enabled, script is in charge of creating non-existent document (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing"]
+===== `sniffing` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+This setting asks Elasticsearch for the list of all cluster nodes and adds them to the hosts list.
+Note: This will return ALL nodes with HTTP enabled (including master nodes!). If you use
+this with master nodes, you probably want to disable HTTP on them by setting
+`http.enabled` to false in their elasticsearch.yml. You can either use the `sniffing` option or
+manually enter multiple Elasticsearch hosts using the `hosts` parameter.
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_delay"]
+===== `sniffing_delay` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How long to wait, in seconds, between sniffing attempts
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_path"]
+===== `sniffing_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to be used for the sniffing requests
+the default value is computed by concatenating the path value and "_nodes/http"
+if sniffing_path is set it will be used as an absolute path
+do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster. Leaving this unspecified will use whatever scheme
+is specified in the URLs listed in 'hosts'. If no explicit protocol is specified plain HTTP will be used.
+If SSL is explicitly disabled here the plugin will refuse to start if an HTTPS URL is given in 'hosts'
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Option to validate the server's certificate. Disabling this severely compromises security.
+For more information on disabling certificate verification please read
+https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="{version}-plugins-{type}s-{plugin}-template"]
+===== `template` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+You can set the path to your own template here, if you so desire.
+If not set, the included template will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-template_name"]
+===== `template_name` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"logstash"`
+
+This configuration option defines how the template is named inside Elasticsearch.
+Note that if you have used the template management features and subsequently
+change this, you will need to prune the old template manually, e.g.
+
+`curl -XDELETE <http://localhost:9200/_template/OldTemplateName?pretty>`
+
+where `OldTemplateName` is whatever the former setting was.
+
+[id="{version}-plugins-{type}s-{plugin}-template_overwrite"]
+===== `template_overwrite` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+The template_overwrite option will always overwrite the indicated template
+in Elasticsearch with either the one indicated by template or the included one.
+This option is set to false by default. If you always want to stay up to date
+with the template provided by Logstash, this option could be very useful to you.
+Likewise, if you have your own template file managed by puppet, for example, and
+you wanted to be able to update it regularly, this option could help there as well.
+
+Please note that if you are using your own customized version of the Logstash
+template (logstash), setting this to true will make Logstash to overwrite
+the "logstash" template (i.e. removing all customized settings)
+
+[id="{version}-plugins-{type}s-{plugin}-timeout"]
+===== `timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Set the timeout, in seconds, for network operations and requests sent Elasticsearch. If
+a timeout occurs, the request will be retried.
+
+[id="{version}-plugins-{type}s-{plugin}-truststore"]
+===== `truststore` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The JKS truststore to validate the server's certificate.
+Use either `:truststore` or `:cacert`
+
+[id="{version}-plugins-{type}s-{plugin}-truststore_password"]
+===== `truststore_password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the truststore password
+
+[id="{version}-plugins-{type}s-{plugin}-upsert"]
+===== `upsert` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set upsert content for update mode.s
+Create a new document with this parameter as json string if `document_id` doesn't exists
+
+[id="{version}-plugins-{type}s-{plugin}-user"]
+===== `user` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Username to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-validate_after_inactivity"]
+===== `validate_after_inactivity` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
+You may want to set this lower, if you get connection errors regularly
+Quoting the Apache commons docs (this client is based Apache Commmons):
+'Defines period of inactivity in milliseconds after which persistent connections must
+be re-validated prior to being leased to the consumer. Non-positive value passed to
+this method disables connection validation. This check helps detect connections that
+have become stale (half-closed) while kept inactive in the pool.'
+See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+
+[id="{version}-plugins-{type}s-{plugin}-version"]
+===== `version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
+See https://www.elastic.co/blog/elasticsearch-versioning-support.
+
+[id="{version}-plugins-{type}s-{plugin}-version_type"]
+===== `version_type` 
+
+  * Value can be any of: `internal`, `external`, `external_gt`, `external_gte`, `force`
+  * There is no default value for this setting.
+
+The version_type to use for indexing.
+See https://www.elastic.co/blog/elasticsearch-versioning-support.
+See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
This PR contains a prototype for the Versioned Plugin Reference. The goal is to create a Versioned Plugin Reference that contains multiple versions of the documentation for each plugin.

To see this content rendered, pull the files to your system and run:

````
../docs/build_docs.pl --doc ../logstash-docs/docs/versioned-plugins/index.asciidoc --chunk=1 -open
````

(adjust the paths for your environment)

I've copied the include folder from the logstash repo and modified the files to work in a sandbox. The final version will used the shared files in the logstash repo.

The actual plugin content isn't really versioned (just copies of the same file) so the dates are the same.

Ping me if you want a link to the detailed document outlining the changes that are required to make this all work.