### PR TITLE
Add core plugins to LS Ref

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -20,6 +20,9 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-fluent,fluent>> | Reads the `fluentd` `msgpack` schema | https://github.com/logstash-plugins/logstash-codec-fluent[logstash-codec-fluent]
 | <<plugins-codecs-graphite,graphite>> | Reads `graphite` formatted lines | https://github.com/logstash-plugins/logstash-codec-graphite[logstash-codec-graphite]
 | <<plugins-codecs-gzip_lines,gzip_lines>> | Reads `gzip` encoded content | https://github.com/logstash-plugins/logstash-codec-gzip_lines[logstash-codec-gzip_lines]
+| <<plugins-codecs-jdots,jdots>> | Renders each processed event as a dot | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/codecs/Dots.java[core plugin]
+| <<plugins-codecs-java_line,java_line>> | Encodes and decodes line-oriented text data | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/codecs/Line.java[core plugin]
+| <<plugins-codecs-java_plain,java_plain>> | Processes text data with no delimiters between events | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/codecs/Plain.java[core plugin]
 | <<plugins-codecs-json,json>> | Reads JSON formatted content, creating one event per element in a JSON array | https://github.com/logstash-plugins/logstash-codec-json[logstash-codec-json]
 | <<plugins-codecs-json_lines,json_lines>> | Reads newline-delimited JSON | https://github.com/logstash-plugins/logstash-codec-json_lines[logstash-codec-json_lines]
 | <<plugins-codecs-line,line>> | Reads line-oriented text data | https://github.com/logstash-plugins/logstash-codec-line[logstash-codec-line]
@@ -67,6 +70,15 @@ include::codecs/graphite.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_dots.asciidoc
+include::../../../logstash/docs/static/core-plugins/codecs/java_dots.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_line.asciidoc
+include::../../../logstash/docs/static/core-plugins/codecs/java_line.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_plain.asciidoc
+include::../../../logstash/docs/static/core-plugins/codecs/java_plain.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/docs/index.asciidoc
 include::codecs/json.asciidoc[]

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -29,6 +29,7 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-grok,grok>> | Parses unstructured event data into fields | https://github.com/logstash-plugins/logstash-filter-grok[logstash-filter-grok]
 | <<plugins-filters-http,http>> | Provides integration with external web services/REST APIs | https://github.com/logstash-plugins/logstash-filter-http[logstash-filter-http]
 | <<plugins-filters-i18n,i18n>> | Removes special characters from a field | https://github.com/logstash-plugins/logstash-filter-i18n[logstash-filter-i18n]
+| <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
 | <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-filter-jdbc_static[logstash-filter-jdbc_static]
 | <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-filter-jdbc_streaming[logstash-filter-jdbc_streaming]
 | <<plugins-filters-json,json>> | Parses JSON events | https://github.com/logstash-plugins/logstash-filter-json[logstash-filter-json]
@@ -116,6 +117,9 @@ include::filters/http.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/filters/java_uuid.asciidoc
+include::../../../logstash/docs/static/core-plugins/filters/java_uuid.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/edit/master/docs/index.asciidoc
 include::filters/jdbc_static.asciidoc[]

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -26,6 +26,8 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-http_poller,http_poller>> | Decodes the output of an HTTP API into events | https://github.com/logstash-plugins/logstash-input-http_poller[logstash-input-http_poller]
 | <<plugins-inputs-imap,imap>> | Reads mail from an IMAP server | https://github.com/logstash-plugins/logstash-input-imap[logstash-input-imap]
 | <<plugins-inputs-irc,irc>> | Reads events from an IRC server | https://github.com/logstash-plugins/logstash-input-irc[logstash-input-irc]
+| <<plugins-inputs-java_generator,java_generator>> | Generates synthetic log events | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/inputs/Generator.java[core plugin]
+| <<plugins-inputs-java_stdin,java_stdin>> | Reads events from standard input| https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/inputs/Stdin.java[core plugin]
 | <<plugins-inputs-jdbc,jdbc>> | Creates events from JDBC data | https://github.com/logstash-plugins/logstash-input-jdbc[logstash-input-jdbc]
 | <<plugins-inputs-jms,jms>> | Reads events from a Jms Broker | https://github.com/logstash-plugins/logstash-input-jms[logstash-input-jms]
 | <<plugins-inputs-jmx,jmx>> | Retrieves metrics from remote Java applications over JMX | https://github.com/logstash-plugins/logstash-input-jmx[logstash-input-jmx]
@@ -115,6 +117,12 @@ include::inputs/imap.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/master/docs/index.asciidoc
 include::inputs/irc.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/inputs/java_generator.asciidoc
+include::../../../logstash/docs/static/core-plugins/inputs/java_generator.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/inputs/java_stdin.asciidoc
+include::../../../logstash/docs/static/core-plugins/inputs/java_stdin.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
 include::inputs/jdbc.asciidoc[]

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -27,6 +27,8 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-http,http>> | Sends events to a generic HTTP or HTTPS endpoint | https://github.com/logstash-plugins/logstash-output-http[logstash-output-http]
 | <<plugins-outputs-influxdb,influxdb>> | Writes metrics to InfluxDB | https://github.com/logstash-plugins/logstash-output-influxdb[logstash-output-influxdb]
 | <<plugins-outputs-irc,irc>> | Writes events to IRC | https://github.com/logstash-plugins/logstash-output-irc[logstash-output-irc]
+| <<plugins-outputs-java_sink,java_sink>> | Discards any events received | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/outputs/Sink.java[core plugin]
+| <<plugins-outputs-java_stdout,java_stdout>> | Prints events to the STDOUT of the shell | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/outputs/Stdout.java[core plugin]
 | <<plugins-outputs-juggernaut,juggernaut>> | Pushes messages to the Juggernaut websockets server | https://github.com/logstash-plugins/logstash-output-juggernaut[logstash-output-juggernaut]
 | <<plugins-outputs-kafka,kafka>> | Writes events to a Kafka topic | https://github.com/logstash-plugins/logstash-output-kafka[logstash-output-kafka]
 | <<plugins-outputs-librato,librato>> | Sends metrics, annotations, and alerts to Librato based on Logstash events | https://github.com/logstash-plugins/logstash-output-librato[logstash-output-librato]
@@ -120,6 +122,12 @@ include::outputs/influxdb.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/docs/index.asciidoc
 include::outputs/irc.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/outputs/java_sink.asciidoc
+include::../../../logstash/docs/static/core-plugins/outputs/java_sink.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/outputs/java_stdout.asciidoc
+include::../../../logstash/docs/static/core-plugins/outputs/java_stdout.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]


### PR DESCRIPTION
This PR pulls core plugin docs into the Logstash Reference. 
@dedemorton Thanks for your help with this one! 

PREREQUISITE: https://github.com/elastic/logstash/pull/10977 must be merged before this one can be merged. 