### PR TITLE
updated docs for 6.4

### DIFF
--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.3
-:release_date: 2018-06-19
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v5.0.3/CHANGELOG.md
+:version: v5.0.4
+:release_date: 2018-08-22
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v5.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/mutate.asciidoc
+++ b/docs/plugins/filters/mutate.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.3.2
-:release_date: 2018-05-01
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.3.2/CHANGELOG.md
+:version: v3.3.3
+:release_date: 2018-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.3.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -237,7 +237,7 @@ Example:
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-Replace a field with a new value. The new value can include `%{foo}` strings
+Replace the value of a field with a new value. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 Example:

--- a/docs/plugins/filters/ruby.asciidoc
+++ b/docs/plugins/filters/ruby.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.4
-:release_date: 2018-03-16
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-ruby/blob/v3.1.4/CHANGELOG.md
+:version: v3.1.5
+:release_date: 2018-08-31
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-ruby/blob/v3.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.3
-:release_date: 2018-07-30
-:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.0.3/CHANGELOG.md
+:version: v1.0.4
+:release_date: 2018-08-09
+:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -73,6 +73,7 @@ DefaultEndpointsProtocol=https;AccountName=logstash;AccountKey=ETOPnkd/hDAWidkEp
 Find the connection string to Blob Storage here: 
 https://portal.azure.com[Azure Portal]`-> Blob Storage account -> Access keys`.
 
+[id="plugins-{type}s-{plugin}-best-practices"]
 ===== Best practices
 
 Here are some guidelines to help you avoid data conflicts that can cause lost
@@ -94,6 +95,17 @@ sure that at least one of these options is different per Event Hub:
 ** storage_connection
 ** storage_container (defaults to Event Hub name if not defined)
 ** consumer_group
+* **Set number of threads correctly.** 
+The number of threads should equal the number of Event Hubs plus one (or more).
+Each Event Hub needs at least one thread. An additional thread is needed to help
+coordinate the other threads. The number of threads should not exceed the number
+of Event Hubs multiplied by the number of partitions per Event Hub plus one.
+Threads are currently available only as a global setting.
+** Sample scenario: Event Hubs = 4. Partitions on each Event Hub = 3.
+Minimum threads is 5 (4 Event Hubs plus one). Maximum threads is 13 (4 Event
+Hubs times 3 partitions plus one). 
+** If you’re collecting activity logs from one event hub instance, 
+then only 2 threads (1 Event Hub plus one) are required.
 
 [id="plugins-{type}s-{plugin}-eh_config_models"]
 ==== Configuration models
@@ -479,6 +491,8 @@ azure_event_hubs {
 }
 ----
 
+The number of threads should be the number of Event Hubs plus one or more. 
+See <<plugins-{type}s-{plugin}-best-practices>> for more information.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/google_pubsub.asciidoc
+++ b/docs/plugins/inputs/google_pubsub.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2018-05-07
-:changelog_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/blob/v1.2.0/CHANGELOG.md
+:version: v1.2.1
+:release_date: 2018-08-17
+:changelog_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/blob/v1.2.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/http.asciidoc
+++ b/docs/plugins/inputs/http.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.0
-:release_date: 2018-05-10
-:changelog_url: https://github.com/logstash-plugins/logstash-input-http/blob/v3.2.0/CHANGELOG.md
+:version: v3.2.1
+:release_date: 2018-08-31
+:changelog_url: https://github.com/logstash-plugins/logstash-input-http/blob/v3.2.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/jdbc.asciidoc
+++ b/docs/plugins/inputs/jdbc.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.3.11
-:release_date: 2018-07-23
-:changelog_url: https://github.com/logstash-plugins/logstash-input-jdbc/blob/v4.3.11/CHANGELOG.md
+:version: v4.3.12
+:release_date: 2018-08-29
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jdbc/blob/v4.3.12/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/jmx.asciidoc
+++ b/docs/plugins/inputs/jmx.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2018-04-13
-:changelog_url: https://github.com/logstash-plugins/logstash-input-jmx/blob/v3.0.6/CHANGELOG.md
+:version: v3.0.7
+:release_date: 2018-08-13
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jmx/blob/v3.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/s3.asciidoc
+++ b/docs/plugins/inputs/s3.asciidoc
@@ -58,7 +58,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-watch_for_new_files>> | <boolean,boolean>|No
+| <<plugins-{type}s-{plugin}-watch_for_new_files>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all

--- a/docs/plugins/inputs/s3.asciidoc
+++ b/docs/plugins/inputs/s3.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.3.7
-:release_date: 2018-07-20
-:changelog_url: https://github.com/logstash-plugins/logstash-input-s3/blob/v3.3.7/CHANGELOG.md
+:version: v3.4.0
+:release_date: 2018-08-27
+:changelog_url: https://github.com/logstash-plugins/logstash-input-s3/blob/v3.4.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -26,6 +26,8 @@ Stream events from files from a S3 bucket.
 
 Each line from each file generates an event.
 Files ending in `.gz` are handled as gzip'ed files.
