### PR TITLE
Fix syntax in dictionary example for filter-translate in 6.2

### DIFF
--- a/docs/plugins/filters/translate.asciidoc
+++ b/docs/plugins/filters/translate.asciidoc
@@ -94,9 +94,9 @@ Example:
     filter {
       translate {
         dictionary => { 
-          "100"         => "Continue",
-          "101"         => "Switching Protocols",
-          "merci"       => "thank you",
+          "100"         => "Continue"
+          "101"         => "Switching Protocols"
+          "merci"       => "thank you"
           "old version" => "new version"
         }
       }


### PR DESCRIPTION
Remove trailing commas from `dictionary` example