### PR TITLE
Update docs 6.5 and add no codec tags

### DIFF
--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.2
-:release_date: 2018-09-10
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.1.2/CHANGELOG.md
+:version: v3.14.1
+:release_date: 2018-05-23
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v3.14.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -31,32 +31,30 @@ This codec supports:
 * Netflow v9
 * IPFIX
 
-The following Netflow/IPFIX exporters have been seen and tested with the most recent version of the Netflow Codec:
+The following Netflow/IPFIX exporters are known to work with the most recent version of the netflow codec:
 
 [cols="6,^2,^2,^2,12",options="header"]
 |===========================================================================================
 |Netflow exporter         | v5 | v9 | IPFIX | Remarks
-|Barracuda Firewall       |    |    |   y   | With support for Extended Uniflow
+|Barracuda Firewall       |    |    |   y   |
 |Cisco ASA                |    | y  |       |  
-|Cisco ASR 1k             |    |    |   N   | Fails because of duplicate fields
+|Cisco ASR 1k             |    |    |   n   | Fails because of duplicate fields
 |Cisco ASR 9k             |    | y  |       |  
 |Cisco IOS 12.x           |    | y  |       |  
-|Cisco ISR w/ HSL         |    | N  |       | Fails because of duplicate fields, see: https://github.com/logstash-plugins/logstash-codec-netflow/issues/93
+|Cisco ISR w/ HSL         |    | n  |       | Fails because of duplicate fields, see: https://github.com/logstash-plugins/logstash-codec-netflow/issues/93
 |Cisco WLC                |    | y  |       |
 |Citrix Netscaler         |    |    |   y   | Still some unknown fields, labeled netscalerUnknown<id>
 |fprobe                   |  y |    |       |
 |Fortigate FortiOS        |    | y  |       |
 |Huawei Netstream         |    | y  |       |
 |ipt_NETFLOW              |  y | y  |   y   |
-|Juniper MX               |  y |    |   y   | SW > 12.3R8. Fails to decode IPFIX from Junos 16.1 due to duplicate field names which we currently don't support.
+|Juniper MX80             |  y |    |       | SW > 12.3R8
 |Mikrotik                 |  y |    |   y   | http://wiki.mikrotik.com/wiki/Manual:IP/Traffic_Flow
 |nProbe                   |  y | y  |   y   | L7 DPI fields now also supported
 |Nokia BRAS               |    |    |   y   |
-|OpenBSD pflow            |  y | N  |   y   | http://man.openbsd.org/OpenBSD-current/man4/pflow.4
-|Riverbed                 |    | N  |       | Not supported due to field ID conflicts. Workaround available in the definitions directory over at Elastiflow <https://github.com/robcowart/elastiflow>
+|OpenBSD pflow            |  y | n  |   y   | http://man.openbsd.org/OpenBSD-current/man4/pflow.4
 |Sandvine Procera PacketLogic| |    |   y   | v15.1
 |Softflowd                |  y | y  |   y   | IPFIX supported in https://github.com/djmdjm/softflowd
-|Sophos UTM               |    |    |   y   |
 |Streamcore Streamgroomer |    | y  |       |
 |Palo Alto PAN-OS         |    | y  |       |
 |Ubiquiti Edgerouter X    |    | y  |       | With MPLS labels

--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.0.3
-:release_date: 2018-02-21
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.0.3/CHANGELOG.md
+:version: v4.0.4
+:release_date: 2018-10-19
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -35,6 +35,20 @@ your own trivially. (See the `patterns_dir` setting)
 
 If you need help building patterns to match your logs, you will find the
 <http://grokdebug.herokuapp.com> and <http://grokconstructor.appspot.com/> applications quite useful!
