### PR TITLE
Clean up formatting in older plugin docs

### DIFF
--- a/docs/versioned-plugins/filters/kv-v4.0.1.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.0.1.asciidoc
@@ -140,7 +140,7 @@ A string of characters to use as delimiters for parsing out key-value pairs.
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.0.2.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.0.2.asciidoc
@@ -140,7 +140,7 @@ A string of characters to use as delimiters for parsing out key-value pairs.
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.0.3.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.0.3.asciidoc
@@ -140,7 +140,7 @@ A string of characters to use as delimiters for parsing out key-value pairs.
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.1.0.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.1.0.asciidoc
@@ -140,7 +140,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.1.1.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.1.1.asciidoc
@@ -140,7 +140,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.1.2.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.1.2.asciidoc
@@ -142,7 +142,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.2.0.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.2.0.asciidoc
@@ -143,7 +143,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.2.1.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.2.1.asciidoc
@@ -143,7 +143,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/filters/kv-v4.3.0.asciidoc
+++ b/docs/versioned-plugins/filters/kv-v4.3.0.asciidoc
@@ -146,7 +146,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/docs/versioned-plugins/inputs/couchdb_changes-v3.1.2.asciidoc
+++ b/docs/versioned-plugins/inputs/couchdb_changes-v3.1.2.asciidoc
@@ -25,11 +25,11 @@ CouchDB http://guide.couchdb.org/draft/notifications.html[_changes] URI.
 Moreover, any "future" changes will automatically be streamed as well making it easy to synchronize
 your CouchDB data with any target destination
 
-### Upsert and delete
+===== Upsert and delete
 You can use event metadata to allow for document deletion.
 All non-delete operations are treated as upserts
 
-### Starting at a Specific Sequence
+===== Starting at a Specific Sequence
 The CouchDB input stores the last sequence number value in location defined by `sequence_path`.
 You can use this fact to start or resume the stream at a particular sequence.
 

--- a/docs/versioned-plugins/inputs/couchdb_changes-v3.1.3.asciidoc
+++ b/docs/versioned-plugins/inputs/couchdb_changes-v3.1.3.asciidoc
@@ -25,11 +25,11 @@ CouchDB http://guide.couchdb.org/draft/notifications.html[_changes] URI.
 Moreover, any "future" changes will automatically be streamed as well making it easy to synchronize
 your CouchDB data with any target destination
 
-### Upsert and delete
+===== Upsert and delete
 You can use event metadata to allow for document deletion.
 All non-delete operations are treated as upserts
 
-### Starting at a Specific Sequence
+===== Starting at a Specific Sequence
 The CouchDB input stores the last sequence number value in location defined by `sequence_path`.
 You can use this fact to start or resume the stream at a particular sequence.
 

--- a/docs/versioned-plugins/inputs/couchdb_changes-v3.1.4.asciidoc
+++ b/docs/versioned-plugins/inputs/couchdb_changes-v3.1.4.asciidoc
@@ -25,11 +25,11 @@ CouchDB http://guide.couchdb.org/draft/notifications.html[_changes] URI.
 Moreover, any "future" changes will automatically be streamed as well making it easy to synchronize
 your CouchDB data with any target destination
 
-### Upsert and delete
+===== Upsert and delete
 You can use event metadata to allow for document deletion.
 All non-delete operations are treated as upserts
 
-### Starting at a Specific Sequence
+===== Starting at a Specific Sequence
 The CouchDB input stores the last sequence number value in location defined by `sequence_path`.
 You can use this fact to start or resume the stream at a particular sequence.
 

--- a/docs/versioned-plugins/inputs/couchdb_changes-v3.1.5.asciidoc
+++ b/docs/versioned-plugins/inputs/couchdb_changes-v3.1.5.asciidoc
@@ -26,11 +26,11 @@ CouchDB http://guide.couchdb.org/draft/notifications.html[_changes] URI.
 Moreover, any "future" changes will automatically be streamed as well making it easy to synchronize
 your CouchDB data with any target destination
 
-### Upsert and delete
+===== Upsert and delete
 You can use event metadata to allow for document deletion.
 All non-delete operations are treated as upserts
 
-### Starting at a Specific Sequence
+===== Starting at a Specific Sequence
 The CouchDB input stores the last sequence number value in location defined by `sequence_path`.
 You can use this fact to start or resume the stream at a particular sequence.
 

