### PR TITLE
Rename output-appsearch to output-elastic_app_search

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -13,7 +13,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-csv,csv>> | Writes events to disk in a delimited format | https://github.com/logstash-plugins/logstash-output-csv[logstash-output-csv]
 | <<plugins-outputs-datadog,datadog>> | Sends events to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog[logstash-output-datadog]
 | <<plugins-outputs-datadog_metrics,datadog_metrics>> | Sends metrics to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog_metrics[logstash-output-datadog_metrics]
-| <<plugins-outputs-elastic_app_search,elastic_app_search>> | Sends events to the Elastic App Search solution | https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch]
+| <<plugins-outputs-elastic_app_search,elastic_app_search>> | Sends events to the Elastic App Search solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-output-elastic_app_search]
 | <<plugins-outputs-elasticsearch,elasticsearch>> | Stores logs in Elasticsearch | https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch]
 | <<plugins-outputs-email,email>> | Sends email to a specified address when output is received | https://github.com/logstash-plugins/logstash-output-email[logstash-output-email]
 | <<plugins-outputs-exec,exec>> | Runs a command for a matching event | https://github.com/logstash-plugins/logstash-output-exec[logstash-output-exec]

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -7,13 +7,13 @@ The following output plugins are available below. For a list of Elastic supporte
 
 |=======================================================================
 | Plugin | Description | Github repository
-| <<plugins-outputs-appsearch,appsearch>> | Sends events to the Elastic App Search solution | https://github.com/logstash-plugins/logstash-output-appsearch[logstash-output-appsearch]
 | <<plugins-outputs-boundary,boundary>> | Sends annotations to Boundary based on Logstash events | https://github.com/logstash-plugins/logstash-output-boundary[logstash-output-boundary]
 | <<plugins-outputs-circonus,circonus>> | Sends annotations to Circonus based on Logstash events | https://github.com/logstash-plugins/logstash-output-circonus[logstash-output-circonus]
 | <<plugins-outputs-cloudwatch,cloudwatch>> | Aggregates and sends metric data to AWS CloudWatch | https://github.com/logstash-plugins/logstash-output-cloudwatch[logstash-output-cloudwatch]
 | <<plugins-outputs-csv,csv>> | Writes events to disk in a delimited format | https://github.com/logstash-plugins/logstash-output-csv[logstash-output-csv]
 | <<plugins-outputs-datadog,datadog>> | Sends events to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog[logstash-output-datadog]
 | <<plugins-outputs-datadog_metrics,datadog_metrics>> | Sends metrics to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog_metrics[logstash-output-datadog_metrics]
+| <<plugins-outputs-elastic_app_search,elastic_app_search>> | Sends events to the Elastic App Search solution | https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch]
 | <<plugins-outputs-elasticsearch,elasticsearch>> | Stores logs in Elasticsearch | https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch]
 | <<plugins-outputs-email,email>> | Sends email to a specified address when output is received | https://github.com/logstash-plugins/logstash-output-email[logstash-output-email]
 | <<plugins-outputs-exec,exec>> | Runs a command for a matching event | https://github.com/logstash-plugins/logstash-output-exec[logstash-output-exec]
@@ -61,9 +61,6 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-zabbix,zabbix>> | Sends events to a Zabbix server | https://github.com/logstash-plugins/logstash-output-zabbix[logstash-output-zabbix]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-appsearch/edit/master/docs/index.asciidoc
-include::outputs/appsearch.asciidoc[]
-
 :edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/docs/index.asciidoc
 include::outputs/boundary.asciidoc[]
 
@@ -81,6 +78,9 @@ include::outputs/datadog.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/edit/master/docs/index.asciidoc
+include::outputs/elastic_app_search.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/master/docs/index.asciidoc
 include::outputs/elasticsearch.asciidoc[]


### PR DESCRIPTION
Update doc to rename appsearch plugin. 
