### PR TITLE
Asciidoctor support

### DIFF
--- a/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
@@ -1,9 +1,11 @@
 ifeval::["{versioned_docs}"!="true"]
+[subs="attributes"]
 ++++
 <titleabbrev>{plugin}</titleabbrev>
 ++++
 endif::[]
 ifeval::["{versioned_docs}"=="true"]
+[subs="attributes"]
 ++++
 <titleabbrev>{version}</titleabbrev>
 ++++
@@ -28,12 +30,14 @@ To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Referen
 
 endif::[]
 
-ifeval::[("{default_plugin}"=="0") and ("{versioned_docs}"!="true")]
+ifeval::["{default_plugin}"=="0"]
+ifeval::["{versioned_docs}"!="true"]
 
 ==== Installation
 
 For plugins not bundled by default, it is easy to install by running +bin/logstash-plugin install logstash-{type}-{plugin}+. See {logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
 
+endif::[]
 endif::[]
 
 ==== Getting Help

--- a/docs/versioned-plugins/include/6.x/version-list-intro.asciidoc
+++ b/docs/versioned-plugins/include/6.x/version-list-intro.asciidoc
@@ -1,6 +1,7 @@
 [id="{type}-{plugin}-index"]
 
 == Versioned {plugin} {type} plugin docs
+[subs="attributes"]
 ++++
 <titleabbrev>{plugin}</titleabbrev>
 ++++


### PR DESCRIPTION
This fixes a few Asciidoctor specific issues with the docs, specifically
removing an `and` from an `ifeval` which is not supported by AsciiDoc
and adding some substitutions that are not the default for Asciidoctor.