### PR TITLE
Bump Plugin version docs for 6.1.4

### DIFF
--- a/docs/plugins/codecs/multiline.asciidoc
+++ b/docs/plugins/codecs/multiline.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.8
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.8/CHANGELOG.md
+:version: v3.0.9
+:release_date: 2018-01-17
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.9/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/csv.asciidoc
+++ b/docs/plugins/filters/csv.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.7
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-csv/blob/v3.0.7/CHANGELOG.md
+:version: v3.0.8
+:release_date: 2018-01-12
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-csv/blob/v3.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -40,6 +40,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-quote_char>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-separator>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-skip_empty_columns>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-skip_empty_rows>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-skip_header>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
@@ -129,6 +131,31 @@ Optional.
 
 Define whether empty columns should be skipped.
 Defaults to false. If set to true, columns containing no value will not get set.
+
+[id="plugins-{type}s-{plugin}-skip_empty_rows"]
+===== `skip_empty_rows` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Define whether empty rows could potentially be skipped.
+Defaults to false. If set to true, rows containing no value will be tagged with "_csvskippedemptyfield".
+This tag can referenced by users if they wish to cancel events using an 'if' conditional statement.
+
+[id="plugins-{type}s-{plugin}-skip_header"]
+===== `skip_header`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Define whether the header should be skipped.
+Defaults to false. If set to true, the header will be skipped.
+Assumes that header is not repeated within further rows as such rows will also be skipped.
+If skip_header is set without autodetect_column_names being set then columns should be set which
+will result in the skipping of any row that exactly matches the specified column values.
+If skip_header and autodetect_column_names are specified then columns should not be specified, in this case
+autodetect_column_names will fill the columns setting in the background, from the first event seen, and any
+subsequent values that match what was autodetected will be skipped.
 
 [id="plugins-{type}s-{plugin}-source"]
 ===== `source` 

--- a/docs/plugins/filters/dissect.asciidoc
+++ b/docs/plugins/filters/dissect.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.1.2
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-dissect/blob/v1.1.2/CHANGELOG.md
+:version: v1.1.4
+:release_date: 2018-02-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-dissect/blob/v1.1.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -254,6 +254,11 @@ filter {
   * Default value is `{}`
 
 A hash of dissections of `field => value` +
+[IMPORTANT]
+Don't use an escaped newline `\n` in the value, it will be seen as two characters `\` + `n`+
+Instead use actual line breaks in the config.+
+Also use single quotes to define the value if it contains double quotes.
+
 A later dissection can be done on values from a previous dissection or they can be independent.
 
 For example
@@ -261,7 +266,9 @@ For example
 filter {
   dissect {
     mapping => {
-      "message" => "%{field1} %{field2} %{description}"
+      # using an actual line break
+      "message" => '"%{field1}" "%{field2}"
+ "%{description}"'
       "description" => "%{field3} %{field4} %{field5}"
     }
   }

--- a/docs/plugins/filters/elasticsearch.asciidoc
+++ b/docs/plugins/filters/elasticsearch.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.1
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.2.1/CHANGELOG.md
+:version: v3.3.0
+:release_date: 2018-01-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.3.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -56,7 +56,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
          }
 
          ruby {
-            code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
+            code => "event.set('duration_hrs', (event.get('@timestamp') - event.get('started')) / 3600)"
          }
       }
 
@@ -68,6 +68,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
          elasticsearch {
             hosts => ["es-server"]
             query_template => "template.json"
+            fields => { "@timestamp" => "started" }
          }
 
          date {
@@ -76,7 +77,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
          }
 
          ruby {
-            code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
+            code => "event.set('duration_hrs', (event.get('@timestamp') - event.get('started')) / 3600)"
          }
   }
 
@@ -90,7 +91,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
        "query": "type:start AND operation:%{[opid]}"
       }
     },
-   "_source": ["@timestamp", "started"]
+   "_source": ["@timestamp"]
  }
 
 As illustrated above, through the use of 'opid', fields from the Logstash events can be referenced within the template.
@@ -106,7 +107,9 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-aggregation_fields>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-ca_file>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-docinfo_fields>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-enable_sort>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
@@ -126,6 +129,24 @@ filter plugins.
 
 &nbsp;
 
