### PR TITLE
Updated Plugin docs for 6.6 plus new TOC entries for filter-http and filter-memcached

### DIFF
--- a/docs/plugins/codecs/cloudtrail.asciidoc
+++ b/docs/plugins/codecs/cloudtrail.asciidoc
@@ -1,0 +1,45 @@
+:plugin: cloudtrail
+:type: codec
+:default_plugin: 0
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.0.5
+:release_date: 2018-06-01
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/blob/v3.0.5/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Cloudtrail codec plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This is the base class for logstash codecs.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Cloudtrail Codec Configuration Options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+|=======================================================================
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-charset"]
+===== `charset` 
+
+  * Value can be any of: `ASCII-8BIT`, `UTF-8`, `US-ASCII`, `Big5`, `Big5-HKSCS`, `Big5-UAO`, `CP949`, `Emacs-Mule`, `EUC-JP`, `EUC-KR`, `EUC-TW`, `GB2312`, `GB18030`, `GBK`, `ISO-8859-1`, `ISO-8859-2`, `ISO-8859-3`, `ISO-8859-4`, `ISO-8859-5`, `ISO-8859-6`, `ISO-8859-7`, `ISO-8859-8`, `ISO-8859-9`, `ISO-8859-10`, `ISO-8859-11`, `ISO-8859-13`, `ISO-8859-14`, `ISO-8859-15`, `ISO-8859-16`, `KOI8-R`, `KOI8-U`, `Shift_JIS`, `UTF-16BE`, `UTF-16LE`, `UTF-32BE`, `UTF-32LE`, `Windows-31J`, `Windows-1250`, `Windows-1251`, `Windows-1252`, `IBM437`, `IBM737`, `IBM775`, `CP850`, `IBM852`, `CP852`, `IBM855`, `CP855`, `IBM857`, `IBM860`, `IBM861`, `IBM862`, `IBM863`, `IBM864`, `IBM865`, `IBM866`, `IBM869`, `Windows-1258`, `GB1988`, `macCentEuro`, `macCroatian`, `macCyrillic`, `macGreek`, `macIceland`, `macRoman`, `macRomania`, `macThai`, `macTurkish`, `macUkraine`, `CP950`, `CP951`, `IBM037`, `stateless-ISO-2022-JP`, `eucJP-ms`, `CP51932`, `EUC-JIS-2004`, `GB12345`, `ISO-2022-JP`, `ISO-2022-JP-2`, `CP50220`, `CP50221`, `Windows-1256`, `Windows-1253`, `Windows-1255`, `Windows-1254`, `TIS-620`, `Windows-874`, `Windows-1257`, `MacJapanese`, `UTF-7`, `UTF8-MAC`, `UTF-16`, `UTF-32`, `UTF8-DoCoMo`, `SJIS-DoCoMo`, `UTF8-KDDI`, `SJIS-KDDI`, `ISO-2022-JP-KDDI`, `stateless-ISO-2022-JP-KDDI`, `UTF8-SoftBank`, `SJIS-SoftBank`, `BINARY`, `CP437`, `CP737`, `CP775`, `IBM850`, `CP857`, `CP860`, `CP861`, `CP862`, `CP863`, `CP864`, `CP865`, `CP866`, `CP869`, `CP1258`, `Big5-HKSCS:2008`, `ebcdic-cp-us`, `eucJP`, `euc-jp-ms`, `EUC-JISX0213`, `eucKR`, `eucTW`, `EUC-CN`, `eucCN`, `CP936`, `ISO2022-JP`, `ISO2022-JP2`, `ISO8859-1`, `ISO8859-2`, `ISO8859-3`, `ISO8859-4`, `ISO8859-5`, `ISO8859-6`, `CP1256`, `ISO8859-7`, `CP1253`, `ISO8859-8`, `CP1255`, `ISO8859-9`, `CP1254`, `ISO8859-10`, `ISO8859-11`, `CP874`, `ISO8859-13`, `CP1257`, `ISO8859-14`, `ISO8859-15`, `ISO8859-16`, `CP878`, `MacJapan`, `ASCII`, `ANSI_X3.4-1968`, `646`, `CP65000`, `CP65001`, `UTF-8-MAC`, `UTF-8-HFS`, `UCS-2BE`, `UCS-4BE`, `UCS-4LE`, `CP932`, `csWindows31J`, `SJIS`, `PCK`, `CP1250`, `CP1251`, `CP1252`, `external`, `locale`
+  * Default value is `"UTF-8"`
+
+
+
+

--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.2.0
-:release_date: 2018-10-28
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.2.0/CHANGELOG.md
+:version: v3.14.1
+:release_date: 2018-05-23
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v3.14.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -31,34 +31,30 @@ This codec supports:
 * Netflow v9
 * IPFIX
 
-The following Netflow/IPFIX exporters have been seen and tested with the most recent version of the Netflow Codec:
+The following Netflow/IPFIX exporters are known to work with the most recent version of the netflow codec:
 
 [cols="6,^2,^2,^2,12",options="header"]
 |===========================================================================================
 |Netflow exporter         | v5 | v9 | IPFIX | Remarks
-|Barracuda Firewall       |    |    |   y   | With support for Extended Uniflow
-|Cisco ACI                |    | y  |       |
+|Barracuda Firewall       |    |    |   y   |
 |Cisco ASA                |    | y  |       |  
