### PR TITLE
Add google_pubsub output to plugin docs

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -20,6 +20,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-ganglia,ganglia>> | Writes metrics to Ganglia's `gmond` | https://github.com/logstash-plugins/logstash-output-ganglia[logstash-output-ganglia]
 | <<plugins-outputs-gelf,gelf>> | Generates GELF formatted output for Graylog2 | https://github.com/logstash-plugins/logstash-output-gelf[logstash-output-gelf]
 | <<plugins-outputs-google_bigquery,google_bigquery>> | Writes events to Google BigQuery | https://github.com/logstash-plugins/logstash-output-google_bigquery[logstash-output-google_bigquery]
+| <<plugins-outputs-google_pubsub,google_pubsub>> | Uploads log events to Google Cloud Pubsub | https://github.com/logstash-plugins/logstash-output-google_pubsub[logstash-output-google_pubsub]
 | <<plugins-outputs-graphite,graphite>> | Writes metrics to Graphite | https://github.com/logstash-plugins/logstash-output-graphite[logstash-output-graphite]
 | <<plugins-outputs-graphtastic,graphtastic>> | Sends metric data on Windows | https://github.com/logstash-plugins/logstash-output-graphtastic[logstash-output-graphtastic]
 | <<plugins-outputs-http,http>> | Sends events to a generic HTTP or HTTPS endpoint | https://github.com/logstash-plugins/logstash-output-http[logstash-output-http]
@@ -97,6 +98,9 @@ include::outputs/gelf.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/docs/index.asciidoc
 include::outputs/google_bigquery.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/edit/master/docs/index.asciidoc
+include::outputs/google_pubsub.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/docs/index.asciidoc
 include::outputs/graphite.asciidoc[]


### PR DESCRIPTION
Adding google_pubsub output plugin (https://github.com/logstash-plugins/logstash-output-google_pubsub/pull/5) to docs.

Do not merge this PR until after the generated plugin docs containing the google_pubsub.asciidoc file have been copied and merged into the relevant repos (master, 6.x, and 6.4).

TO DO:
Pull down generated doc and test it
Verify that plugin has been released/published