+
+Files that are archived to AWS Glacier will be skipped.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== S3 Input Configuration Options
@@ -56,6 +58,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-watch_for_new_files>> | <boolean,boolean>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -274,7 +277,14 @@ If specified, this setting must be a filename path and not just a directory.
 
 Set the directory where logstash will store the tmp files before processing them.
 
+[id="plugins-{type}s-{plugin}-watch_for_new_files"]
+===== `watch_for_new_files`
 
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Whether or not to watch for new files.
+Disabling this option causes the input to close itself after processing the files from a single listing.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/udp.asciidoc
+++ b/docs/plugins/inputs/udp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.3.3
-:release_date: 2018-05-09
-:changelog_url: https://github.com/logstash-plugins/logstash-input-udp/blob/v3.3.3/CHANGELOG.md
+:version: v3.3.4
+:release_date: 2018-08-24
+:changelog_url: https://github.com/logstash-plugins/logstash-input-udp/blob/v3.3.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -41,6 +41,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-queue_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-receive_buffer_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-workers>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-source_ip_fieldname>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -102,7 +103,13 @@ Consult your operating system documentation if you need to increase this max all
 
 Number of threads processing packets
 
+[id="plugins-{type}s-{plugin}-source_ip_fieldname"]
+===== `source_ip_fieldname`
 
+  * Value type is <<string,string>>
+  * Default value is `"host"`
+
+The name of the field where the source IP address will be stored.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v9.2.0
-:release_date: 2018-06-09
-:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.2.0/CHANGELOG.md
+:version: v9.2.1
+:release_date: 2018-08-17
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.2.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -32,8 +32,15 @@ plugin to version 6.2.5 or higher.
 
 ================================================================================
 
-This plugin is the recommended method of storing logs in Elasticsearch.
-If you plan on using the Kibana web interface, you'll want to use this output.
+If you plan to use the Kibana web
+interface, use the Elasticsearch output plugin to get your log data into
+Elasticsearch. 
+
+TIP: You can run Elasticsearch on your own hardware, or use our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
+Elastic Cloud. The Elasticsearch Service is available on both AWS and GCP.
+https://www.elastic.co/cloud/elasticsearch-service/signup[Try the {es} Service
+for free].
 
 This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
 We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
@@ -638,8 +645,9 @@ a timeout occurs, the request will be retried.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-The JKS truststore to validate the server's certificate.
-Use either `:truststore` or `:cacert`
+The truststore to validate the server's certificate.
+It can be either .jks or .p12.
+Use either `:truststore` or `:cacert`.
 
 [id="plugins-{type}s-{plugin}-truststore_password"]
 ===== `truststore_password` 

--- a/docs/plugins/outputs/influxdb.asciidoc
+++ b/docs/plugins/outputs/influxdb.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.4
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-influxdb/blob/v5.0.4/CHANGELOG.md
+:version: v5.0.5
+:release_date: 2018-08-15
+:changelog_url: https://github.com/logstash-plugins/logstash-output-influxdb/blob/v5.0.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -187,7 +187,7 @@ The number of time to retry recoverable errors before dropping the events.
 
 A value of -1 will cause the plugin to retry indefinately.
 A value of 0 will cause the plugin to never retry.
-Otherwise it will retry up to the specified mumber of times.
+Otherwise it will retry up to the specified number of times.
 
 
 [id="plugins-{type}s-{plugin}-measurement"]
@@ -230,7 +230,8 @@ The retention policy to use
 
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
-request should be considered metadata and given as tags.
+request should be considered metadata and given as tags. Tags are only sent when
+present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl` 
@@ -265,8 +266,6 @@ Automatically use fields from the event as the data points sent to Influxdb
   * Default value is `nil`
 
 The user who has access to the named database
-
-
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.1.2
-:release_date: 2018-08-01
-:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.1.2/CHANGELOG.md
+:version: v7.1.3
+:release_date: 2018-08-27
+:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.1.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/s3.asciidoc
+++ b/docs/plugins/outputs/s3.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.4
-:release_date: 2018-05-30
-:changelog_url: https://github.com/logstash-plugins/logstash-output-s3/blob/v4.1.4/CHANGELOG.md
+:version: v4.1.5
+:release_date: 2018-08-29
+:changelog_url: https://github.com/logstash-plugins/logstash-output-s3/blob/v4.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Doc for 6.4 generated using new CI job (https://logstash-ci.elastic.co/view/Docs/job/elastic+docs-tools+logstash-plugin-docs/) to address https://github.com/logstash-plugins/logstash-filter-translate/issues/78 (Old Doc on web page) 