-|Cisco ASR 1k             |    |    |   N   | Fails because of duplicate fields
+|Cisco ASR 1k             |    |    |   n   | Fails because of duplicate fields
 |Cisco ASR 9k             |    | y  |       |  
 |Cisco IOS 12.x           |    | y  |       |  
-|Cisco ISR w/ HSL         |    | N  |       | Fails because of duplicate fields, see: https://github.com/logstash-plugins/logstash-codec-netflow/issues/93
+|Cisco ISR w/ HSL         |    | n  |       | Fails because of duplicate fields, see: https://github.com/logstash-plugins/logstash-codec-netflow/issues/93
 |Cisco WLC                |    | y  |       |
 |Citrix Netscaler         |    |    |   y   | Still some unknown fields, labeled netscalerUnknown<id>
 |fprobe                   |  y |    |       |
 |Fortigate FortiOS        |    | y  |       |
 |Huawei Netstream         |    | y  |       |
 |ipt_NETFLOW              |  y | y  |   y   |
-|IXIA packet broker       |    |    |   y   |
-|Juniper MX               |  y |    |   y   | SW > 12.3R8. Fails to decode IPFIX from Junos 16.1 due to duplicate field names which we currently don't support.
+|Juniper MX80             |  y |    |       | SW > 12.3R8
 |Mikrotik                 |  y |    |   y   | http://wiki.mikrotik.com/wiki/Manual:IP/Traffic_Flow
 |nProbe                   |  y | y  |   y   | L7 DPI fields now also supported
 |Nokia BRAS               |    |    |   y   |
-|OpenBSD pflow            |  y | N  |   y   | http://man.openbsd.org/OpenBSD-current/man4/pflow.4
-|Riverbed                 |    | N  |       | Not supported due to field ID conflicts. Workaround available in the definitions directory over at Elastiflow <https://github.com/robcowart/elastiflow>
+|OpenBSD pflow            |  y | n  |   y   | http://man.openbsd.org/OpenBSD-current/man4/pflow.4
 |Sandvine Procera PacketLogic| |    |   y   | v15.1
 |Softflowd                |  y | y  |   y   | IPFIX supported in https://github.com/djmdjm/softflowd
-|Sophos UTM               |    |    |   y   |
 |Streamcore Streamgroomer |    | y  |       |
 |Palo Alto PAN-OS         |    | y  |       |
 |Ubiquiti Edgerouter X    |    | y  |       | With MPLS labels

--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.2.0
-:release_date: 2018-10-28
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.2.0/CHANGELOG.md
+:version: v3.14.1
+:release_date: 2018-05-23
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v3.14.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -31,7 +31,7 @@ This codec supports:
 * Netflow v9
 * IPFIX
 
-The following Netflow/IPFIX exporters have been seen and tested with the most recent version of the Netflow Codec:
+The following Netflow/IPFIX exporters are known to work with the most recent version of the netflow codec:
 
 [cols="6,^2,^2,^2,12",options="header"]
 |===========================================================================================

--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.14.1
-:release_date: 2018-05-23
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v3.14.1/CHANGELOG.md
+:version: v4.2.0
+:release_date: 2018-10-28
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -31,7 +31,7 @@ This codec supports:
 * Netflow v9
 * IPFIX
 
-The following Netflow/IPFIX exporters are known to work with the most recent version of the netflow codec:
+The following Netflow/IPFIX exporters have been seen and tested with the most recent version of the Netflow Codec:
 
 [cols="6,^2,^2,^2,12",options="header"]
 |===========================================================================================

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -26,12 +26,14 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-fingerprint,fingerprint>> | Fingerprints fields by replacing values with a consistent hash | https://github.com/logstash-plugins/logstash-filter-fingerprint[logstash-filter-fingerprint]
 | <<plugins-filters-geoip,geoip>> | Adds geographical information about an IP address | https://github.com/logstash-plugins/logstash-filter-geoip[logstash-filter-geoip]
 | <<plugins-filters-grok,grok>> | Parses unstructured event data into fields | https://github.com/logstash-plugins/logstash-filter-grok[logstash-filter-grok]
+| <<plugins-filters-http,http>> | Provides integration with external data in Memcached | https://github.com/logstash-plugins/logstash-filter-http[logstash-filter-http]
 | <<plugins-filters-i18n,i18n>> | Removes special characters from a field | https://github.com/logstash-plugins/logstash-filter-i18n[logstash-filter-i18n]
 | <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-filter-jdbc_static[logstash-filter-jdbc_static]
 | <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-filter-jdbc_streaming[logstash-filter-jdbc_streaming]
 | <<plugins-filters-json,json>> | Parses JSON events | https://github.com/logstash-plugins/logstash-filter-json[logstash-filter-json]
 | <<plugins-filters-json_encode,json_encode>> | Serializes a field to JSON | https://github.com/logstash-plugins/logstash-filter-json_encode[logstash-filter-json_encode]
 | <<plugins-filters-kv,kv>> | Parses key-value pairs | https://github.com/logstash-plugins/logstash-filter-kv[logstash-filter-kv]
