### PR TITLE
Add bytes filter to the plugin docs

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -10,6 +10,7 @@ The following filter plugins are available below. For a list of Elastic supporte
 | Plugin | Description | Github repository
 | <<plugins-filters-aggregate,aggregate>> | Aggregates information from several events originating with a single task | https://github.com/logstash-plugins/logstash-filter-aggregate[logstash-filter-aggregate]
 | <<plugins-filters-alter,alter>> | Performs general alterations to fields that the `mutate` filter does not handle | https://github.com/logstash-plugins/logstash-filter-alter[logstash-filter-alter]
+| <<plugins-filters-bytes,bytes>> | Parses string representations of computer storage sizes, such as "123 MB" or "5.6gb", into their numeric value in bytes | https://github.com/logstash-plugins/logstash-filter-bytes[logstash-filter-bytes]
 | <<plugins-filters-cidr,cidr>> | Checks IP addresses against a list of network blocks | https://github.com/logstash-plugins/logstash-filter-cidr[logstash-filter-cidr]
 | <<plugins-filters-cipher,cipher>> | Applies or removes a cipher to an event | https://github.com/logstash-plugins/logstash-filter-cipher[logstash-filter-cipher]
 | <<plugins-filters-clone,clone>> | Duplicates events | https://github.com/logstash-plugins/logstash-filter-clone[logstash-filter-clone]
@@ -56,6 +57,9 @@ include::filters/aggregate.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/docs/index.asciidoc
 include::filters/alter.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-filter-bytes/edit/master/docs/index.asciidoc
+include::filters/bytes.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/docs/index.asciidoc
 include::filters/cidr.asciidoc[]


### PR DESCRIPTION
Do not merge this PR until after the generated plugin docs containing the bytes.asciidoc file have been copied and merged into the relevant repos (master, 6.x, and whichever other 6.n releases require these docs).

@ycombinator The 1.0.0 version of the bytes filter asciidoc breaks the doc build because it references an ID that is not defined anywhere. I think you need to remove this line (or add the missing content) and republish the gem:

`<<plugins-{type}s-{plugin}-digit_group_separator>> |<<string,string>>|No`

You'll need to bump the version, too, so the docgen script can pick up the doc change.

@karenzone This is an example of how you add docs for an entirely new plugin

@jsvd Just a heads up that you'll also have to generate the docs for master (and any other branches where you want this PR) before this PR gets merged
