### PR TITLE
Add azure_event_hubs input to the plug-in docs

### DIFF
--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -7,6 +7,7 @@ The following input plugins are available below. For a list of Elastic supported
 
 |=======================================================================
 | Plugin | Description | Github repository
+| <<plugins-inputs-azure_event_hubs,azure_event_hubs>> | Receives events from Azure Event Hubs | https://github.com/logstash-plugins/azure_event_hubs[azure_event_hubs]
 | <<plugins-inputs-beats,beats>> | Receives events from the Elastic Beats framework | https://github.com/logstash-plugins/logstash-input-beats[logstash-input-beats]
 | <<plugins-inputs-cloudwatch,cloudwatch>> | Pulls events from the Amazon Web Services CloudWatch API  | https://github.com/logstash-plugins/logstash-input-cloudwatch[logstash-input-cloudwatch]
 | <<plugins-inputs-couchdb_changes,couchdb_changes>> | Streams events from CouchDB's `_changes` URI | https://github.com/logstash-plugins/logstash-input-couchdb_changes[logstash-input-couchdb_changes]
@@ -56,6 +57,9 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-wmi,wmi>> | Creates events based on the results of a WMI query | https://github.com/logstash-plugins/logstash-input-wmi[logstash-input-wmi]
 | <<plugins-inputs-xmpp,xmpp>> | Receives events over the XMPP/Jabber protocol | https://github.com/logstash-plugins/logstash-input-xmpp[logstash-input-xmpp]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/edit/master/docs/index.asciidoc
+include::inputs/azure_event_hubs.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/master/docs/index.asciidoc
 include::inputs/beats.asciidoc[]


### PR DESCRIPTION
Adding azure_event_hubs input plugin (https://github.com/logstash-plugins/logstash-input-azure_event_hubs/pull/6) to docs.

Do not merge this PR until after the generated plugin docs containing the azure_event_hubs.asciidoc file have been copied and merged into the relevant repos (master, 6.x, and whichever other 6.n releases require these docs).

TO DO:
- Pull down generated doc and test it
- Wait for plugin to be released/published