+| <<plugins-filters-memcached,memcached>> | Provides integration with external web services/REST APIs | https://github.com/logstash-plugins/logstash-filter-memcached[logstash-filter-memcached]
 | <<plugins-filters-metricize,metricize>> | Takes complex events containing a number of metrics and splits these up into multiple events, each holding a single metric | https://github.com/logstash-plugins/logstash-filter-metricize[logstash-filter-metricize]
 | <<plugins-filters-metrics,metrics>> | Aggregates metrics | https://github.com/logstash-plugins/logstash-filter-metrics[logstash-filter-metrics]
 | <<plugins-filters-mutate,mutate>> | Performs mutations on fields | https://github.com/logstash-plugins/logstash-filter-mutate[logstash-filter-mutate]
@@ -105,6 +107,12 @@ include::filters/geoip.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/docs/index.asciidoc
 include::filters/grok.asciidoc[]
 
+
+:edit_url: https://github.com/logstash-plugins/logstash-filter-http/edit/master/docs/index.asciidoc
+include::filters/http.asciidoc[]
+
+
+
 :edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
 
@@ -122,6 +130,9 @@ include::filters/json_encode.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/docs/index.asciidoc
 include::filters/kv.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-filter-memcached/edit/master/docs/index.asciidoc
+include::filters/memcached.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/docs/index.asciidoc
 include::filters/metricize.asciidoc[]

--- a/docs/plugins/filters/cipher.asciidoc
+++ b/docs/plugins/filters/cipher.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.1
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-cipher/blob/v3.0.1/CHANGELOG.md
+:version: v4.0.0
+:release_date: 2019-01-11
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-cipher/blob/v4.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/elasticsearch.asciidoc
+++ b/docs/plugins/filters/elasticsearch.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.4.0
-:release_date: 2018-09-14
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.4.0/CHANGELOG.md
+:version: v3.6.0
+:release_date: 2018-11-30
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.6.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/fingerprint.asciidoc
+++ b/docs/plugins/filters/fingerprint.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.0
-:release_date: 2018-06-20
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/blob/v3.2.0/CHANGELOG.md
+:version: v3.2.1
+:release_date: 2018-11-23
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/blob/v3.2.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/http.asciidoc
+++ b/docs/plugins/filters/http.asciidoc
@@ -1,14 +1,13 @@
 :plugin: http
-:type: output
+:type: filter
 :default_plugin: 1
-:default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.2.3
-:release_date: 2018-11-27
-:changelog_url: https://github.com/logstash-plugins/logstash-output-http/blob/v5.2.3/CHANGELOG.md
+:version: v1.0.0
+:release_date: 2019-01-11
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-http/blob/v1.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -16,26 +15,33 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Http output plugin
+=== HTTP filter plugin
 
 include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-This output lets you send events to a generic HTTP(S) endpoint.
-
-This output will execute up to 'pool_max' requests in parallel for performance.
-Consider this when tuning this plugin for performance.
-
-Additionally, note that when parallel execution is used strict ordering of events is not
-guaranteed!
-
-Beware, this gem does not yet support codecs. Please use the 'format' option for now.
+The HTTP filter provides integration with external web services/REST APIs.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Http Output Configuration Options
+==== HTTP Filter Configuration Options
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-body>> | String, Array or Hash |No
+| <<plugins-{type}s-{plugin}-body_format>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-query>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-target_body>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-target_headers>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-verb>> |<<string,string>>|No
+|=======================================================================
+
+There are also multiple configuration options related to the HTTP connectivity:
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -45,42 +51,100 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-client_cert>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-client_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-content_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-format>> |<<string,string>>, one of `["json", "json_batch", "form", "message"]`|No
-| <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
-| <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-http_method>> |<<string,string>>, one of `["put", "post", "patch", "delete", "get", "head"]`|Yes
-| <<plugins-{type}s-{plugin}-ignorable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-keystore_type>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-mapping>> |<<hash,hash>>|No
-| <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-pool_max_per_route>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-proxy>> |<<,>>|No
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-retry_failed>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-retryable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-user>> |<<string,string>>|no
 | <<plugins-{type}s-{plugin}-validate_after_inactivity>> |<<number,number>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
-output plugins.
+filter plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-body"]
+===== `body`
+
+  * Value type can be a <<string,string>>, <<number,number>>, <<array,array>> or <<hash,hash>>
+  * There is no default value
+
+The body of the HTTP request to be sent.
+
+[id="plugins-{type}s-{plugin}-body_format"]
+===== `body_format`
+
+  * Value type can be either `"json"` or `"text"`
+  * Default value is `"text"`
+
+If set to `"json"` the body will be serialized as JSON. Otherwise it is sent as is.
+
+[id="plugins-{type}s-{plugin}-headers"]
+===== `headers`
+
+  * Value type is <<hash,hash>>
+  * There is no default value
+
+The HTTP headers to be sent in the request. Both the names of the headers and their
+values can reference values from event fields.
+
+[id="plugins-{type}s-{plugin}-query"]
+===== `query`
+
+  * Value type is <<hash,hash>>
+  * There is no default value
+
+Define the query string parameters (key-value pairs) to be sent in the HTTP request.
+
+[id="plugins-{type}s-{plugin}-target_body"]
+===== `target_body`
+
+  * Value type is <<hash,hash>>
+  * There is no default value
+
+Define the target field for placing the body of the HTTP response. If this setting is omitted, the data will be stored in the "body" field.
+
+[id="plugins-{type}s-{plugin}-target_headers"]
+===== `target_headers`
+
+  * Value type is <<hash,hash>>
+  * There is no default value
+
+Define the target field for placing the headers of the HTTP response. If this setting is omitted, the data will be stored in the "headers" field.
+
+[id="plugins-{type}s-{plugin}-url"]
+===== `url`
+
+  * Value type is <<string,string>>
+  * There is no default value
+
+The URL to send the request to. The value can be fetched from event fields.
+
+[id="plugins-{type}s-{plugin}-verb"]
+===== `verb`
+
+  * Value type can be either `"GET"`, `"HEAD"`, `"PATCH"`, `"DELETE"`, `"POST"`
+  * Default value is `"GET"`
+
+The verb to be used for the HTTP request.
 
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-automatic_retries"]
-===== `automatic_retries` 
+===== `automatic_retries`
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -90,7 +154,7 @@ to zero if keepalive is enabled. Some servers incorrectly end keepalives early r
 Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
 [id="plugins-{type}s-{plugin}-cacert"]
