### PR TITLE
Fix tcp ssl_certificate_authorities documentation header

### DIFF
--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -146,7 +146,7 @@ Path to certificate in PEM format. This certificate will be presented
 to the connecting clients.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
-===== `ssl_extra_chain_certs`
+===== `ssl_certificate_authorities`
 
   * Value type is <<array,array>>
   * Default value is `[]`


### PR DESCRIPTION
related to https://github.com/logstash-plugins/logstash-input-tcp/pull/130/files

This should be merged in master, 6.x and 6.5