+[id="plugins-{type}s-{plugin}-aggregation_fields"]
+===== `aggregation_fields` 
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+Hash of aggregation names to copy from elasticsearch response into Logstash event fields
+
+Example:
+[source,ruby]
+    filter {
+      elasticsearch {
+        aggregation_fields => {
+          "my_agg_name" => "my_ls_field"
+        }
+      }
+    }
+
 [id="plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file` 
 
@@ -133,6 +154,25 @@ filter plugins.
   * There is no default value for this setting.
 
 SSL Certificate Authority file
+
+[id="plugins-{type}s-{plugin}-docinfo_fields"]
+===== `docinfo_fields` 
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+Hash of docinfo fields to copy from old event (found via elasticsearch) into new event
+
+Example:
+[source,ruby]
+    filter {
+      elasticsearch {
+        docinfo_fields => {
+          "_id" => "document_id"
+          "_index" => "document_index"
+        }
+      }
+    }
 
 [id="plugins-{type}s-{plugin}-enable_sort"]
 ===== `enable_sort` 

--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.0.1
-:release_date: 2017-12-18
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.0.1/CHANGELOG.md
+:version: v4.0.2
+:release_date: 2018-01-29
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -39,18 +39,16 @@ output {
   elasticsearch {
     hosts => "localhost:9200"
     manage_template => false
-    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
-    document_type => "%{[@metadata][type]}" <1>
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
   }
 }
 ------------------------------------------------------------------------------
 
-<1> Starting with Logstash 6.0, the `document_type` option is
-deprecated due to the
-https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal of types in Logstash 6.0].
-It will be removed in the next major version of Logstash. If you are running
-Logstash 6.0 or later, you do not need to set `document_type` in your
-configuration because Logstash sets the type to `doc` by default.
+NOTE: The Beats shipper automatically sets the `type` field on the event.
+You cannot override this setting in the Logstash config. If you specify
+a setting for the <<plugins-inputs-beats-type,`type`>> config option in
+Logstash, it is ignored.
 
 IMPORTANT: If you are shipping events that span multiple lines, you need to
 use the https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html[configuration options available in Filebeat] to handle multiline events

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.1
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.1.1/CHANGELOG.md
+:version: v4.2.0
+:release_date: 2018-01-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -33,6 +33,9 @@ plugin to version 4.0.2 or higher.
 
 Read from an Elasticsearch cluster, based on search query results.
 This is useful for replaying test logs, reindexing, etc.
+You can periodically schedule ingestion using a cron syntax 
+(see `schedule` setting) or run the query one time to load
+data into Logstash.
 
 Example:
 [source,ruby]
@@ -56,6 +59,25 @@ This would create an Elasticsearch query with the following format:
     }'
 
 
+==== Scheduling
+
+Input from this plugin can be scheduled to run periodically according to a specific
+schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+
+Further documentation describing this syntax can be found
+https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Input Configuration Options
 
@@ -72,6 +94,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
@@ -128,6 +151,11 @@ Example
     }
 
 
+NOTE: Starting with Logstash 6.0, the `document_type` option is
+deprecated due to the
+https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal of types in Logstash 6.0].
+It will be removed in the next major version of Logstash.
+
 [id="plugins-{type}s-{plugin}-docinfo_fields"]
 ===== `docinfo_fields` 
 
@@ -137,7 +165,7 @@ Example
 If document metadata storage is requested by enabling the `docinfo`
 option, this option lists the metadata fields to save in the current
 event. See
-[Document Metadata](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_document_metadata.html)
+http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_document_metadata.html[Document Metadata]
 in the Elasticsearch documentation for more information.
 
 [id="plugins-{type}s-{plugin}-docinfo_target"]
@@ -185,8 +213,20 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-[Elasticsearch query DSL documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
+https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
+
+[id="plugins-{type}s-{plugin}-schedule"]
+===== `schedule` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Schedule of when to periodically run statement, in Cron format
+for example: "* * * * *" (execute query every minute, on the minute)
+
+There is no schedule by default. If no schedule is given, then the statement is run
+exactly once.
 
 [id="plugins-{type}s-{plugin}-scroll"]
 ===== `scroll` 

--- a/docs/plugins/inputs/gelf.asciidoc
+++ b/docs/plugins/inputs/gelf.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.7
-:release_date: 2017-11-14
-:changelog_url: https://github.com/logstash-plugins/logstash-input-gelf/blob/v3.0.7/CHANGELOG.md
+:version: v3.1.0
+:release_date: 2018-01-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-gelf/blob/v3.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -45,7 +45,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-use_udp>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_tcp>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-port_tcp>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-port_udp>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-remap>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-strip_leading_underscore>> |<<boolean,boolean>>|No
 |=======================================================================
@@ -63,6 +67,22 @@ input plugins.
 
 The IP address or hostname to listen on.
 
+[id="plugins-{type}s-{plugin}-use_udp"]
+===== `use_udp`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Whether to listen for gelf messages sent over udp
+
+[id="plugins-{type}s-{plugin}-use_tcp"]
+===== `use_tcp`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Whether to listen for gelf messages sent over tcp
+
 [id="plugins-{type}s-{plugin}-port"]
 ===== `port` 
 
@@ -71,6 +91,22 @@ The IP address or hostname to listen on.
 
 The port to listen on. Remember that ports less than 1024 (privileged
 ports) may require root to use.
+port_tcp and port_udp can be used to set a specific port for each protocol.
+[id="plugins-{type}s-{plugin}-port_tcp"]
+===== `port_tcp`
+
+  * Value type is <<number,number>>
+  * There is no default value for this setting.
+
+Tcp port to listen on. Use port instead of this setting unless you need a different port for udp than tcp
+
+[id="plugins-{type}s-{plugin}-port_udp"]
+===== `port_udp`
+
+  * Value type is <<number,number>>
+  * There is no default value for this setting.
+
+Udp port to listen on. Use port instead of this setting unless you need a different port for udp than tcp
 
 [id="plugins-{type}s-{plugin}-remap"]
 ===== `remap` 

--- a/docs/plugins/outputs/email.asciidoc
+++ b/docs/plugins/outputs/email.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.0.6
-:release_date: 2017-08-16
-:changelog_url: https://github.com/logstash-plugins/logstash-output-email/blob/v4.0.6/CHANGELOG.md
+:version: v4.1.0
+:release_date: 2018-01-15
+:changelog_url: https://github.com/logstash-plugins/logstash-output-email/blob/v4.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -34,6 +34,7 @@ output {
       from => 'monitor@example.com'
       subject => 'Alert - %{title}'
       body => "Tags: %{tags}\\n\\Content:\\n%{message}"
+      template_file => "/tmp/email_template.mustache"
       domain => 'mail.example.com'
       port => 25
     }