+
+===== Grok or Dissect? Or both?
+
+The {logstash-ref}/plugins-filters-dissect.html[`dissect`] filter plugin
+is another way to extract unstructured event data into fields using delimiters.
+
+Dissect differs from Grok in that it does not use regular expressions and is faster. 
+Dissect works well when data is reliably repeated.
+Grok is a better choice when the structure of your text varies from line to line.
+
+You can use both Dissect and Grok for a hybrid use case when a section of the
+line is reliably repeated, but the entire line is not. The Dissect filter can
+deconstruct the section of the line that is repeated. The Grok filter can process
+the remaining field values with more regex predictability.
 
 ==== Grok Basics
 
@@ -207,20 +221,30 @@ If `true`, keep empty captures as event fields.
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-A hash of matches of field => value
+A hash that defines the mapping of _where to look_, and with which patterns.
 
-For example:
+For example, the following will match an existing value in the `message` field for the given pattern, and if a match is found will add the field `duration` to the event with the captured value:
 [source,ruby]
     filter {
-      grok { match => { "message" => "Duration: %{NUMBER:duration}" } }
+      grok {
+        match => {
+          "message" => "Duration: %{NUMBER:duration}"
+        }
+      }
     }
 
-If you need to match multiple patterns against a single field, the value can be an array of patterns
+If you need to match multiple patterns against a single field, the value can be an array of patterns:
 [source,ruby]
     filter {
-      grok { match => { "message" => [ "Duration: %{NUMBER:duration}", "Speed: %{NUMBER:speed}" ] } }
+      grok {
+        match => {
+          "message" => [
+            "Duration: %{NUMBER:duration}",
+            "Speed: %{NUMBER:speed}"
+          ]
+        }
+      }
     }
-
 
 [id="plugins-{type}s-{plugin}-named_captures_only"]
 ===== `named_captures_only` 

--- a/docs/plugins/filters/mutate.asciidoc
+++ b/docs/plugins/filters/mutate.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.3.3
-:release_date: 2018-08-15
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.3.3/CHANGELOG.md
+:version: v3.3.4
+:release_date: 2018-10-19
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.3.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -23,6 +23,44 @@ include::{include_path}/plugin_header.asciidoc[]
 
 The mutate filter allows you to perform general mutations on fields. You
 can rename, remove, replace, and modify fields in your events.
+
+[id="plugins-{type}s-{plugin}-proc_order"]
+===== Processing order
+
+Mutations in a config file are executed in this order:
+
+* coerce
+* rename
+* update
+* replace
+* convert
+* gsub
+* uppercase
+* capitalize
+* lowercase
+* strip
+* remove
+* split
+* join
+* merge
+* copy
+
+You can control the order by using separate mutate blocks.
+
+Example:
+[source,ruby]
+-----
+filter {
+    mutate {
+        split => ["hostname", "."]
+        add_field => { "shortHostname" => "%{hostname[0]}" }
+    }
+
+    mutate {    
+        rename => ["shortHostname", "hostname" ]
+    }
+}
+-----
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Mutate Filter Configuration Options

