### PR TITLE
Add latest plugin docs

### DIFF
--- a/docs/versioned-plugins/filters/dissect-index.asciidoc
+++ b/docs/versioned-plugins/filters/dissect-index.asciidoc
@@ -5,13 +5,13 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
-| <<v1.1.3-plugins-filters-dissect,v1.1.3>> | 2018-01-30
+| <<v1.1.4-plugins-filters-dissect,v1.1.4>> | 2018-02-15
 | <<v1.1.2-plugins-filters-dissect,v1.1.2>> | 2017-11-07
 | <<v1.1.1-plugins-filters-dissect,v1.1.1>> | 2017-11-02
 | <<v1.0.9-plugins-filters-dissect,v1.0.9>> | 2017-06-23
 |=======================================================================
 
-include::dissect-v1.1.3.asciidoc[]
+include::dissect-v1.1.4.asciidoc[]
 include::dissect-v1.1.2.asciidoc[]
 include::dissect-v1.1.1.asciidoc[]
 include::dissect-v1.0.9.asciidoc[]

--- a/docs/versioned-plugins/filters/dissect-v1.1.4.asciidoc
+++ b/docs/versioned-plugins/filters/dissect-v1.1.4.asciidoc
@@ -1,0 +1,290 @@
+:plugin: dissect
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.1.4
+:release_date: 2018-02-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-dissect/blob/v1.1.4/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Dissect filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The Dissect filter is a kind of split operation. Unlike a regular split operation where one delimiter is applied to
+the whole string, this operation applies a set of delimiters to a string value. +
+Dissect does not use regular expressions and is very fast. +
+However, if the structure of your text varies from line to line then Grok is more suitable. +
+There is a hybrid case where Dissect can be used to de-structure the section of the line that is reliably repeated and
+then Grok can be used on the remaining field values with more regex predictability and less overall work to do. +
+
+A set of fields and delimiters is called a *dissection*.
+
+The dissection is described using a set of `%{}` sections:
+....
+%{a} - %{b} - %{c}
+....
+
+A *field* is the text from `%` to `}` inclusive.
+
+A *delimiter* is the text between a `}` and next `%{` characters.
+
+[NOTE]
+Any set of characters that do not fit `%{`, `'not }'`, `}` pattern is a delimiter.
+
+The config might look like this:
+....
+  filter {
+    dissect {
+      mapping => {
+        "message" => "%{ts} %{+ts} %{+ts} %{src} %{} %{prog}[%{pid}]: %{msg}"
+      }
+    }
+  }
+....
+When dissecting a string from left to right, text is captured upto the first delimiter - this captured text is stored in the first field.
+This is repeated for each field/# delimiter pair thereafter until the last delimiter is reached, then *the remaining text is stored in the last field*. +
+
+*The Key:* +
+The key is the text between the `%{` and `}`, exclusive of the ?, +, & prefixes and the ordinal suffix. +
+`%{?aaa}` - key is `aaa` +
+`%{+bbb/3}` - key is `bbb` +
+`%{&ccc}` - key is `ccc` +
+
+===== Normal field notation
+The found value is added to the Event using the key. +
+`%{some_field}` - a normal field has no prefix or suffix
+
+*Skip field notation:* +
+The found value is stored internally but not added to the Event. +
+The key, if supplied, is prefixed with a `?`.
+
+`%{}` is an empty skip field.
+
+`%{?foo}` is a named skip field.
+
+===== Append field notation
+The value is appended to another value or stored if its the first field seen. +
+The key is prefixed with a `+`. +
+The final value is stored in the Event using the key. +
+
+[NOTE]
+====
+The delimiter found before the field is appended with the value. +
+If no delimiter is found before the field, a single space character is used.
+====
+
+`%{+some_field}` is an append field. +
+`%{+some_field/2}` is an append field with an order modifier.
+
+An order modifier, `/digits`, allows one to reorder the append sequence. +
+e.g. for a text of `1 2 3 go`, this `%{+a/2} %{+a/1} %{+a/4} %{+a/3}` will build a key/value of `a => 2 1 go 3` +
+Append fields without an order modifier will append in declared order. +
+e.g. for a text of `1 2 3 go`, this `%{a} %{b} %{+a}` will build two key/values of `a => 1 3 go, b => 2` +
+
+===== Indirect field notation
+The found value is added to the Event using the found value of another field as the key. +
+The key is prefixed with a `&`. +
+`%{&some_field}` - an indirect field where the key is indirectly sourced from the value of `some_field`. +
+e.g. for a text of `error: some_error, some_description`, this `error: %{?err}, %{&err}` will build a key/value of `some_error => some_description`.
+
+[NOTE]
+for append and indirect field the key can refer to a field that already exists in the event before dissection.
+
+[NOTE]
+use a Skip field if you do not want the indirection key/value stored.
+
+e.g. for a text of `google: 77.98`, this `%{?a}: %{&a}` will build a key/value of `google => 77.98`.
+
+[NOTE]
+===============================
+append and indirect cannot be combined and will fail validation. +
+`%{+&something}` - will add a value to the `&something` key, probably not the intended outcome. +
+`%{&+something}` will add a value to the `+something` key, again probably unintended. +
+===============================
+
+==== Multiple Consecutive Delimiter Handling
+
+[IMPORTANT]
+===============================
+Starting from version 1.1.1 of this plugin, multiple found delimiter handling has changed.
+Now multiple consecutive delimiters will be seen as missing fields by default and not padding.
+If you are already using Dissect and your source text has fields padded with extra delimiters,
+you will need to change your config. Please read the section below.
+===============================
+
+===== Empty data between delimiters
+Given this text as the sample used to create a dissection:
+....
+John Smith,Big Oaks,Wood Lane,Hambledown,Canterbury,CB34RY
+....
+The created dissection, with 6 fields, is:
+....
+%{name},%{addr1},%{addr2},%{addr3},%{city},%{zip}
+....
+When a line like this is processed:
+....
+Jane Doe,4321 Fifth Avenue,,,New York,87432
+....
+Dissect will create an event with empty fields for `addr2 and addr3` like so:
+....
+{
+  "name": "Jane Doe",
+  "addr1": "4321 Fifth Avenue",
+  "addr2": "",
+  "addr3": "",
+  "city": "New York"
+  "zip": "87432"
+}
+....
+
+===== Delimiters used as padding to visually align fields
+*Padding to the right hand side*
+
+Given these texts as the samples used to create a dissection:
+....
+00000043 ViewReceive     machine-321
+f3000a3b Calc            machine-123
+....
+The dissection, with 3 fields, is:
+....
+%{id} %{function->} %{server}
+....
+Note, above, the second field has a `->` suffix which tells Dissect to ignore padding to its right. +
+Dissect will create these events:
+....
+{
+  "id": "00000043",
+  "function": "ViewReceive",
+  "server": "machine-123"
+}
+{
+  "id": "f3000a3b",
+  "function": "Calc",
+  "server": "machine-321"
+}
+....
+[IMPORTANT]
+Always add the `->` suffix to the field on the left of the padding.
+
+*Padding to the left hand side (to the human eye)*
+
+Given these texts as the samples used to create a dissection:
+....
+00000043     ViewReceive machine-321
+f3000a3b            Calc machine-123
+....
+The dissection, with 3 fields, is now:
+....
+%{id->} %{function} %{server}
+....
+Here the `->` suffix moves to the `id` field because Dissect sees the padding as being to the right of the `id` field. +
+
+==== Conditional processing
+
+You probably want to use this filter inside an `if` block. +
+This ensures that the event contains a field value with a suitable structure for the dissection.
+
+For example...
+....
+filter {
+  if [type] == "syslog" or "syslog" in [tags] {
+    dissect {
+      mapping => {
+        "message" => "%{ts} %{+ts} %{+ts} %{src} %{} %{prog}[%{pid}]: %{msg}"
+      }
+    }
+  }
+}
+....
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Dissect Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-convert_datatype>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-mapping>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-tag_on_failure>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-convert_datatype"]
+===== `convert_datatype`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+With this setting `int` and `float` datatype conversions can be specified. +
+These will be done after all `mapping` dissections have taken place. +
+Feel free to use this setting on its own without a `mapping` section. +
+
+For example
+[source, ruby]
+filter {
+  dissect {
+    convert_datatype => {
+      cpu => "float"
+      code => "int"
+    }
+  }
+}
+
+[id="{version}-plugins-{type}s-{plugin}-mapping"]
+===== `mapping`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+A hash of dissections of `field => value` +
+[IMPORTANT]
+Don't use an escaped newline `\n` in the value, it will be seen as two characters `\` + `n`+
+Instead use actual line breaks in the config.+
+Also use single quotes to define the value if it contains double quotes.
+
+A later dissection can be done on values from a previous dissection or they can be independent.
+
+For example
+[source, ruby]
+filter {
+  dissect {
+    mapping => {
+      # using an actual line break
+      "message" => '"%{field1}" "%{field2}"
+ "%{description}"'
+      "description" => "%{field3} %{field4} %{field5}"
+    }
+  }
+}
+
+This is useful if you want to keep the field `description` but also
+dissect it some more.
+
+[id="{version}-plugins-{type}s-{plugin}-tag_on_failure"]
+===== `tag_on_failure`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `["_dissectfailure"]`
+
+Append values to the `tags` field when dissection fails
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/kv-index.asciidoc
+++ b/docs/versioned-plugins/filters/kv-index.asciidoc
@@ -5,11 +5,13 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v4.1.0-plugins-filters-kv,v4.1.0>> | 2018-02-13
 | <<v4.0.3-plugins-filters-kv,v4.0.3>> | 2017-11-07
 | <<v4.0.2-plugins-filters-kv,v4.0.2>> | 2017-08-15
 | <<v4.0.1-plugins-filters-kv,v4.0.1>> | 2017-06-23
 |=======================================================================
 
