### PR TITLE
Add google_cloud_storage to list of inputs

### DIFF
--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -19,6 +19,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-gelf,gelf>> | Reads GELF-format messages from Graylog2 as events | https://github.com/logstash-plugins/logstash-input-gelf[logstash-input-gelf]
 | <<plugins-inputs-generator,generator>> | Generates random log events for test purposes | https://github.com/logstash-plugins/logstash-input-generator[logstash-input-generator]
 | <<plugins-inputs-github,github>> | Reads events from a GitHub webhook | https://github.com/logstash-plugins/logstash-input-github[logstash-input-github]
+| <<plugins-inputs-google_cloud_storage,google_cloud_storage>> | Extract events from files in a Google Cloud Storage bucket | https://github.com/logstash-plugins/logstash-input-google_cloud_storage[logstash-input-google_cloud_storage]
 | <<plugins-inputs-google_pubsub,google_pubsub>> | Consume events from a Google Cloud PubSub service | https://github.com/logstash-plugins/logstash-input-google_pubsub[logstash-input-google_pubsub]
 | <<plugins-inputs-graphite,graphite>> | Reads metrics from the `graphite` tool | https://github.com/logstash-plugins/logstash-input-graphite[logstash-input-graphite]
 | <<plugins-inputs-heartbeat,heartbeat>> | Generates heartbeat events for testing | https://github.com/logstash-plugins/logstash-input-heartbeat[logstash-input-heartbeat]
@@ -94,6 +95,9 @@ include::inputs/generator.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/docs/index.asciidoc
 include::inputs/github.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-input-google_cloud_storage/edit/master/docs/index.asciidoc
+include::inputs/google_cloud_storage.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/docs/index.asciidoc
 include::inputs/google_pubsub.asciidoc[]


### PR DESCRIPTION
Adds new input-google_cloud_storage to LS Ref.

IMPORTANT: Generated `inputs/google_cloud_storage.asciidoc`  files  must be present before this PR can be merged into a branch.  Otherwise, the doc build will fail.

Branch 7.0
- [x] file present 
- [x]  PR merged

Branch 7.1
- [x] file present 
- [x]  PR merged

Branch 7.2
- [x] file present 
- [x]  PR merged

Branch 7.3
- [x] file present
- [ ]  PR merged

Branch 7.x
- [x] file present
- [ ]  PR merged

Branch master
- [x]  file present
- [ ]   PR merged