--- a/docs/plugins/inputs/snmp.asciidoc
+++ b/docs/plugins/inputs/snmp.asciidoc
@@ -1,0 +1,310 @@
+:plugin: snmp
+:type: input
+:default_plugin: 1
+:default_codec: plain
+
+// TO DO:  VERIFY default codec!
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.0.0
+:release_date: 2018-10-24
+:changelog_url: https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.0.0/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== SNMP input plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The SNMP input polls network devices using Simple Network Management Protocol (SNMP)
+to gather information related to the current state of the devices operation.
+
+[id="plugins-{type}s-{plugin}-import-mibs"]
+==== Importing MIBs 
+
+This plugin already includes the IETF MIBs (management information bases) and these do not need to be imported.
+
+Any other MIB will need to be manually imported to provide mapping of the numeric OIDs to MIB field names in the resulting event.
+
+To import a MIB, the OSS https://www.ibr.cs.tu-bs.de/projects/libsmi/[libsmi library] is required.
+libsmi is available and installable on most operating systems.
+
+To import a MIB, you need to first convert the ASN.1 MIB file into a `.dic` file using the libsmi `smidump` command line utility.
+
+Example (using `RFC1213-MIB` file)
+
+[source,sh]
+-----
+$ smidump --level=1 -k -f python RFC1213-MIB > RFC1213-MIB.dic
+-----
+
+Note that the resulting file as output by `smidump` must have the `.dic` extension.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== SNMP Input Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-auth_pass>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-auth_protocol>> |<<string,string>>, one of `["md5", "sha", "sha2", "hmac128sha224", "hmac192sha256", "hmac256sha384", "hmac384sha512"]`|No
+| <<plugins-{type}s-{plugin}-get>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-mib_paths>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-priv_pass>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-priv_protocol>> |<<string,string>>, one of `["des", "3des", "aes", "aes128", "aes192", "aes256"]`|No
+| <<plugins-{type}s-{plugin}-security_level>> |<<string,string>>, one of `["noAuthNoPriv", "authNoPriv", "authPriv"]`|No
+| <<plugins-{type}s-{plugin}-security_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-walk>> |<<array,array>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+[id="plugins-{type}s-{plugin}-get"]
+===== `get` 
+
+Use the `get` option to query for scalar values for the given OID(s).
+One or more OID(s) are specified as an array of strings of OID(s).
+
+* Value type is <<array,array>>
+* There is no default value for this setting
+
+Example
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"]
+    hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
+  }
+}
+-----
+
+[id="plugins-{type}s-{plugin}-hosts"]
+===== `hosts`
+
+The `hosts` option specifies the list of hosts to query the configured `get` and `walk` options.
+
+Each host definition is a hash and must define the `host` key and value.
+`host` must use the format `{tcp|udp}:{ip address}/{port}`, for example `host => "udp:127.0.0.1/161"`
+
+* Value type is <<array,array>>
+* There is no default value for this setting
+
+Each host definition can optionally include the following keys and values:
+
+* `community` the community string, default is `public`.
+* `version` `1`, `2c` or `3`, default is `2c`.
+* `retries` is the number of retries in case of failure, default is `2`.
+* `timeout` is the timeout in milliseconds with a default value of `1000`.
+
+*Specifying all hosts options*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0"]
+    hosts => [{host => "udp:127.0.0.1/161" community => "public" version => "2c"  retries => 2  timeout => 1000}]
+  }
+}
+-----
+
+*Specifying multiple hosts*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0"]
+    hosts => [{host => "udp:127.0.0.1/161" community => "public"}, {host => "udp:192.168.0.1/161" community => "private"}]
+  }
+}
+-----
+
+[id="plugins-{type}s-{plugin}-interval"]
+===== `interval` 
+
+The `interval` option specifies the polling interval in seconds.
+
+* Value type is <<number,number>>
+* Default value is `30`
+
+[id="plugins-{type}s-{plugin}-mib_paths"]
+===== `mib_paths` 
+
+The `mib_paths` option specifies the location of one or more imported MIB files. The value can be either a dir path containing
+the imported MIB `.dic` files or a file path to a single MIB `.dic` file.
+
+* Value type is <<path,path>>
+* There is no default value for this setting
+
+This plugin includes the IETF MIBs.
+If you require other MIBs, you need to import them. See <<plugins-{type}s-{plugin}-import-mibs>>.
+
+[id="plugins-{type}s-{plugin}-oid_root_skip"]
+===== `oid_root_skip` 
+
+The `oid_root_skip` option specifies the  number of OID root digits to ignore in event field name.
+For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the first 5 digits could be ignored by setting `oid_root_skip => 5`
+which would result in a field name "1.1.1.0". Similarly when a MIB is used an OID such
+"1.3.6.1.2.mib-2.system.sysDescr.0" would become "mib-2.system.sysDescr.0"
+
+* Value type is <<number,number>>
+* Default value is `0`
+
+[id="plugins-{type}s-{plugin}-walk"]
+===== `walk`
+
+Use the `walk` option to retrieve the subtree of information for the given OID(s).
+One or more OID(s) are specified as an array of strings of OID(s).
+
+* Value type is <<array,array>>
+* There is no default value for this setting
+
+Queries the subtree of information starting at the given OID(s).
+
+Example
+[source,ruby]
+-----
+  snmp {
+    walk => ["1.3.6.1.2.1.1"]
+    hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
+  }
+}
+-----
+
+==== SNMPv3 Authentication Options
+
+A **single user** can be configured and will be used for all defined SNMPv3 hosts.
+Multiple snmp input declarations will be needed if multiple SNMPv3 users are required.
+These options are required only if you are using SNMPv3.
+
+[id="plugins-{type}s-{plugin}-auth_pass"]
+===== `auth_pass`
+
+The `auth_pass` option specifies the SNMPv3 authentication passphrase or password
+
+* Value type is <<password,password>>
+* There is no default value for this setting
+
+[id="plugins-{type}s-{plugin}-auth_protocol"]
+===== `auth_protocol`
+
+The `auth_protocol` option specifies the SNMPv3 authentication protocol or type
+
+* Value can be any of: `md5`, `sha`, `sha2`, `hmac128sha224`, `hmac192sha256`, `hmac256sha384`, `hmac384sha512`
+* There is no default value for this setting
+
+[id="plugins-{type}s-{plugin}-priv_pass"]
+===== `priv_pass`
+
+The `priv_pass` option specifies the SNMPv3 encryption password
+
+* Value type is <<password,password>>
+* There is no default value for this setting
+
+[id="plugins-{type}s-{plugin}-priv_protocol"]
+===== `priv_protocol`
+
+The `priv_protocol` option specifies the SNMPv3 privacy/encryption protocol
+
+* Value can be any of: `des`, `3des`, `aes`, `aes128`, `aes192`, `aes256`
+* There is no default value for this setting
+
+[id="plugins-{type}s-{plugin}-security_name"]
+===== `security_name`
+
+The `security_name` option specifies the SNMPv3 security name or user name
+
+* Value type is <<string,string>>
+* There is no default value for this setting
+
+[id="plugins-{type}s-{plugin}-security_level"]
+===== `security_level`
+
+The `security_level` option specifies the SNMPv3 security level between Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy
+
+* Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
+* There is no default value for this setting
+
+==== More configuration examples
+
+*Using both `get` and `walk` in the same poll cycle for each host(s)*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"]
+    walk => ["1.3.6.1.2.1.1"]
+    hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
+  }
+}
+-----
+
+*Specifying all global options* 
+
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0"]
+    hosts => [{host => "udp:127.0.0.1/161"}]
+    
+    mib_paths => ["path/to/converted/mibfile.dic"]
+    oid_root_skip => 0
+    interval => 30
+  }
+}
+-----
+
+==== Polled host information
+
+All the polled host information is stored in the event `@metadata`:
+
+* `[@metadata][host_protocol]` : `udp` or `tcp`
+* `[@metadata][host_address]` : host address for example `127.0.0.1`
+* `[@metadata][host_port]` : host port (for example `161`)
+* `[@metadata][host_community]` : community string for example `public`
+
+
+By default, a `host` field is added to the event with the `[@metadata][host_address]` value.
+
+[source,ruby]
+-----
+config :add_field, :validate => :hash, :default => { "host" => "%{[@metadata][host_address]}" }
+-----
+
+You can customize the format and content of the `host` field by specifying an alternate `add_field`. 
+
+Example
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0"]
+    hosts => [{host => "udp:127.0.0.1/161"}]
+    
+    add_field => {host => "%{[@metadata][host_protocol]}:%{[@metadata][host_address]}/%{[@metadata][host_port]},%{[@metadata][host_community]}"}
+  }
+}
+-----
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:default_codec!:

