### PR TITLE
Add branch attribute to resolve doc paths

### DIFF
--- a/docs/versioned-plugins/index.asciidoc
+++ b/docs/versioned-plugins/index.asciidoc
@@ -3,6 +3,8 @@
 // other books in our library.
 :versioned_docs: true
 
+:branch: current
+
 // Set include path for common files
 :include_path: ../include/6.x
 


### PR DESCRIPTION
At some point, someone on the doc team added a branch attribute to the shared attributes file, but didn't realize that the versioned plugin reference does not set the branch attribute (because it's not tied to a specific release). This meant that links were not resolving correctly.

This PR sets the branch to `current` so all links will point to the current version of the docs. 

This approach (pointing to `current `for everything) makes the linking in the versioned plugin reference a bit fragile. As links break (because we move stuff around or features go away), we'll need to fix them in the docs. 

@jsvd Another option is to set the branch attribute individually in each generated plugin doc file to override the branch setting (the link would point to the version of the Logstash reference that was available when that version of the plugin was released). We don't have a huge number of links, so maybe fixing them manually is acceptable for now, but over time, this issue needs to be addressed. 