### PR TITLE
Add cloudtrail codec docs back

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -11,6 +11,7 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-avro,avro>> | Reads serialized Avro records as Logstash events | https://github.com/logstash-plugins/logstash-codec-avro[logstash-codec-avro]
 | <<plugins-codecs-cef,cef>> | Reads the ArcSight Common Event Format (CEF). | https://github.com/logstash-plugins/logstash-codec-cef[logstash-codec-cef]
 | <<plugins-codecs-cloudfront,cloudfront>> | Reads AWS CloudFront reports | https://github.com/logstash-plugins/logstash-codec-cloudfront[logstash-codec-cloudfront]
+| <<plugins-codecs-cloudtrail,cloudtrail>> | Reads AWS CloudTrail log files| https://github.com/logstash-plugins/logstash-codec-cloudtrail[logstash-codec-cloudtrail]
 | <<plugins-codecs-collectd,collectd>> | Reads events from the `collectd` binary protocol using UDP. | https://github.com/logstash-plugins/logstash-codec-collectd[logstash-codec-collectd]
 | <<plugins-codecs-dots,dots>> | Sends 1 dot per event to `stdout` for performance tracking | https://github.com/logstash-plugins/logstash-codec-dots[logstash-codec-dots]
 | <<plugins-codecs-edn,edn>> | Reads EDN format data | https://github.com/logstash-plugins/logstash-codec-edn[logstash-codec-edn]
@@ -39,6 +40,9 @@ include::codecs/cef.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/docs/index.asciidoc
 include::codecs/cloudfront.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/docs/index.asciidoc
+include::codecs/cloudtrail.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]


### PR DESCRIPTION
Cloudtrail codec documentation was previously removed because it was unable to be installed in later versions of Logstash. This has now been resolved, so the documentation can be re-added.