--- a/docs/plugins/inputs/snmp.asciidoc
+++ b/docs/plugins/inputs/snmp.asciidoc
@@ -1,7 +1,7 @@
 :plugin: snmp
 :type: input
 :default_plugin: 1
-:default_codec: plain
+:no_codec:
 
 // TO DO:  VERIFY default codec!
 
@@ -307,4 +307,4 @@ input {
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
+:no_codec!:

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.0
-:release_date: 2018-09-05
-:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v5.1.0/CHANGELOG.md
+:version: v5.2.0
+:release_date: 2018-10-24
+:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v5.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -84,6 +84,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|Yes
 | <<plugins-{type}s-{plugin}-proxy_protocol>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_cert>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_enable>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_extra_chain_certs>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
@@ -141,7 +142,17 @@ http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-SSL certificate path
+Path to certificate in PEM format. This certificate will be presented
+to the connecting clients.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_extra_chain_certs`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+Validate client certificate or certificate chain against these authorities.
+You can define multiple files or paths. All the certificates will be read and added to the trust store.
 
 [id="plugins-{type}s-{plugin}-ssl_enable"]
 ===== `ssl_enable` 
@@ -157,8 +168,9 @@ Enable SSL (must be set for other `ssl_` options to take effect).
   * Value type is <<array,array>>
   * Default value is `[]`
 
-An Array of extra X509 certificates to be added to the certificate chain.
-Useful when the CA chain is not necessary in the system store.
+An Array of paths to extra X509 certificates.
+These are used together with the certificate to construct the certificate chain
+presented to the client.
 
 [id="plugins-{type}s-{plugin}-ssl_key"]
 ===== `ssl_key` 
@@ -166,7 +178,7 @@ Useful when the CA chain is not necessary in the system store.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-SSL key path
+The path to the private key corresponding to the specified certificate (PEM format).
 
 [id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
 ===== `ssl_key_passphrase` 
@@ -174,7 +186,7 @@ SSL key path
   * Value type is <<password,password>>
   * Default value is `nil`
 
-SSL key passphrase
+SSL key passphrase for the private key.
 
 [id="plugins-{type}s-{plugin}-ssl_verify"]
 ===== `ssl_verify` 

--- a/docs/plugins/outputs/appsearch.asciidoc
+++ b/docs/plugins/outputs/appsearch.asciidoc
@@ -1,7 +1,7 @@
 :plugin: appsearch
 :type: output
 :default_plugin: 1
-:default_codec: plain
+:no_codec:
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -100,4 +100,4 @@ Where to move the timestamp value that all Logstash events contain in the `@time
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
+:no_codec!:

--- a/docs/plugins/outputs/appsearch.asciidoc
+++ b/docs/plugins/outputs/appsearch.asciidoc
@@ -1,0 +1,103 @@
+:plugin: appsearch
+:type: output
+:default_plugin: 1
+:default_codec: plain
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.0.0.beta1
+:release_date: 2018-10-23
+:changelog_url: https://github.com/logstash-plugins/logstash-output-appsearch/blob/v1.0.0.beta1/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== App Search output plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This output lets you send events to Elastic's App Search solution.
+On receiving a batch of events from the Logstash pipeline, the plugin
+will convert the events into documents and use App Search's bulk API
+to index multiple events in one request.
+
+Because App Search doesn't allow fields to being with `@timestamp`,
+by default the fields `@timestamp` and `@version` will be removed from
+each event prior to being sent to App Search. If you want to keep
+the `@timestamp` field you can use the
+<<plugins-{type}s-{plugin}-timestamp_destination,timestamp_destination>> option
+to store this timestamp in a different field.
+
+This gem does not support codec customization.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== AppSearch Output Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-engine>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-timestamp_destination>> |<<string,string>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-api_key"]
+===== `api_key`
+
+  * Value type is <<password,password>>
+  * There is no default value
+
+The private API Key with write permissions. Visit the https://app.swiftype.com/as/credentials[Credentials] in the App Search dashboard to find the key associated with your account.
+
+[id="plugins-{type}s-{plugin}-document_id"]
+===== `document_id`
+
+  * Value type is <<string,string>>
+  * There is no default value
+
+What to use as id for app search documents. This can be an interpolated value
+like `myapp-%{sequence_id}`. Reusing ids will cause documents to be rewritten.
+
+[id="plugins-{type}s-{plugin}-engine"]
+===== `engine`
+
+  * Value type is <<string,string>>
+  * There is no default value
+
+The Engine name. Engine is your search engine created in App Search, an information repository that includes the indexed document records.
+
+[id="plugins-{type}s-{plugin}-host"]
+===== `host`
+
+  * Value type is <<string,string>>
+  * There is no default value
+
+The hostname of the App Search API that is associated with your App Search account.
+
+[id="plugins-{type}s-{plugin}-timestamp_destination"]
+===== `timestamp_destination`
+
+  * Value type is <<string,string>>
+  * There is no default value
+
+Where to move the timestamp value that all Logstash events contain in the `@timestamp` field. Since App Search doesn't support fields starting with `@timestamp`, by default this field will be deleted. If you wish to keep it, set this value to the name of the field where `@timestamp` will be copied to.
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:default_codec!:

--- a/docs/plugins/outputs/google_bigquery.asciidoc
+++ b/docs/plugins/outputs/google_bigquery.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.0
-:release_date: 2018-09-07
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.0/CHANGELOG.md
+:version: v4.1.1
+:release_date: 2018-10-25
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -24,25 +24,24 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ===== Summary
 
-This plugin uploads events to Google BigQuery using the streaming API
-so data can become available nearly immediately.
+This Logstash plugin uploads events to Google BigQuery using the streaming API
+so data can become available to query nearly immediately.
 
 You can configure it to flush periodically, after N events or after
 a certain amount of data is ingested.
 
 ===== Environment Configuration
 
-You must enable BigQuery on your Google Cloud Storage (GCS) account and create a dataset to
+You must enable BigQuery on your Google Cloud account and create a dataset to
 hold the tables this plugin generates.
 
-You must also grant the service account this plugin uses access to
-the dataset.
+You must also grant the service account this plugin uses access to the dataset.
 
 You can use https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html[Logstash conditionals]
 and multiple configuration blocks to upload events with different structures.
 
 ===== Usage
-This is an example of logstash config:
+This is an example of Logstash config:
 
 [source,ruby]
 --------------------------
@@ -66,15 +65,18 @@ https://cloud.google.com/docs/authentication/production[Application Default Cred
 
 ===== Considerations
 
-* There is a small fee to insert data into BigQuery using the streaming API
+* There is a small fee to insert data into BigQuery using the streaming API.
 * This plugin buffers events in-memory, so make sure the flush configurations are appropriate
   for your use-case and consider using
-  https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues]
+  https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues].
+* Events will be flushed when <<plugins-{type}s-{plugin}-batch_size>>, <<plugins-{type}s-{plugin}-batch_size_bytes>>, or <<plugins-{type}s-{plugin}-flush_interval_secs>> is met, whatever comes first.
+  If you notice a delay in your processing or low throughput, try adjusting those settings.
 
 ===== Additional Resources
 
 * https://cloud.google.com/docs/authentication/production[Application Default Credentials (ADC) Overview]
 * https://cloud.google.com/bigquery/[BigQuery Introduction]