-===== `cacert` 
+===== `cacert`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -98,7 +162,7 @@ Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and
 If you need to use a custom X.509 CA (.pem certs) specify the path to that here
 
 [id="plugins-{type}s-{plugin}-client_cert"]
-===== `client_cert` 
+===== `client_cert`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -106,7 +170,7 @@ If you need to use a custom X.509 CA (.pem certs) specify the path to that here
 If you'd like to use a client certificate (note, most people don't want this) set the path to the x509 cert here
 
 [id="plugins-{type}s-{plugin}-client_key"]
-===== `client_key` 
+===== `client_key`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -114,29 +178,15 @@ If you'd like to use a client certificate (note, most people don't want this) se
 If you're using a client certificate specify the path to the encryption key here
 
 [id="plugins-{type}s-{plugin}-connect_timeout"]
-===== `connect_timeout` 
+===== `connect_timeout`
 
   * Value type is <<number,number>>
   * Default value is `10`
 
 Timeout (in seconds) to wait for a connection to be established. Default is `10s`
 
-[id="plugins-{type}s-{plugin}-content_type"]
-===== `content_type` 
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-Content type
-
-If not specified, this defaults to the following:
-
-* if format is "json", "application/json"
-* if format is "json_batch", "application/json". Each Logstash batch of events will be concatenated into a single array and sent in one request.
-* if format is "form", "application/x-www-form-urlencoded"
-
 [id="plugins-{type}s-{plugin}-cookies"]
-===== `cookies` 
+===== `cookies`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -145,70 +195,15 @@ Enable cookie support. With this enabled the client will persist cookies
 across requests as a normal web browser would. Enabled by default
 
 [id="plugins-{type}s-{plugin}-follow_redirects"]
-===== `follow_redirects` 
+===== `follow_redirects`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 Should redirects be followed? Defaults to `true`
 
-[id="plugins-{type}s-{plugin}-format"]
-===== `format` 
-
-  * Value can be any of: `json`, `json_batch`, `form`, `message`
-  * Default value is `"json"`
-
-Set the format of the http body.
-
-If json_batch, each batch of events received by this output will be placed
-into a single JSON array and sent in one request. This is particularly useful
-for high throughput scenarios such as sending data between Logstash instaces.
-
-If form, then the body will be the mapping (or whole event) converted
-into a query parameter string, e.g. `foo=bar&baz=fizz...`
-
-If message, then the body will be the result of formatting the event according to message
-
-Otherwise, the event is sent as json.
-
-[id="plugins-{type}s-{plugin}-headers"]
-===== `headers` 
-
-  * Value type is <<hash,hash>>
-  * There is no default value for this setting.
-
-Custom headers to use
-format is `headers => ["X-My-Header", "%{host}"]`
-
-[id="plugins-{type}s-{plugin}-http_compression"]
-===== `http_compression`
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
-
-Enable request compression support. With this enabled the plugin will compress
-http requests using gzip.
-
-[id="plugins-{type}s-{plugin}-http_method"]
-===== `http_method` 
-
-  * This is a required setting.
-  * Value can be any of: `put`, `post`, `patch`, `delete`, `get`, `head`
-  * There is no default value for this setting.
-
-The HTTP Verb. One of "put", "post", "patch", "delete", "get", "head"
-
-[id="plugins-{type}s-{plugin}-ignorable_codes"]
-===== `ignorable_codes` 
-
-  * Value type is <<number,number>>
-  * There is no default value for this setting.
-
-If you would like to consider some non-2xx codes to be successes 
-enumerate them here. Responses returning these codes will be considered successes
-
 [id="plugins-{type}s-{plugin}-keepalive"]
-===== `keepalive` 
+===== `keepalive`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -217,7 +212,7 @@ Turn this on to enable HTTP keepalive support. We highly recommend setting `auto
 one with this to fix interactions with broken keepalive implementations.
 
 [id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore` 
