### PR TITLE
Fix syntax in dictionary example for filter-translate

### DIFF
--- a/docs/plugins/filters/translate.asciidoc
+++ b/docs/plugins/filters/translate.asciidoc
@@ -92,9 +92,9 @@ Example:
 [source,ruby]
     filter {
       translate {
-        dictionary => [ "100", "Continue",
-                        "101", "Switching Protocols",
-                        "merci", "thank you",
+        dictionary => [ "100", "Continue"
+                        "101", "Switching Protocols"
+                        "merci", "thank you"
                         "old version", "new version" ]
       }
     }


### PR DESCRIPTION
Remove trailing commas from dictionary example