### PR TITLE
Fix asciidoc formatting for conversion to asciidoctor (for 6.8)

### DIFF
--- a/docs/plugins/filters/csv.asciidoc
+++ b/docs/plugins/filters/csv.asciidoc
@@ -91,7 +91,7 @@ in the data than specified in this column list, extra columns will be auto-numbe
 Define a set of datatype conversions to be applied to columns.
 Possible conversions are integer, float, date, date_time, boolean
 
-# Example:
+Example:
 [source,ruby]
     filter {
       csv {

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/inputs/dead_letter_queue.asciidoc
+++ b/docs/plugins/inputs/dead_letter_queue.asciidoc
@@ -35,8 +35,8 @@ input {
 -----------------------------------------
 
 
-+For more information about processing events in the dead letter queue, see
-+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
+For more information about processing events in the dead letter queue, see
+{logstash-ref}/dead-letter-queues.html[Dead Letter Queues].
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Dead_letter_queue Input Configuration Options

--- a/docs/plugins/inputs/jmx.asciidoc
+++ b/docs/plugins/inputs/jmx.asciidoc
@@ -27,7 +27,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-==== The configuration
+==== Configuration
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing


### PR DESCRIPTION
Backport of #694 