+include::kv-v4.1.0.asciidoc[]
 include::kv-v4.0.3.asciidoc[]
 include::kv-v4.0.2.asciidoc[]
 include::kv-v4.0.1.asciidoc[]

--- a/docs/versioned-plugins/filters/kv-v4.1.0.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.1.0.asciidoc
@@ -1,0 +1,447 @@
+:plugin: kv
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v4.1.0
+:release_date: 2018-02-13
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-kv/blob/v4.1.0/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Kv filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This filter helps automatically parse messages (or specific event fields)
+which are of the `foo=bar` variety.
+
+For example, if you have a log message which contains `ip=1.2.3.4
+error=REFUSED`, you can parse those automatically by configuring:
+[source,ruby]
+    filter {
+      kv { }
+    }
+
+The above will result in a message of `ip=1.2.3.4 error=REFUSED` having
+the fields:
+
+* `ip: 1.2.3.4`
+* `error: REFUSED`
+
+This is great for postfix, iptables, and other types of logs that
+tend towards `key=value` syntax.
+
+You can configure any arbitrary strings to split your data on,
+in case your data is not structured using `=` signs and whitespace.
+For example, this filter can also be used to parse query parameters like
+`foo=bar&baz=fizz` by setting the `field_split` parameter to `&`.
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Kv Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-allow_duplicate_values>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-default_keys>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-exclude_keys>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-field_split>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_brackets>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-include_keys>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-prefix>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-recursive>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-remove_char_key>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-remove_char_value>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-source>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-target>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-transform_key>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["lowercase", "uppercase", "capitalize"]`|No
+| <<{version}-plugins-{type}s-{plugin}-transform_value>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["lowercase", "uppercase", "capitalize"]`|No
+| <<{version}-plugins-{type}s-{plugin}-trim_key>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-trim_value>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-value_split>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-allow_duplicate_values"]
+===== `allow_duplicate_values` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+A bool option for removing duplicate key/value pairs. When set to false, only
+one unique key/value pair will be preserved.
+
+For example, consider a source like `from=me from=me`. `[from]` will map to
+an Array with two elements: `["me", "me"]`. To only keep unique key/value pairs,
+you could use this configuration:
+[source,ruby]
+    filter {
+      kv {
+        allow_duplicate_values => false
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-default_keys"]
+===== `default_keys` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+A hash specifying the default keys and their values which should be added to the event
+in case these keys do not exist in the source field being parsed.
+[source,ruby]
+    filter {
+      kv {
+        default_keys => [ "from", "logstash@example.com",
+                         "to", "default@dev.null" ]
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-exclude_keys"]
+===== `exclude_keys` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+An array specifying the parsed keys which should not be added to the event.
+By default no keys will be excluded.
+
+For example, consider a source like `Hey, from=<abc>, to=def foo=bar`.
+To exclude `from` and `to`, but retain the `foo` key, you could use this configuration:
+[source,ruby]
+    filter {
+      kv {
+        exclude_keys => [ "from", "to" ]
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-field_split"]
+===== `field_split` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `" "`
+
+A string of characters to use as single-character field delimiters for parsing out key-value pairs.
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+#### Example with URL Query Strings
+
+For example, to split out the args from a url query string such as
+`?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:
+[source,ruby]
+    filter {
+      kv {
+        field_split => "&?"
+      }
+    }
+
+The above splits on both `&` and `?` characters, giving you the following
+fields:
+
+* `pin: 12345~0`
+* `d: 123`
+* `e: foo@bar.com`
+* `oq: bobo`
+* `ss: 12345`
+
+[id="{version}-plugins-{type}s-{plugin}-field_split_pattern"]
+===== `field_split_pattern`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A regex expression to use as field delimiter for parsing out key-value pairs.
+Useful to define multi-character field delimiters.
+Setting the `field_split_pattern` options will take precedence over the `field_split` option.
+
+Note that you should avoid using captured groups in your regex and you should be
+cautious with lookaheads or lookbehinds and positional anchors.
+
+For example, to split fields on a repetition of one or more colons
+`k1=v1:k2=v2::k3=v3:::k4=v4`:
+[source,ruby]
+    filter { kv { field_split_pattern => ":+" } }
+
+To split fields on a regex character that need escaping like the plus sign
+`k1=v1++k2=v2++k3=v3++k4=v4`:
+[source,ruby]
+    filter { kv { field_split_pattern => "\\+\\+" } }
+
+[id="{version}-plugins-{type}s-{plugin}-include_brackets"]
+===== `include_brackets` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+A boolean specifying whether to treat square brackets, angle brackets,
+and parentheses as value "wrappers" that should be removed from the value.
+[source,ruby]
+    filter {
+      kv {
+        include_brackets => true
+      }
+    }
+
+For example, the result of this line:
+`bracketsone=(hello world) bracketstwo=[hello world] bracketsthree=<hello world>`
+
+will be:
+
+* bracketsone: hello world
+* bracketstwo: hello world
+* bracketsthree: hello world
+
+instead of:
+
+* bracketsone: (hello
+* bracketstwo: [hello
+* bracketsthree: <hello
+
+
+[id="{version}-plugins-{type}s-{plugin}-include_keys"]
+===== `include_keys` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+An array specifying the parsed keys which should be added to the event.
+By default all keys will be added.
+
+For example, consider a source like `Hey, from=<abc>, to=def foo=bar`.
+To include `from` and `to`, but exclude the `foo` key, you could use this configuration:
+[source,ruby]
+    filter {
+      kv {
+        include_keys => [ "from", "to" ]
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-prefix"]
+===== `prefix` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+A string to prepend to all of the extracted keys.
+
+For example, to prepend arg_ to all keys:
+[source,ruby]
+    filter { kv { prefix => "arg_" } }
+
+[id="{version}-plugins-{type}s-{plugin}-recursive"]
+===== `recursive` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+A boolean specifying whether to drill down into values
+and recursively get more key-value pairs from it.
+The extra key-value pairs will be stored as subkeys of the root key.
+
+Default is not to recursive values.
+[source,ruby]
+    filter {
+      kv {
+        recursive => "true"
+      }
+    }
+
+
+[id="{version}-plugins-{type}s-{plugin}-remove_char_key"]
+===== `remove_char_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A string of characters to remove from the key.
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+Contrary to trim option, all characters are removed from the key, whatever their position.
+
+For example, to remove `<` `>` `[` `]` and `,` characters from keys:
+[source,ruby]
+    filter {
+      kv {
+        remove_char_key => "<>\[\],"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-remove_char_value"]
+===== `remove_char_value` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A string of characters to remove from the value.
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+Contrary to trim option, all characters are removed from the value, whatever their position.
+
+For example, to remove `<`, `>`, `[`, `]` and `,` characters from values:
+[source,ruby]
+    filter {
+      kv {
+        remove_char_value => "<>\[\],"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-source"]
+===== `source` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"message"`
+
+The field to perform `key=value` searching on
+
+For example, to process the `not_the_message` field:
+[source,ruby]
+    filter { kv { source => "not_the_message" } }
+
+[id="{version}-plugins-{type}s-{plugin}-target"]
+===== `target` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The name of the container to put all of the key-value pairs into.
+
+If this setting is omitted, fields will be written to the root of the
+event, as individual fields.
+
+For example, to place all keys into the event field kv:
+[source,ruby]
+    filter { kv { target => "kv" } }
+
+[id="{version}-plugins-{type}s-{plugin}-transform_key"]
+===== `transform_key` 
+
+  * Value can be any of: `lowercase`, `uppercase`, `capitalize`
+  * There is no default value for this setting.
+
+Transform keys to lower case, upper case or capitals.
+
+For example, to lowercase all keys:
+[source,ruby]
+    filter {
+      kv {
+        transform_key => "lowercase"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-transform_value"]
+===== `transform_value` 
+
+  * Value can be any of: `lowercase`, `uppercase`, `capitalize`
+  * There is no default value for this setting.
+
+Transform values to lower case, upper case or capitals.
+
+For example, to capitalize all values:
+[source,ruby]
+    filter {
+      kv {
+        transform_value => "capitalize"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-trim_key"]
+===== `trim_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A string of characters to trim from the key. This is useful if your
+keys are wrapped in brackets or start with space.
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+Only leading and trailing characters are trimed from the key.
+
+For example, to trim `<` `>` `[` `]` and `,` characters from keys:
+[source,ruby]
+    filter {
+      kv {
+        trim_key => "<>\[\],"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-trim_value"]
+===== `trim_value` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Constants used for transform check
+A string of characters to trim from the value. This is useful if your
+values are wrapped in brackets or are terminated with commas (like postfix
+logs).
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+Only leading and trailing characters are trimed from the value.
+
+For example, to trim `<`, `>`, `[`, `]` and `,` characters from values:
+[source,ruby]
+    filter {
+      kv {
+        trim_value => "<>\[\],"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-value_split"]
+===== `value_split` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"="`
+
+A non-empty string of characters to use as single-character value delimiters for parsing out key-value pairs.
+
+These characters form a regex character class and thus you must escape special regex
+characters like `[` or `]` using `\`.
+
+For example, to identify key-values such as
+`key1:value1 key2:value2`:
+[source,ruby]
+    filter { kv { value_split => ":" } }
+
+
+[id="{version}-plugins-{type}s-{plugin}-value_split_pattern"]
+===== `value_split_pattern`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A regex expression to use as value delimiter for parsing out key-value pairs.
+Useful to define multi-character value delimiters.
+Setting the `value_split_pattern` options will take precedence over the `value_split option`.
+
+Note that you should avoid using captured groups in your regex and you should be
+cautious with lookaheads or lookbehinds and positional anchors.
+
+See `field_split_pattern` for examples.
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-index.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-index.asciidoc
@@ -5,6 +5,8 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v5.0.9-plugins-inputs-beats,v5.0.9>> | 2018-02-14
+| <<v5.0.8-plugins-inputs-beats,v5.0.8>> | 2018-02-12
 | <<v5.0.6-plugins-inputs-beats,v5.0.6>> | 2018-01-05
 | <<v5.0.5-plugins-inputs-beats,v5.0.5>> | 2017-12-19
 | <<v5.0.4-plugins-inputs-beats,v5.0.4>> | 2017-12-12
@@ -19,6 +21,8 @@ include::{include_path}/version-list-intro.asciidoc[]
 | <<v4.0.1-plugins-inputs-beats,v4.0.1>> | 2017-06-03
 |=======================================================================
 
+include::beats-v5.0.9.asciidoc[]
+include::beats-v5.0.8.asciidoc[]
 include::beats-v5.0.6.asciidoc[]
 include::beats-v5.0.5.asciidoc[]
 include::beats-v5.0.4.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-v5.0.8.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-v5.0.8.asciidoc
@@ -1,0 +1,223 @@
+:plugin: beats
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v5.0.8
+:release_date: 2018-02-12
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.0.8/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Beats input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input plugin enables Logstash to receive events from the
+https://www.elastic.co/products/beats[Elastic Beats] framework.
+
+The following example shows how to configure Logstash to listen on port
+5044 for incoming Beats connections and to index into Elasticsearch:
+
+[source,ruby]
+------------------------------------------------------------------------------
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "localhost:9200"
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}" <1>
+  }
+}
+------------------------------------------------------------------------------
+<1> Starting with Logstash 6.0, the `document_type` option is
+deprecated due to the
+https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal of types in Logstash 6.0].
+It will be removed in the next major version of Logstash. If you are running
+Logstash 6.0 or later, you do not need to set `document_type` in your
+configuration because Logstash sets the type to `doc` by default.
+
+IMPORTANT: If you are shipping events that span multiple lines, you need to
+use the https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html[configuration options available in Filebeat] to handle multiline events
+before sending the event data to Logstash. You cannot use the
+{logstash-ref}/plugins-codecs-multiline.html[Multiline codec plugin] to handle multiline events. Doing so will
+result in the failure to start Logstash.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Beats Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-cipher_suites>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-client_inactivity_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-host>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_codec_tag>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-port>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key_passphrase>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_verify_mode>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["none", "peer", "force_peer"]`|No
+| <<{version}-plugins-{type}s-{plugin}-tls_max_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-tls_min_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-cipher_suites"]
+===== `cipher_suites` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
+
+The list of ciphers suite to use, listed by priorities.
+
+[id="{version}-plugins-{type}s-{plugin}-client_inactivity_timeout"]
+===== `client_inactivity_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Close Idle clients after X seconds of inactivity.
+
+[id="{version}-plugins-{type}s-{plugin}-host"]
+===== `host` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"0.0.0.0"`
+
+The IP address to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-include_codec_tag"]
+===== `include_codec_tag` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-port"]
+===== `port` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * There is no default value for this setting.
+
+The port to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Events are by default sent in plain text. You can
+enable encryption by setting `ssl` to true and configuring
+the `ssl_certificate` and `ssl_key` options.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL certificate to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Validate client certificates against these authorities. 
+You can define multiple files or paths. All the certificates will
+be read and added to the trust store. You need to configure the `ssl_verify_mode`
+to `peer` or `force_peer` to enable the verification.
+
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+Time in milliseconds for an incomplete ssl handshake to timeout
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL key to use.
+NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
+for more information.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+SSL key passphrase to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_verify_mode"]
+===== `ssl_verify_mode` 
+
+  * Value can be any of: `none`, `peer`, `force_peer`
+  * Default value is `"none"`
+
+By default the server doesn't do any client verification.
+
+`peer` will make the server ask the client to provide a certificate. 
+If the client provides a certificate, it will be validated.
+
+`force_peer` will make the server ask the client to provide a certificate.
+If the client doesn't provide a certificate, the connection will be closed.
+
+This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="{version}-plugins-{type}s-{plugin}-tls_max_version"]
+===== `tls_max_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1.2`
+
+The maximum TLS version allowed for the encrypted connections. The value must be the one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+[id="{version}-plugins-{type}s-{plugin}-tls_min_version"]
+===== `tls_min_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The minimum TLS version allowed for the encrypted connections. The value must be one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/beats-v5.0.9.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-v5.0.9.asciidoc
@@ -1,0 +1,223 @@
+:plugin: beats
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v5.0.9
+:release_date: 2018-02-14
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.0.9/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Beats input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input plugin enables Logstash to receive events from the
+https://www.elastic.co/products/beats[Elastic Beats] framework.
+
+The following example shows how to configure Logstash to listen on port
+5044 for incoming Beats connections and to index into Elasticsearch:
+
+[source,ruby]
+------------------------------------------------------------------------------
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "localhost:9200"
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}" <1>
+  }
+}
+------------------------------------------------------------------------------
+<1> Starting with Logstash 6.0, the `document_type` option is
+deprecated due to the
+https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal of types in Logstash 6.0].
+It will be removed in the next major version of Logstash. If you are running
+Logstash 6.0 or later, you do not need to set `document_type` in your
+configuration because Logstash sets the type to `doc` by default.
+
+IMPORTANT: If you are shipping events that span multiple lines, you need to
+use the https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html[configuration options available in Filebeat] to handle multiline events
+before sending the event data to Logstash. You cannot use the
+{logstash-ref}/plugins-codecs-multiline.html[Multiline codec plugin] to handle multiline events. Doing so will
+result in the failure to start Logstash.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Beats Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-cipher_suites>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-client_inactivity_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-host>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_codec_tag>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-port>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key_passphrase>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_verify_mode>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["none", "peer", "force_peer"]`|No
+| <<{version}-plugins-{type}s-{plugin}-tls_max_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-tls_min_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-cipher_suites"]
+===== `cipher_suites` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
+
+The list of ciphers suite to use, listed by priorities.
+
+[id="{version}-plugins-{type}s-{plugin}-client_inactivity_timeout"]
+===== `client_inactivity_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Close Idle clients after X seconds of inactivity.
+
+[id="{version}-plugins-{type}s-{plugin}-host"]
+===== `host` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"0.0.0.0"`
+
+The IP address to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-include_codec_tag"]
+===== `include_codec_tag` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-port"]
+===== `port` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * There is no default value for this setting.
+
+The port to listen on.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Events are by default sent in plain text. You can
+enable encryption by setting `ssl` to true and configuring
+the `ssl_certificate` and `ssl_key` options.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL certificate to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+Validate client certificates against these authorities. 
+You can define multiple files or paths. All the certificates will
+be read and added to the trust store. You need to configure the `ssl_verify_mode`
+to `peer` or `force_peer` to enable the verification.
+
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+Time in milliseconds for an incomplete ssl handshake to timeout
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL key to use.
+NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
+for more information.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+SSL key passphrase to use.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_verify_mode"]
+===== `ssl_verify_mode` 
+
+  * Value can be any of: `none`, `peer`, `force_peer`
+  * Default value is `"none"`
+
+By default the server doesn't do any client verification.
+
+`peer` will make the server ask the client to provide a certificate. 
+If the client provides a certificate, it will be validated.
+
+`force_peer` will make the server ask the client to provide a certificate.
+If the client doesn't provide a certificate, the connection will be closed.
+
+This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="{version}-plugins-{type}s-{plugin}-tls_max_version"]
+===== `tls_max_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1.2`
+
+The maximum TLS version allowed for the encrypted connections. The value must be the one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+[id="{version}-plugins-{type}s-{plugin}-tls_min_version"]
+===== `tls_min_version` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The minimum TLS version allowed for the encrypted connections. The value must be one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/jdbc-index.asciidoc
+++ b/docs/versioned-plugins/inputs/jdbc-index.asciidoc
@@ -5,6 +5,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v4.3.4-plugins-inputs-jdbc,v4.3.4>> | 2018-02-14
 | <<v4.3.3-plugins-inputs-jdbc,v4.3.3>> | 2017-12-14
 | <<v4.3.2-plugins-inputs-jdbc,v4.3.2>> | 2017-12-07
 | <<v4.3.1-plugins-inputs-jdbc,v4.3.1>> | 2017-11-07
@@ -15,6 +16,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 | <<v4.2.1-plugins-inputs-jdbc,v4.2.1>> | 2017-06-23
 |=======================================================================
 
+include::jdbc-v4.3.4.asciidoc[]
 include::jdbc-v4.3.3.asciidoc[]
 include::jdbc-v4.3.2.asciidoc[]
 include::jdbc-v4.3.1.asciidoc[]

--- a/docs/versioned-plugins/inputs/jdbc-v4.3.4.asciidoc
+++ b/docs/versioned-plugins/inputs/jdbc-v4.3.4.asciidoc
@@ -1,0 +1,486 @@
+:plugin: jdbc
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v4.3.4
+:release_date: 2018-02-14
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jdbc/blob/v4.3.4/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Jdbc input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This plugin was created as a way to ingest data in any database
+with a JDBC interface into Logstash. You can periodically schedule ingestion
+using a cron syntax (see `schedule` setting) or run the query one time to load
+data into Logstash. Each row in the resultset becomes a single event.
+Columns in the resultset are converted into fields in the event.
+
+==== Drivers
+
+This plugin does not come packaged with JDBC driver libraries. The desired
+jdbc driver library must be explicitly passed in to the plugin using the
+`jdbc_driver_library` configuration option.
+
+==== Scheduling
+
+Input from this plugin can be scheduled to run periodically according to a specific
+schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+
+Further documentation describing this syntax can be found https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+
+==== State
+
+The plugin will persist the `sql_last_value` parameter in the form of a
+metadata file stored in the configured `last_run_metadata_path`. Upon query execution,
+this file will be updated with the current value of `sql_last_value`. Next time
+the pipeline starts up, this value will be updated by reading from the file. If
+`clean_run` is set to true, this value will be ignored and `sql_last_value` will be
+set to Jan 1, 1970, or 0 if `use_column_value` is true, as if no query has ever been executed.
+
+==== Dealing With Large Result-sets
+
+Many JDBC drivers use the `fetch_size` parameter to limit how many
+results are pre-fetched at a time from the cursor into the client's cache
+before retrieving more results from the result-set. This is configured in
+this plugin using the `jdbc_fetch_size` configuration option. No fetch size
+is set by default in this plugin, so the specific driver's default size will
+be used.
+
+==== Usage:
+
+Here is an example of setting up the plugin to fetch data from a MySQL database.
+First, we place the appropriate JDBC driver library in our current
+path (this can be placed anywhere on your filesystem). In this example, we connect to
+the 'mydb' database using the user: 'mysql' and wish to input all rows in the 'songs'
+table that match a specific artist. The following examples demonstrates a possible
+Logstash configuration for this. The `schedule` option in this example will
+instruct the plugin to execute this input statement on the minute, every minute.
+
+[source,ruby]
+------------------------------------------------------------------------------
+input {
+  jdbc {
+    jdbc_driver_library => "mysql-connector-java-5.1.36-bin.jar"
+    jdbc_driver_class => "com.mysql.jdbc.Driver"
+    jdbc_connection_string => "jdbc:mysql://localhost:3306/mydb"
+    jdbc_user => "mysql"
+    parameters => { "favorite_artist" => "Beethoven" }
+    schedule => "* * * * *"
+    statement => "SELECT * from songs where artist = :favorite_artist"
+  }
+}
+------------------------------------------------------------------------------
+
+==== Configuring SQL statement
+
+A sql statement is required for this input. This can be passed-in via a
+statement option in the form of a string, or read from a file (`statement_filepath`). File
+option is typically used when the SQL statement is large or cumbersome to supply in the config.
+The file option only supports one SQL statement. The plugin will only accept one of the options.
+It cannot read a statement from a file as well as from the `statement` configuration parameter.
+
+==== Configuring multiple SQL statements 
+
+Configuring multiple SQL statements is useful when there is a need to query and ingest data 
+from different database tables or views. It is possible to define separate Logstash 
+configuration files for each statement or to define multiple statements in a single configuration 
+file. When using multiple statements in a single Logstash configuration file, each statement 
+has to be defined as a separate jdbc input (including jdbc driver, connection string and other 
+required parameters). 
+
+Please note that if any of the statements use the `sql_last_value` parameter (e.g. for 
+ingesting only data changed since last run), each input should define its own 
+`last_run_metadata_path` parameter. Failure to do so will result in undesired behaviour, as
+all inputs will store their state to the same (default) metadata file, effectively 
+overwriting each other's `sql_last_value`.
+
+==== Predefined Parameters
+
+Some parameters are built-in and can be used from within your queries.
+Here is the list:
+
+|==========================================================
+|sql_last_value | The value used to calculate which rows to query. Before any query is run,
+this is set to Thursday, 1 January 1970, or 0 if `use_column_value` is true and
+`tracking_column` is set. It is updated accordingly after subsequent queries are run.
+|==========================================================
+
+Example:
+[source,ruby]
+---------------------------------------------------------------------------------------------------
+input {
+  jdbc {
+    statement => "SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value"
+    use_column_value => true
+    tracking_column => "id"
+    # ... other configuration bits
+  }
+}
+---------------------------------------------------------------------------------------------------
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Jdbc Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-clean_run>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-columns_charset>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-connection_retry_attempts>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-connection_retry_attempts_wait_time>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_connection_string>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-jdbc_default_timezone>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_driver_class>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-jdbc_driver_library>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_fetch_size>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_page_size>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_paging_enabled>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_password_filepath>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_pool_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_user>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-jdbc_validate_connection>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-jdbc_validation_timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-last_run_metadata_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-lowercase_column_names>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-parameters>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-record_last_run>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-schedule>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-sequel_opts>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-sql_log_level>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["fatal", "error", "warn", "info", "debug"]`|No
+| <<{version}-plugins-{type}s-{plugin}-statement>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-statement_filepath>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-tracking_column>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-tracking_column_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["numeric", "timestamp"]`|No
+| <<{version}-plugins-{type}s-{plugin}-use_column_value>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-clean_run"]
+===== `clean_run` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Whether the previous run state should be preserved
+
+[id="{version}-plugins-{type}s-{plugin}-columns_charset"]
+===== `columns_charset` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+The character encoding for specific columns. This option will override the `:charset` option 
+for the specified columns.
+
+Example:
+[source,ruby]
+-------------------------------------------------------
+input {
+  jdbc {
+    ...
+    columns_charset => { "column0" => "ISO-8859-1" }
+    ...
+  }
+}
+-------------------------------------------------------
+this will only convert column0 that has ISO-8859-1 as an original encoding.
+
+[id="{version}-plugins-{type}s-{plugin}-connection_retry_attempts"]
+===== `connection_retry_attempts` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+Maximum number of times to try connecting to database
+
+[id="{version}-plugins-{type}s-{plugin}-connection_retry_attempts_wait_time"]
+===== `connection_retry_attempts_wait_time` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `0.5`
+
+Number of seconds to sleep between connection attempts
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_connection_string"]
+===== `jdbc_connection_string` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+JDBC connection string
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_default_timezone"]
+===== `jdbc_default_timezone` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Timezone conversion.
+SQL does not allow for timezone data in timestamp fields.  This plugin will automatically
+convert your SQL timestamp fields to Logstash timestamps, in relative UTC time in ISO8601 format.
+
+Using this setting will manually assign a specified timezone offset, instead
+of using the timezone setting of the local machine.  You must use a canonical
+timezone, *America/Denver*, for example.
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_driver_class"]
+===== `jdbc_driver_class` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+JDBC driver class to load, for exmaple, "org.apache.derby.jdbc.ClientDriver"
+NB per https://github.com/logstash-plugins/logstash-input-jdbc/issues/43 if you are using
+the Oracle JDBC driver (ojdbc6.jar) the correct `jdbc_driver_class` is `"Java::oracle.jdbc.driver.OracleDriver"`
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_driver_library"]
+===== `jdbc_driver_library` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Tentative of abstracting JDBC logic to a mixin
+for potential reuse in other plugins (input/output)
+This method is called when someone includes this module
+Add these methods to the 'base' given.
+JDBC driver library path to third party driver library. In case of multiple libraries being
+required you can pass them separated by a comma.
+
+If not provided, Plugin will look for the driver class in the Logstash Java classpath.
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_fetch_size"]
+===== `jdbc_fetch_size` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * There is no default value for this setting.
+
+JDBC fetch size. if not provided, respective driver's default will be used
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_page_size"]
+===== `jdbc_page_size` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100000`
+
+JDBC page size
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_paging_enabled"]
+===== `jdbc_paging_enabled` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+JDBC enable paging
+
+This will cause a sql statement to be broken up into multiple queries.
+Each query will use limits and offsets to collectively retrieve the full
+result-set. The limit size is set with `jdbc_page_size`.
+
+Be aware that ordering is not guaranteed between queries.
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_password"]
+===== `jdbc_password` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+JDBC password
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_password_filepath"]
+===== `jdbc_password_filepath` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+JDBC password filename
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_pool_timeout"]
+===== `jdbc_pool_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+Connection pool configuration.
+The amount of seconds to wait to acquire a connection before raising a PoolTimeoutError (default 5)
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_user"]
+===== `jdbc_user` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+JDBC user
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_validate_connection"]
+===== `jdbc_validate_connection` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Connection pool configuration.
+Validate connection before use.
+
+[id="{version}-plugins-{type}s-{plugin}-jdbc_validation_timeout"]
+===== `jdbc_validation_timeout` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `3600`
+
+Connection pool configuration.
+How often to validate a connection (in seconds)
+
+[id="{version}-plugins-{type}s-{plugin}-last_run_metadata_path"]
+===== `last_run_metadata_path` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"/home/ph/.logstash_jdbc_last_run"`
+
+Path to file with last run time
+
+[id="{version}-plugins-{type}s-{plugin}-lowercase_column_names"]
+===== `lowercase_column_names` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Whether to force the lowercasing of identifier fields
+
+[id="{version}-plugins-{type}s-{plugin}-parameters"]
+===== `parameters` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+Hash of query parameter, for example `{ "target_id" => "321" }`
+
+[id="{version}-plugins-{type}s-{plugin}-record_last_run"]
+===== `record_last_run` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+Whether to save state or not in last_run_metadata_path
+
+[id="{version}-plugins-{type}s-{plugin}-schedule"]
+===== `schedule` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Schedule of when to periodically run statement, in Cron format
+for example: "* * * * *" (execute query every minute, on the minute)
+
+There is no schedule by default. If no schedule is given, then the statement is run
+exactly once.
+
+[id="{version}-plugins-{type}s-{plugin}-sequel_opts"]
+===== `sequel_opts` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * Default value is `{}`
+
+General/Vendor-specific Sequel configuration options.
+
+An example of an optional connection pool configuration
+   max_connections - The maximum number of connections the connection pool
+
+examples of vendor-specific options can be found in this
+documentation page: https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc
+
+[id="{version}-plugins-{type}s-{plugin}-sql_log_level"]
+===== `sql_log_level` 
+
+  * Value can be any of: `fatal`, `error`, `warn`, `info`, `debug`
+  * Default value is `"info"`
+
+Log level at which to log SQL queries, the accepted values are the common ones fatal, error, warn,
+info and debug. The default value is info.
+
+[id="{version}-plugins-{type}s-{plugin}-statement"]
+===== `statement` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+If undefined, Logstash will complain, even if codec is unused.
+Statement to execute
+
+To use parameters, use named parameter syntax.
+For example:
+
+[source, ruby]
+-----------------------------------------------
+"SELECT * FROM MYTABLE WHERE id = :target_id"
+-----------------------------------------------
+
+here, ":target_id" is a named parameter. You can configure named parameters
+with the `parameters` setting.
+
+[id="{version}-plugins-{type}s-{plugin}-statement_filepath"]
+===== `statement_filepath` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+Path of file containing statement to execute
+
+[id="{version}-plugins-{type}s-{plugin}-tracking_column"]
+===== `tracking_column` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+If tracking column value rather than timestamp, the column whose value is to be tracked
+
+[id="{version}-plugins-{type}s-{plugin}-tracking_column_type"]
+===== `tracking_column_type` 
+
+  * Value can be any of: `numeric`, `timestamp`
+  * Default value is `"numeric"`
+
+Type of tracking column. Currently only "numeric" and "timestamp"
+
+[id="{version}-plugins-{type}s-{plugin}-use_column_value"]
+===== `use_column_value` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Use an incremental column value rather than a timestamp
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/inputs/meetup-index.asciidoc
+++ b/docs/versioned-plugins/inputs/meetup-index.asciidoc
@@ -5,12 +5,14 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v3.1.0-plugins-inputs-meetup,v3.1.0>> | 2018-02-14
 | <<v3.0.4-plugins-inputs-meetup,v3.0.4>> | 2018-01-30
 | <<v3.0.3-plugins-inputs-meetup,v3.0.3>> | 2017-11-07
 | <<v3.0.2-plugins-inputs-meetup,v3.0.2>> | 2017-08-15
 | <<v3.0.1-plugins-inputs-meetup,v3.0.1>> | 2017-06-23
 |=======================================================================
 
+include::meetup-v3.1.0.asciidoc[]
 include::meetup-v3.0.4.asciidoc[]
 include::meetup-v3.0.3.asciidoc[]
 include::meetup-v3.0.2.asciidoc[]

--- a/docs/versioned-plugins/inputs/meetup-v3.1.0.asciidoc
+++ b/docs/versioned-plugins/inputs/meetup-v3.1.0.asciidoc
@@ -1,0 +1,111 @@
+:plugin: meetup
+:type: input
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.1.0
+:release_date: 2018-02-14
+:changelog_url: https://github.com/logstash-plugins/logstash-input-meetup/blob/v3.1.0/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Meetup input plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Periodically query meetup.com regarding updates on events for the given Meetup key.
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Meetup Input Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-eventstatus>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-groupid>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-meetupkey>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-urlname>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-venueid>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-text>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-eventstatus"]
+===== `eventstatus` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * Default value is `"upcoming,past"`.
+
+Event Status can be one of `"upcoming"`, `"past"`, or `"upcoming,past"`. Default is `"upcoming,past"`.
+
+[id="{version}-plugins-{type}s-{plugin}-groupid"]
+===== `groupid` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * There is no default value for this setting.
+
+The Group ID, multiple may be specified seperated by commas. 
+Must have one of `urlname`, `venueid`, `groupid`, `text`.
+
+[id="{version}-plugins-{type}s-{plugin}-interval"]
+===== `interval` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number].
+  * There is no default value for this setting.
+
+Interval to run the command. Value is in minutes.
+
+[id="{version}-plugins-{type}s-{plugin}-meetupkey"]
+===== `meetupkey` 
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * There is no default value for this setting.
+
+Meetup Key, aka personal token.
+
+[id="{version}-plugins-{type}s-{plugin}-urlname"]
+===== `urlname` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * There is no default value for this setting.
+
+URLName - the URL name ie `ElasticSearch-Oklahoma-City`.
+Must have one of urlname, venue_id, group_id, `text`.
+
+[id="{version}-plugins-{type}s-{plugin}-venueid"]
+===== `venueid` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * There is no default value for this setting.
+
+The venue ID
+Must have one of `urlname`, `venue_id`, `group_id`, `text`.
+
+[id="{version}-plugins-{type}s-{plugin}-text"]
+===== `text` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string].
+  * There is no default value for this setting.
+
+A text string to search meetup events by.
+Must have one of `urlname`, `venue_id`, `group_id`, `text`.
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
Updating versioned plugin reference with latest generated files.

The removal of dissect 1.1.3 is OK because 1.1.3 is not a published gem version.