### PR TITLE
Update link to support matrix

### DIFF
--- a/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
@@ -39,5 +39,5 @@ endif::[]
 ==== Getting Help
 
 For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-{type}-{plugin}[Github].
-For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#show_logstash_plugins[Elastic Support Matrix].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
 


### PR DESCRIPTION
Adding change from https://github.com/elastic/logstash/pull/9275 to versioned_plugin_docs.