@@ -54,6 +55,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-authentication>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-body>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cc>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-bcc>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-contenttype>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-debug>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-domain>> |<<string,string>>|No
@@ -67,6 +69,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-use_tls>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-via>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-template_file>> |<<path,path>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -116,6 +119,16 @@ The fully-qualified email address(es) to include as cc: address(es).
 
 This field also accepts a comma-separated string of addresses, for example:
 `"me@example.com, you@example.com"`
+
+[id="plugins-{type}s-{plugin}-bcc"]
+===== `bcc` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The fully-qualified email address(es) to include as bcc: address(es).
+
+This field accepts several addresses like cc.
 
 [id="plugins-{type}s-{plugin}-contenttype"]
 ===== `contenttype` 
@@ -230,6 +243,14 @@ Username to authenticate with the server
 
 How Logstash should send the email, either via SMTP or by invoking sendmail.
 
+[id="plugins-{type}s-{plugin}-template_file"]
+===== `template_file` 
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+Path of a [Mustache templating](https://mustache.github.io/) file used for email templating. See example in test fixture.
+Can be used with `body` to send multi-part emails. Takes precedence over `htmlBody`.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/plugins/outputs/http.asciidoc
+++ b/docs/plugins/outputs/http.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.1
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-output-http/blob/v5.1.1/CHANGELOG.md
+:version: v5.2.0
+:release_date: 2018-01-15
+:changelog_url: https://github.com/logstash-plugins/logstash-output-http/blob/v5.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -47,7 +47,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-content_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-format>> |<<string,string>>, one of `["json", "form", "message"]`|No
+| <<plugins-{type}s-{plugin}-format>> |<<string,string>>, one of `["json", "json_batch", "form", "message"]`|No
 | <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-http_method>> |<<string,string>>, one of `["put", "post", "patch", "delete", "get", "head"]`|Yes
@@ -131,6 +131,7 @@ Content type
 If not specified, this defaults to the following:
 
 * if format is "json", "application/json"
+* if format is "json_batch", "application/json". Each Logstash batch of events will be concatenated into a single array and sent in one request.
 * if format is "form", "application/x-www-form-urlencoded"
 
 [id="plugins-{type}s-{plugin}-cookies"]
@@ -153,10 +154,14 @@ Should redirects be followed? Defaults to `true`
 [id="plugins-{type}s-{plugin}-format"]
 ===== `format` 
 
-  * Value can be any of: `json`, `form`, `message`
+  * Value can be any of: `json`, `json_batch`, `form`, `message`
   * Default value is `"json"`
 
 Set the format of the http body.
+
+If json_batch, each batch of events received by this output will be placed
+into a single JSON array and sent in one request. This is particularly useful
+for high throughput scenarios such as sending data between Logstash instaces.
 
 If form, then the body will be the mapping (or whole event) converted
 into a query parameter string, e.g. `foo=bar&baz=fizz...`

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.0.6
-:release_date: 2018-01-05
-:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.0.6/CHANGELOG.md
+:version: v7.0.8
+:release_date: 2018-01-24
+:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -21,7 +21,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-Write events to a Kafka topic.
+Write events to a Kafka topic. 
 
 This plugin uses Kafka Client 1.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 

--- a/docs/plugins/outputs/rabbitmq.asciidoc
+++ b/docs/plugins/outputs/rabbitmq.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.3
-:release_date: 2017-11-13
-:changelog_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/blob/v5.0.3/CHANGELOG.md
+:version: v5.1.0
+:release_date: 2018-01-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/blob/v5.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Note:

 This commit is larger than I expected - it looks like the plugin documentation was not fully updated to the latest plugin version on previous `6.1` releases.