### PR TITLE
Plugin docs for 6.4 with cef changes

### DIFF
--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -38,6 +38,7 @@ produce an event with the payload as the 'message' field and a '_cefparsefailure
 | <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-product>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-reverse_mapping>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-severity>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-signature>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-vendor>> |<<string,string>>|No
@@ -76,14 +77,6 @@ This setting allows the following character sequences to have special meaning:
   * Value type is <<boolean,boolean>>
   * There is no default value for this setting.
 
-[id="plugins-{type}s-{plugin}-reverse_mapping"]
-===== `reverse_mapping`
-
-  * Value type is <<<boolean,boolean>>
-  * Default value is `false`
-
-Set to true to adhere to the specifications and encode using the CEF key name (short name) for the CEF field names.
-
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 
 
@@ -109,6 +102,14 @@ to help you build a new value from other parts of the event.
 
 Device product field in CEF header. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
+
+[id="plugins-{type}s-{plugin}-reverse_mapping"]
+===== `reverse_mapping`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set to true to adhere to the specifications and encode using the CEF key name (short name) for the CEF field names.
 
 [id="plugins-{type}s-{plugin}-sev"]
 ===== `sev`  (OBSOLETE)

--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.4
-:release_date: 2018-08-22
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v5.0.4/CHANGELOG.md
+:version: v5.0.6
+:release_date: 2018-09-21
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v5.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -75,6 +75,14 @@ This setting allows the following character sequences to have special meaning:
   * OBSOLETE WARNING: This configuration item is obsolete and will prevent the pipeline from starting if used
   * Value type is <<boolean,boolean>>
   * There is no default value for this setting.
+
+[id="plugins-{type}s-{plugin}-reverse_mapping"]
+===== `reverse_mapping`
+
+  * Value type is <<<boolean,boolean>>
+  * Default value is `false`
+
+Set to true to adhere to the specifications and encode using the CEF key name (short name) for the CEF field names.
 
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 

--- a/docs/plugins/inputs/heartbeat.asciidoc
+++ b/docs/plugins/inputs/heartbeat.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-heartbeat/blob/v3.0.6/CHANGELOG.md
+:version: v3.0.7
+:release_date: 2018-09-13
+:changelog_url: https://github.com/logstash-plugins/logstash-input-heartbeat/blob/v3.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/kinesis.asciidoc
+++ b/docs/plugins/inputs/kinesis.asciidoc
@@ -1,13 +1,14 @@
 :plugin: kinesis
 :type: input
 :default_plugin: 0
+:default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.0.7
-:release_date: 2017-11-14
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.0.7/CHANGELOG.md
+:version: v2.0.8
+:release_date: 2018-09-25
+:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -111,3 +112,5 @@ By default this is empty and the default chain will be used.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+
+:default_codec!:

--- a/docs/plugins/outputs/google_pubsub.asciidoc
+++ b/docs/plugins/outputs/google_pubsub.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.0
-:release_date: 2018-07-27
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.0/CHANGELOG.md
+:version: v1.0.1
+:release_date: 2018-09-25
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -130,7 +130,7 @@ output {
 ==== Additional Resources
 
  * https://cloud.google.com/pubsub/[Cloud Pub/Sub Homepage]
- * https://cloud.google.com/pubsub/pricing-summary/[Cloud Pub/Sub Pricing]
+ * https://cloud.google.com/pubsub/pricing/[Cloud Pub/Sub Pricing]
  * https://cloud.google.com/iam/docs/service-accounts[IAM Service Accounts]
  * https://cloud.google.com/docs/authentication/production[Application Default Credentials]
 


### PR DESCRIPTION
Based off #625 with changes to cef docs added:
- Added `reverse_mapping` to options table
- Moved `reverse_mapping` option to proper place in alphabetized options list
- Corrected typo in input type

All other changes in #625 LGTM