+* https://cloud.google.com/bigquery/quota[BigQuery Quotas and Limits]
 * https://cloud.google.com/bigquery/docs/schemas[BigQuery Schema Formats and Types]
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -121,7 +123,12 @@ added[4.0.0]
   * Value type is <<number,number>>
   * Default value is `128`
 
-The number of messages to upload at a single time. (< 1000, default: 128)
+The maximum number of messages to upload at a single time.
+This number must be < 10,000.
+Batching can increase performance and throughput to a point, but at the cost of per-request latency.
+Too few rows per request and the overhead of each request can make ingestion inefficient.
+Too many rows per request and the throughput may drop.
+BigQuery recommends using about 500 rows per request, but experimentation with representative data (schema and data sizes) will help you determine the ideal batch size.
 
 [id="plugins-{type}s-{plugin}-batch_size_bytes"]
 ===== `batch_size_bytes`
@@ -131,10 +138,11 @@ added[4.0.0]
   * Value type is <<number,number>>
   * Default value is `1_000_000`
 
-An approximate number of bytes to upload as part of a batch. Default: 1MB
+An approximate number of bytes to upload as part of a batch.
+This number should be < 10MB or inserts may fail.
 
 [id="plugins-{type}s-{plugin}-csv_schema"]
-===== `csv_schema` 
+===== `csv_schema`
 
   * Value type is <<string,string>>
   * Default value is `nil`