--- a/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.1.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.1.asciidoc
@@ -33,8 +33,8 @@ input {
 -----------------------------------------
 
 
-+For more information about processing events in the dead letter queue, see
-+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
+For more information about processing events in the dead letter queue, see
+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
 
 [id="{version}-plugins-{type}s-{plugin}-options"]
 ==== Dead_letter_queue Input Configuration Options

--- a/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.2.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.2.asciidoc
@@ -33,8 +33,8 @@ input {
 -----------------------------------------
 
 
-+For more information about processing events in the dead letter queue, see
-+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
+For more information about processing events in the dead letter queue, see
+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
 
 [id="{version}-plugins-{type}s-{plugin}-options"]
 ==== Dead_letter_queue Input Configuration Options

--- a/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.4.asciidoc
+++ b/docs/versioned-plugins/inputs/dead_letter_queue-v1.1.4.asciidoc
@@ -34,8 +34,8 @@ input {
 -----------------------------------------
 
 
-+For more information about processing events in the dead letter queue, see
-+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
+For more information about processing events in the dead letter queue, see
+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
 
 [id="{version}-plugins-{type}s-{plugin}-options"]
 ==== Dead_letter_queue Input Configuration Options

--- a/docs/versioned-plugins/inputs/neo4j-v2.0.5.asciidoc
+++ b/docs/versioned-plugins/inputs/neo4j-v2.0.5.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 This plugin gets data from a Neo4j database in predefined intervals. To fetch
 this data uses a given Cypher query.
 
-===== Usage:
+===== Usage
 [source, ruby]
 input {
   neo4j {

--- a/docs/versioned-plugins/inputs/neo4j-v2.0.5.asciidoc
+++ b/docs/versioned-plugins/inputs/neo4j-v2.0.5.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 This plugin gets data from a Neo4j database in predefined intervals. To fetch
 this data uses a given Cypher query.
 
-### Usage:
+===== Usage:
 [source, ruby]
 input {
   neo4j {

--- a/docs/versioned-plugins/inputs/neo4j-v2.0.6.asciidoc
+++ b/docs/versioned-plugins/inputs/neo4j-v2.0.6.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 This plugin gets data from a Neo4j database in predefined intervals. To fetch
 this data uses a given Cypher query.
 
-===== Usage:
+===== Usage
 [source, ruby]
 input {
   neo4j {

--- a/docs/versioned-plugins/inputs/neo4j-v2.0.6.asciidoc
+++ b/docs/versioned-plugins/inputs/neo4j-v2.0.6.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 This plugin gets data from a Neo4j database in predefined intervals. To fetch
 this data uses a given Cypher query.
 
-### Usage:
+===== Usage:
 [source, ruby]
 input {
   neo4j {

--- a/docs/versioned-plugins/inputs/tcp-v4.1.2.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v4.1.2.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v4.2.2.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v4.2.2.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v4.2.3.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v4.2.3.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v4.2.4.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v4.2.4.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v5.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v5.0.0.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v5.0.1.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v5.0.1.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v5.0.2.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v5.0.2.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/inputs/tcp-v5.0.3.asciidoc
+++ b/docs/versioned-plugins/inputs/tcp-v5.0.3.asciidoc
@@ -27,7 +27,7 @@ Like stdin and file inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
-#### Accepting log4j2 logs
+===== Accepting log4j2 logs
 
 Log4j2 can send JSON over a socket, and we can use that combined with our tcp
 input to accept the logs. 

--- a/docs/versioned-plugins/outputs/s3-v4.0.10.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.10.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.0.11.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.11.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
-Requirements:
+Requirements
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+===== Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.0.12.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.12.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.0.13.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.13.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.0.8.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.8.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,11 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
-
-
-
-
-
-#### Usage:
+===== Usage
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.0.9.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.0.9.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if you file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.0.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.0.asciidoc
@@ -20,11 +20,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -43,16 +42,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.1.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.1.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+===== Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.2.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.2.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.3.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.3.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.4.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.4.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+===== Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.5.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.5.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.6.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.6.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.7.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.7.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {

--- a/docs/versioned-plugins/outputs/s3-v4.1.8.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v4.1.8.asciidoc
@@ -21,11 +21,10 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-INFORMATION:
-
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
 Requirements:
+
 * Amazon S3 Bucket and S3 Access Permissions (Typically access_key_id and secret_access_key)
 * S3 PutObject permission
 
@@ -44,16 +43,12 @@ ls.s3.312bc026-2f5d-49bc-ae9f-5940cf4ad9a6.2013-04-18T10.00.tag_hello.part0.txt
 | part0 | this means if you indicate size_file then it will generate more parts if your file.size > size_file. When a file is full it will be pushed to the bucket and then deleted from the temporary directory. If a file is empty, it is simply deleted.  Empty files will not be pushed |
 |=======
 
-Crash Recovery:
-* This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
+===== Crash Recovery
 
+This plugin will recover and upload temporary log files after crash/abnormal termination when using `restore` set to true
 
+=====  Usage
 
-
-
-
-
-#### Usage:
 This is an example of logstash config:
 [source,ruby]
 output {


### PR DESCRIPTION
Clean up formatting to enable converting Versioned Plugin Reference from asciidoc to asciidoctor. 
NOTE:  The formatting is correct in the plugin repos and in current versions. 