+===== `keystore`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -225,7 +220,7 @@ one with this to fix interactions with broken keepalive implementations.
 If you need to use a custom keystore (`.jks`) specify that here. This does not work with .pem keys!
 
 [id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password` 
+===== `keystore_password`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -234,37 +229,23 @@ Specify the keystore password here.
 Note, most .jks files created with keytool require a password!
 
 [id="plugins-{type}s-{plugin}-keystore_type"]
-===== `keystore_type` 
+===== `keystore_type`
 
   * Value type is <<string,string>>
   * Default value is `"JKS"`
 
 Specify the keystore type here. One of `JKS` or `PKCS12`. Default is `JKS`
 
-[id="plugins-{type}s-{plugin}-mapping"]
-===== `mapping` 
+[id="plugins-{type}s-{plugin}-password"]
+===== `password`
 
-  * Value type is <<hash,hash>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
-This lets you choose the structure and parts of the event that are sent.
-
-
-For example:
-[source,ruby]
-   mapping => {"foo" => "%{host}"
-              "bar" => "%{type}"}
-
-[id="plugins-{type}s-{plugin}-message"]
-===== `message` 
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-
+Password to be used in conjunction with the username for HTTP authentication.
 
 [id="plugins-{type}s-{plugin}-pool_max"]
-===== `pool_max` 
+===== `pool_max`
 
   * Value type is <<number,number>>
   * Default value is `50`
@@ -272,7 +253,7 @@ For example:
 Max number of concurrent connections. Defaults to `50`
 
 [id="plugins-{type}s-{plugin}-pool_max_per_route"]
-===== `pool_max_per_route` 
+===== `pool_max_per_route`
 
   * Value type is <<number,number>>
   * Default value is `25`
@@ -280,7 +261,7 @@ Max number of concurrent connections. Defaults to `50`
 Max number of concurrent connections to a single host. Defaults to `25`
 
 [id="plugins-{type}s-{plugin}-proxy"]
-===== `proxy` 
+===== `proxy`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -292,42 +273,23 @@ If you'd like to use an HTTP proxy . This supports multiple configuration syntax
 3. Proxy host in form: `{url =>  'http://proxy.org:1234', user => 'username@host', password => 'password'}`
 
 [id="plugins-{type}s-{plugin}-request_timeout"]
-===== `request_timeout` 
+===== `request_timeout`
 
   * Value type is <<number,number>>
   * Default value is `60`
 
-This module makes it easy to add a very fully configured HTTP client to logstash
-based on [Manticore](https://github.com/cheald/manticore).
-For an example of its usage see https://github.com/logstash-plugins/logstash-input-http_poller
-Timeout (in seconds) for the entire request
-
-[id="plugins-{type}s-{plugin}-retry_failed"]
-===== `retry_failed` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-Set this to false if you don't want this output to retry failed requests
+Timeout (in seconds) for the entire request.
 
 [id="plugins-{type}s-{plugin}-retry_non_idempotent"]
-===== `retry_non_idempotent` 
+===== `retry_non_idempotent`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
 If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
 
-[id="plugins-{type}s-{plugin}-retryable_codes"]
-===== `retryable_codes` 
-
-  * Value type is <<number,number>>
-  * Default value is `[429, 500, 502, 503, 504]`
-
-If encountered as response codes this plugin will retry these requests
-
 [id="plugins-{type}s-{plugin}-socket_timeout"]
-===== `socket_timeout` 
+===== `socket_timeout`
 
   * Value type is <<number,number>>
   * Default value is `10`
@@ -335,7 +297,7 @@ If encountered as response codes this plugin will retry these requests
 Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 [id="plugins-{type}s-{plugin}-truststore"]
-===== `truststore` 
+===== `truststore`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -343,7 +305,7 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 If you need to use a custom truststore (`.jks`) specify that here. This does not work with .pem certs!
 
 [id="plugins-{type}s-{plugin}-truststore_password"]
-===== `truststore_password` 
+===== `truststore_password`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -352,37 +314,33 @@ Specify the truststore password here.
 Note, most .jks files created with keytool require a password!
 
 [id="plugins-{type}s-{plugin}-truststore_type"]
-===== `truststore_type` 
+===== `truststore_type`
 
   * Value type is <<string,string>>
   * Default value is `"JKS"`
 
 Specify the truststore type here. One of `JKS` or `PKCS12`. Default is `JKS`
 
-[id="plugins-{type}s-{plugin}-url"]
-===== `url` 
+[id="plugins-{type}s-{plugin}-user"]
+===== `user`
 
-  * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-URL to use
+Username to use with HTTP authentication for ALL requests. Note that you can also set this per-URL.
+If you set this you must also set the `password` option.
 
 [id="plugins-{type}s-{plugin}-validate_after_inactivity"]
-===== `validate_after_inactivity` 
+===== `validate_after_inactivity`
 
   * Value type is <<number,number>>
   * Default value is `200`
 
 How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
-You may want to set this lower, possibly to 0 if you get connection errors regularly
+# You may want to set this lower, possibly to 0 if you get connection errors regularly
 Quoting the Apache commons docs (this client is based Apache Commmons):
 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
 See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
 
-
-
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
-
-:default_codec!:

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -1,0 +1,140 @@
+:plugin: memcached
+:type: filter
+:default_plugin: 1
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v0.1.1
+:release_date: 2019-01-10
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-memcached/blob/v0.1.1/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Memcached filter plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The Memcached filter provides integration with external data in Memcached.
+
+It currently provides the following facilities:
+ - `get`: get values for one or more memcached keys and inject them into the event at the provided paths
+ - `set`: set values from the event to the corresponding memcached keys
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Memcached Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-namespace>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-get>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-set>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-ttl>> |<<number,number>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-hosts"]
+===== `hosts`
+
+  * Value type is <<array,array>>
+  * Default value is `localhost`
+
+The `hosts` parameter accepts an array of addresses corresponding to memcached instances.
+
+Hosts can be specified via FQDN (e.g., `example.com`), an IPV4 address (e.g., `123.45.67.89`), or an IPV6 address (e.g. `::1` or `2001:0db8:85a3:0000:0000:8a2e:0370:7334`).
+If your memcached host uses a non-standard port, the port can be specified by appending a colon (`:`) and the port number; to include a port with an IPv6 address, the address must first be wrapped in square-brackets (`[` and `]`), e.g., `[::1]:11211`.
+
+If more than one host is specified, requests will be distributed to the given hosts using a modulus of the CRC-32 checksum of each key.
+
+[id="plugins-{type}s-{plugin}-namespace"]
+===== `namespace`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+If specified, prefix all memcached keys with the given string followed by a colon (`:`); this is useful if all keys being used by this plugin share a common prefix.
+
+EXAMPLE:
+
+In the following configuration, we would GET `fruit:banana` and `fruit:apple` from memcached:
+----
+filter {
+  memcached {
+    namespace => "fruit"
+    get => {
+      "banana" => "[fruit-stats][banana]"
+      "apple"  => "[fruit-stats][apple]
+    }
+  }
+}
+----
+
+[id="plugins-{type}s-{plugin}-get"]
+===== `get`
+
+  * Value type is <<hash,hash>>
+  * There is no default value for this setting.
+
+If specified, get the values for the given keys from memcached, and store them in the corresponding fields on the event.
+
+  * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
+  * fields can be nested references
+
+----
+filter {
+  memcached {
+    get => {
+      "memcached-key-1" => "field1"
+      "memcached-key-2" => "[nested][field2]"
+    }
+  }
+}
+----
+
+[id="plugins-{type}s-{plugin}-set"]
+===== `set`
+
+  * Value type is <<hash,hash>>
+  * There is no default value for this setting.
+
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
+
+  * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
+  * fields can be nested references
+
+----
+filter {
+  memcached {
+    set => {
+      "field1"           => "memcached-key-1"
+      "[nested][field2]" => "memcached-key-2"
+    }
+  }
+}
+----
+
+[id="plugins-{type}s-{plugin}-ttl"]
+===== `ttl`
+
+For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+
+  * Value type is <<number,number>>
+  * The default value is `0` (no expiry)
+
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/filters/split.asciidoc
+++ b/docs/plugins/filters/split.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.6
-:release_date: 2017-12-11
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-split/blob/v3.1.6/CHANGELOG.md
+:version: v3.1.7
+:release_date: 2019-01-04
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-split/blob/v3.1.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -26,7 +26,7 @@ placing each value resulting from the split into a clone of the original
 event. The field being split can either be a string or an array.
 
 An example use case of this filter is for taking output from the
-<<plugins-inputs-exec,exec input plugin>> which emits one event for
+{logstash-ref}/plugins-inputs-exec.html[exec input plugin] which emits one event for
 the whole output of a command and splitting that output by newline -
 making each line an event.
 

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.6
-:release_date: 2018-07-27
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.1.6/CHANGELOG.md
+:version: v5.1.8
+:release_date: 2018-11-30
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.1.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.7
-:release_date: 2018-10-29
-:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.1.7/CHANGELOG.md
+:version: v4.1.9
+:release_date: 2018-12-19
+:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.1.9/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/gelf.asciidoc
+++ b/docs/plugins/inputs/gelf.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.1
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-gelf/blob/v3.1.1/CHANGELOG.md
+:version: v3.2.0
+:release_date: 2018-12-12
+:changelog_url: https://github.com/logstash-plugins/logstash-input-gelf/blob/v3.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/http.asciidoc
+++ b/docs/plugins/inputs/http.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.2
-:release_date: 2018-09-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-http/blob/v3.2.2/CHANGELOG.md
+:version: v3.2.4
+:release_date: 2018-11-30
+:changelog_url: https://github.com/logstash-plugins/logstash-input-http/blob/v3.2.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v8.2.0
-:release_date: 2018-09-27
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v8.2.0/CHANGELOG.md
+:version: v8.3.1
+:release_date: 2018-12-19
+:changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v8.3.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -24,7 +24,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This input will read events from a Kafka topic.
 
-This plugin uses Kafka Client 2.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need.
 
@@ -109,6 +109,7 @@ https://kafka.apache.org/documentation for more details.
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
 | <<plugins-{type}s-{plugin}-send_buffer_bytes>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-session_timeout_ms>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_endpoint_identification_algorithm>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_key_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_location>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
@@ -462,6 +463,15 @@ The size of the TCP send buffer (SO_SNDBUF) to use when sending data
 
 The timeout after which, if the `poll_timeout_ms` is not invoked, the consumer is marked dead
 and a rebalance operation is triggered for the group identified by `group_id`
+
+[id="plugins-{type}s-{plugin}-ssl_endpoint_identification_algorithm"]
+===== `ssl_endpoint_identification_algorithm`
+
+  * Value type is <<string,string>>
+  * Default value is `"https"`
+
+The endpoint identification algorithm, defaults to `"https"`. Set to empty string `""` to disable endpoint verification
+
 
 [id="plugins-{type}s-{plugin}-ssl_key_password"]
 ===== `ssl_key_password` 

--- a/docs/plugins/inputs/kinesis.asciidoc
+++ b/docs/plugins/inputs/kinesis.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.0.10
-:release_date: 2018-11-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.0.10/CHANGELOG.md
+:version: v2.0.11
+:release_date: 2019-01-04
+:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.0.11/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -48,8 +48,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-checkpoint_interval_seconds>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-kinesis_stream_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-metrics>> |<<string,string>>, one of `[nil, "cloudwatch"]`|No
-| <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-profile>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-role_arn>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-role_session_name>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -92,6 +94,16 @@ The kinesis stream name.
 Worker metric tracking. By default this is disabled, set it to "cloudwatch"
 to enable the cloudwatch integration in the Kinesis Client Library.
 
+[id="plugins-{type}s-{plugin}-profile"]
+===== `profile`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The AWS profile name for authentication.
+This ensures that the `~/.aws/credentials` AWS auth provider is used.
+By default this is empty and the default chain will be used.
+
 [id="plugins-{type}s-{plugin}-region"]
 ===== `region`
 
@@ -100,15 +112,24 @@ to enable the cloudwatch integration in the Kinesis Client Library.
 
 The AWS region for Kinesis, DynamoDB, and CloudWatch (if enabled)
 
-[id="plugins-{type}s-{plugin}-profile"]
-===== `profile`
+[id="plugins-{type}s-{plugin}-role_arn"]
+===== `role_arn`
 
   * Value type is <<string,string>>
-  * Default value is `nil`
+  * There is no default value for this setting.
 
-The AWS profile name for authentication.
-This ensures that the `~/.aws/credentials` AWS auth provider is used.
-By default this is empty and the default chain will be used.
+The AWS role to assume. This can be used, for example, to access a Kinesis stream in a different AWS
+account. This role will be assumed after the default credentials or profile credentials are created. By default
+this is empty and a role will not be assumed.
+
+[id="plugins-{type}s-{plugin}-role_session_name"]
+===== `role_session_name`
+
+  * Value type is <<string,string>>
+  * Default value is `logstash`
+
+Session name to use when assuming an IAM role. This is recorded in CloudTrail logs for example.
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -146,7 +146,7 @@ Path to certificate in PEM format. This certificate will be presented
 to the connecting clients.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
-===== `ssl_certificate_authorities`
+===== `ssl_extra_chain_certs`
 
   * Value type is <<array,array>>
   * Default value is `[]`

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,7 +1,7 @@
 :plugin: elastic_app_search
 :type: output
 :default_plugin: 1
-:no_codec:
+:default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -108,4 +108,4 @@ To keep the timestamp field, set this value to the name of the field where you w
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:no_codec!:
+:default_codec!:

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -99,6 +99,12 @@ happens, the problem is logged as a warning, and the event is dropped. See
 
 beta[]
 
+[IMPORTANT]
+To use Index Lifecycle Management feature, please upgrade this plugin to the latest available version
+using the Logstash plugin upgrader:
+`bin/logstash-plugin upgrade logstash-output-elasticsearch`.
+The upgraded plugin should be version `9.3.1` or higher.
+
 [NOTE]
 This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
 

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v9.2.3
-:release_date: 2018-11-05
-:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.2.3/CHANGELOG.md
+:version: v9.3.0
+:release_date: 2018-12-18
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.3.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -76,13 +76,13 @@ HTTP requests to the bulk API are expected to return a 200 response code. All ot
 
 The following document errors are handled as follows:
 
-  * 400 and 404 errors are sent to the dead letter queue (DLQ), if enabled. If a DLQ is not enabled, a log message will be emitted, and the event will be dropped. See <<dlq-policy>> for more info.
+  * 400 and 404 errors are sent to the dead letter queue (DLQ), if enabled. If a DLQ is not enabled, a log message will be emitted, and the event will be dropped. See <<plugins-{type}s-{plugin}-dlq-policy>> for more info.
   * 409 errors (conflict) are logged as a warning and dropped. 
 
 Note that 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
 It is more performant for Elasticsearch to retry these exceptions than this plugin.
 
-[[dlq-policy]]
+[id="plugins-{type}s-{plugin}-dlq-policy"]
 ==== DLQ Policy
 
 Mapping (404) errors from Elasticsearch can lead to data loss. Unfortunately
@@ -94,10 +94,60 @@ re-indexed to Elasticsearch. If the DLQ is not enabled, and a mapping error
 happens, the problem is logged as a warning, and the event is dropped. See
 <<dead-letter-queues>> for more information about processing events in the DLQ.
 
+[id="plugins-{type}s-{plugin}-ilm"]
+==== Index Lifecycle Management (Beta)
+
+beta[]
+
+[NOTE]
+This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
+
+Logstash can use the {ref}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
+
+To configure the Elasticsearch output to use Index Lifecycle Management, set the `ilm_enabled` flag to true in the output definition:
+
+[source,ruby]
+    output {
+      elasticsearch {
+        ilm_enabled => true
+      }
+    }
+
+This will overwrite the index settings and adjust the Logstash template to write the necessary settings for the template
+to support index lifecycle management, including the index policy and rollover alias to be used.
+
+Logstash will create a rollover alias for the indices to be written to, including a pattern for how the actual indices will be named, and unless an ILM policy that already exists has been specified,
+a default policy will also be created. The default policy is configured to rollover an index when it reaches either 50 gigabytes in size, or is 30 days old, whichever happens first.
+
+The default rollover alias is called `logstash`, with a default pattern for the rollover index of `{now/d}-00001`,
+which will name indices on the date that the index is rolled over, followed by an incrementing number. Note that the pattern must end with a dash and a number that will be incremented.
+
+See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
+
+The rollover alias, ilm pattern and policy can be modified.
+
+See config below for an example:
+[source,ruby]
+    output {
+      elasticsearch {
+        ilm_enabled => true
+        ilm_rollover_alias: "custom"
+        ilm_pattern: "000001"
+        ilm_policy: "custom_policy"
+      }
+    }
+
+NOTE: Custom ILM policies must already exist on the Elasticsearch cluster before they can be used.
+
+NOTE: If the rollover alias or pattern is modified, the index template will need to be overwritten as the settings `index.lifecycle.name` and `index.lifecycle.rollover_alias` are automatically written to the template
+
+NOTE: If the index property is supplied in the output definition, it will be overwritten by the rollover alias.
+
+
 ==== Batch Sizes
 
 This plugin attempts to send batches of events as a single request. However, if
-a request exceeds 20MB we will break it up until multiple batch requests. If a single document exceeds 20MB it will be sent as a single request.
+a request exceeds 20MB we will break it up into multiple batch requests. If a single document exceeds 20MB it will be sent as a single request.
 
 ==== DNS Caching
 
@@ -140,6 +190,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-healthcheck_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ilm_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ilm_pattern>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ilm_rollover_alias>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
@@ -314,6 +368,54 @@ Any special characters present in the URLs here MUST be URL escaped! This means 
   * Default value is `false`
 
 Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
+
+[id="plugins-{type}s-{plugin}-ilm_enabled"]
+===== `ilm_enabled`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Setting this flag to `true` will enable indices to be managed by the Index Lifecycle Management feature in Elasticsearch.
+
+NOTE: This feature requires a Basic License or above to be installed on an Elasticsearch cluster version 6.6.0 or later
+
+[id="plugins-{type}s-{plugin}-ilm_pattern"]
+===== `ilm_pattern`
+
+  * Value type is <<string,string>>
+  * Default value is `{now/d}-000001`
+
+Pattern used for generating indices managed by Index Lifecycle Management. The value specified in the pattern will be appended to
+the write alias, and incremented automatically when a new index is created by ILM.
+
+Date Math can be used when specifying an ilm pattern, see {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
+
+NOTE: Updating the pattern will require the index template to be rewritten
+
+NOTE: The pattern must finish with a dash and a number that will be automatically incremented when indices rollover.
+
+[id="plugins-{type}s-{plugin}-ilm_policy"]
+===== `ilm_policy`
+
+  * Value type is <<string,string>>
+  * Default value is `logstash`
+
+Modify this setting to use a custom Index Lifecycle Management policy, rather than the default. If this value is not set, the default policy will
+be automatically installed into Elasticsearch
+
+NOTE: If this setting is specified, the policy must already exist in Elasticsearch cluster.
+
+[id="plugins-{type}s-{plugin}-ilm_rollover_alias"]
+===== `ilm_rollover_alias`
+
+  * Value type is <<string,string>>
+  * Default value is `logstash`
+
+The rollover alias is the alias where indices managed using Index Lifecycle Management will be written to.
+
+NOTE: If both `index` and `ilm_rollover_alias` are specified, `ilm_rollover_alias` takes precedence.
+
+NOTE: Updating the rollover alias will require the index template to be rewritten
 
 [id="plugins-{type}s-{plugin}-index"]
 ===== `index` 

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.2.0
-:release_date: 2018-09-27
-:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.2.0/CHANGELOG.md
+:version: v7.3.1
+:release_date: 2018-12-19
+:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v7.3.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -24,7 +24,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Write events to a Kafka topic. 
 
-This plugin uses Kafka Client 2.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
 
 If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need.
 
@@ -83,6 +83,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
 | <<plugins-{type}s-{plugin}-send_buffer_bytes>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ssl_endpoint_identification_algorithm>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_key_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_location>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
@@ -332,6 +333,14 @@ Security protocol to use, which can be either of PLAINTEXT,SSL,SASL_PLAINTEXT,SA
   * Default value is `131072`
 
 The size of the TCP send buffer to use when sending data.
+
+[id="plugins-{type}s-{plugin}-ssl_endpoint_identification_algorithm"]
+===== `ssl_endpoint_identification_algorithm`
+
+  * Value type is <<string,string>>
+  * Default value is `"https"`
+
+The endpoint identification algorithm, defaults to `"https"`. Set to empty string `""` to disable
 
 [id="plugins-{type}s-{plugin}-ssl_key_password"]
 ===== `ssl_key_password` 

--- a/docs/plugins/outputs/pagerduty.asciidoc
+++ b/docs/plugins/outputs/pagerduty.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.7
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-pagerduty/blob/v3.0.7/CHANGELOG.md
+:version: v3.0.8
+:release_date: 2019-01-05
+:changelog_url: https://github.com/logstash-plugins/logstash-output-pagerduty/blob/v3.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/tcp.asciidoc
+++ b/docs/plugins/outputs/tcp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.3
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-tcp/blob/v5.0.3/CHANGELOG.md
+:version: v5.0.4
+:release_date: 2019-01-02
+:changelog_url: https://github.com/logstash-plugins/logstash-output-tcp/blob/v5.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Starts with generated docs for 6.6  #671 and adds:
- new logstash-filter-http to Logstash Reference Guide
- new logstash-filter-memcached to Logstash Reference Guide
- ILM note from #667 to logstash-output-elasticsearch