@@ -143,7 +151,7 @@ Schema for log data. It must follow the format `name1:type1(,name2:type2)*`.
 For example, `path:STRING,status:INTEGER,score:FLOAT`.
 
 [id="plugins-{type}s-{plugin}-dataset"]
-===== `dataset` 
+===== `dataset`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -152,7 +160,7 @@ For example, `path:STRING,status:INTEGER,score:FLOAT`.
 The BigQuery dataset the tables for the events will be added to.
 
 [id="plugins-{type}s-{plugin}-date_pattern"]
-===== `date_pattern` 
+===== `date_pattern`
 
   * Value type is <<string,string>>
   * Default value is `"%Y-%m-%dT%H:00"`
@@ -188,15 +196,16 @@ transparently upload to a GCS bucket.
 Files names follow the pattern `[table name]-[UNIX timestamp].log`
 
 [id="plugins-{type}s-{plugin}-flush_interval_secs"]
-===== `flush_interval_secs` 
+===== `flush_interval_secs`
 
   * Value type is <<number,number>>
   * Default value is `5`
 
-Uploads all data this often even if other upload criteria aren't met. Default: 5s
+Uploads all data this often even if other upload criteria aren't met.
+
 
 [id="plugins-{type}s-{plugin}-ignore_unknown_values"]
-===== `ignore_unknown_values` 
+===== `ignore_unknown_values`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -223,12 +232,12 @@ added[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type
   * Value type is <<string,string>>
   * Default value is `nil`
 
-If logstash is running within Google Compute Engine, the plugin can use
+If Logstash is running within Google Compute Engine, the plugin can use
 GCE's Application Default Credentials. Outside of GCE, you will need to
 specify a Service Account JSON key file.
 
 [id="plugins-{type}s-{plugin}-json_schema"]
-===== `json_schema` 
+===== `json_schema`
 
   * Value type is <<hash,hash>>
   * Default value is `nil`
@@ -288,7 +297,7 @@ Please use one of the following mechanisms:
     `gcloud iam service-accounts keys create key.json --iam-account my-sa-123@my-project-123.iam.gserviceaccount.com`
 
 [id="plugins-{type}s-{plugin}-project_id"]
-===== `project_id` 
+===== `project_id`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -315,7 +324,7 @@ Insert all valid rows of a request, even if invalid rows exist.
 The default value is false, which causes the entire request to fail if any invalid rows exist.
 
 [id="plugins-{type}s-{plugin}-table_prefix"]
-===== `table_prefix` 
+===== `table_prefix`
 
   * Value type is <<string,string>>
   * Default value is `"logstash"`
@@ -324,7 +333,7 @@ BigQuery table ID prefix to be used when creating new tables for log data.
 Table name will be `<table_prefix><table_separator><date>`
 
 [id="plugins-{type}s-{plugin}-table_separator"]
-===== `table_separator` 
+===== `table_separator`
 
   * Value type is <<string,string>>
   * Default value is `"_"`


### PR DESCRIPTION
Generated plugins from #631 with `no_codec` tags added for `input-snmp` and `output-appsearch`