### PR TITLE
Fix formatting for code samples

### DIFF
--- a/docs/plugins/filters/ruby.asciidoc
+++ b/docs/plugins/filters/ruby.asciidoc
@@ -17,23 +17,28 @@ For the list of Elastic supported plugins, please consult the https://www.elasti
 Execute ruby code.
 
 For example, to cancel 90% of events, you can do this:
+
 [source,ruby]
+-----
     filter {
       ruby {
         # Cancel 90% of events
         code => "event.cancel if rand <= 0.90"
       }
     }
+-----
 
 If you need to create additional events, it cannot be done as in other filters where you would use `yield`,
 you must use a specific syntax `new_event_block.call(event)` like in this example duplicating the input event
+
 [source,ruby]
+-----
 filter {
   ruby {
     code => "new_event_block.call(event.clone)"
   }
 }
-
+-----
 
 &nbsp;
 
@@ -84,12 +89,15 @@ Field names can be dynamic and include parts of the event using the `%{field}`.
 
 Example:
 [source,ruby]
+-----
     filter {
       ruby {
         add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
       }
     }
+-----
 [source,ruby]
+-----
     # You can also add multiple fields at once:
     filter {
       ruby {
@@ -99,6 +107,7 @@ Example:
         }
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add field `foo_hello` if it is present, with the
@@ -117,18 +126,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       ruby {
         add_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple tags at once:
     filter {
       ruby {
         add_tag => [ "foo_%{somefield}", "taggedy_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
@@ -199,20 +213,25 @@ Optional.
 
 If this filter is successful, remove arbitrary fields from this event.
 Fields names can be dynamic and include parts of the event using the %{field}
+
 Example:
 [source,ruby]
+-----
     filter {
       ruby {
         remove_field => [ "foo_%{somefield}" ]
       }
     }
+-----
 [source,ruby]
+-----
     # You can also remove multiple fields at once:
     filter {
       ruby {
         remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the field with name `foo_hello` if it is present. The second
@@ -230,18 +249,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       ruby {
         remove_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple tags at once:
     filter {
       ruby {
         remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the tag `foo_hello` if it is present. The second example

--- a/docs/plugins/filters/sleep.asciidoc
+++ b/docs/plugins/filters/sleep.asciidoc
@@ -68,12 +68,16 @@ Field names can be dynamic and include parts of the event using the `%{field}`.
 
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
       }
     }
+-----    
+    
 [source,ruby]
+-----
     # You can also add multiple fields at once:
     filter {
       sleep {
@@ -83,6 +87,7 @@ Example:
         }
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add field `foo_hello` if it is present, with the
@@ -101,18 +106,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         add_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple tags at once:
     filter {
       sleep {
         add_tag => [ "foo_%{somefield}", "taggedy_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
@@ -137,12 +147,14 @@ Sleep on every N'th. This option is ignored in replay mode.
 
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         time => "1"   # Sleep 1 second
         every => 10   # on every 10th event
       }
     }
+-----
 
 [[plugins-filters-sleep-id]]
 ===== `id` 
@@ -182,20 +194,26 @@ Optional.
 
 If this filter is successful, remove arbitrary fields from this event.
 Fields names can be dynamic and include parts of the event using the %{field}
+
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         remove_field => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple fields at once:
     filter {
       sleep {
         remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the field with name `foo_hello` if it is present. The second
@@ -213,18 +231,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         remove_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple tags at once:
     filter {
       sleep {
         remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the tag `foo_hello` if it is present. The second example
@@ -251,12 +274,14 @@ value of 0.25 will replay at 1/4th speed.
 
 For example:
 [source,ruby]
+-----
     filter {
       sleep {
         time => 2
         replay => true
       }
     }
+-----
 
 The above will sleep in such a way that it will perform
 replay 2-times faster than the original time speed.
@@ -276,11 +301,12 @@ to indicate the amount of time to sleep.
 
 Example:
 [source,ruby]
+-----
     filter {
       sleep {
         # Sleep 1 second for every event.
         time => "1"
       }
     }
-
+-----
 

--- a/docs/plugins/filters/split.asciidoc
+++ b/docs/plugins/filters/split.asciidoc
@@ -102,12 +102,16 @@ Field names can be dynamic and include parts of the event using the `%{field}`.
 
 Example:
 [source,ruby]
+-----
     filter {
       split {
         add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
       }
     }
+-----  
+    
 [source,ruby]
+-----
     # You can also add multiple fields at once:
     filter {
       split {
@@ -117,6 +121,7 @@ Example:
         }
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add field `foo_hello` if it is present, with the
@@ -135,18 +140,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       split {
         add_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple tags at once:
     filter {
       split {
         add_tag => [ "foo_%{somefield}", "taggedy_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
@@ -209,20 +219,26 @@ Optional.
 
 If this filter is successful, remove arbitrary fields from this event.
 Fields names can be dynamic and include parts of the event using the %{field}
+
 Example:
 [source,ruby]
+-----
     filter {
       split {
         remove_field => [ "foo_%{somefield}" ]
       }
     }
+-----
+    
 [source,ruby]
+-----
     # You can also remove multiple fields at once:
     filter {
       split {
         remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the field with name `foo_hello` if it is present. The second
@@ -240,18 +256,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       split {
         remove_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple tags at once:
     filter {
       split {
         remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the tag `foo_hello` if it is present. The second example

--- a/docs/plugins/filters/syslog_pri.asciidoc
+++ b/docs/plugins/filters/syslog_pri.asciidoc
@@ -71,12 +71,16 @@ Field names can be dynamic and include parts of the event using the `%{field}`.
 
 Example:
 [source,ruby]
+-----
     filter {
       syslog_pri {
         add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple fields at once:
     filter {
       syslog_pri {
@@ -86,6 +90,7 @@ Example:
         }
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add field `foo_hello` if it is present, with the
@@ -104,18 +109,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       syslog_pri {
         add_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple tags at once:
     filter {
       syslog_pri {
         add_tag => [ "foo_%{somefield}", "taggedy_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
@@ -176,20 +186,26 @@ Optional.
 
 If this filter is successful, remove arbitrary fields from this event.
 Fields names can be dynamic and include parts of the event using the %{field}
+
 Example:
 [source,ruby]
+-----
     filter {
       syslog_pri {
         remove_field => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple fields at once:
     filter {
       syslog_pri {
         remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the field with name `foo_hello` if it is present. The second
@@ -207,18 +223,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       syslog_pri {
         remove_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple tags at once:
     filter {
       syslog_pri {
         remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the tag `foo_hello` if it is present. The second example

--- a/docs/plugins/filters/throttle.asciidoc
+++ b/docs/plugins/filters/throttle.asciidoc
@@ -25,14 +25,19 @@ The plugin is thread-safe and properly tracks past events.
 
 For example, if you wanted to throttle events so you only receive an event after 2
 occurrences and you get no more than 3 in 10 minutes, you would use the configuration:
+
 [source,ruby]
+-----
     period => 600
     max_age => 1200
     before_count => 3
     after_count => 5
+-----
 
 Which would result in:
-==========================
+
+[source,txt]
+-----
     event 1 - throttled (successful filter, period start)
     event 2 - throttled (successful filter)
     event 3 - not throttled
@@ -49,17 +54,23 @@ Which would result in:
     event 5 - not throttled
     event 6 - throttled (successful filter)
     ...
-==========================
+-----
+
 Another example is if you wanted to throttle events so you only
 receive 1 event per hour, you would use the configuration:
+
 [source,ruby]
+-----
     period => 3600
     max_age => 7200
     before_count => -1
     after_count => 1
+-----
 
 Which would result in:
-==========================
+
+[source,txt]
+-----
     event 1 - not throttled (period start)
     event 2 - throttled (successful filter)
     event 3 - throttled (successful filter)
@@ -71,11 +82,14 @@ Which would result in:
     event 3 - throttled (successful filter)
     event 4 - throttled (successful filter)
     ...
-==========================
+-----
+
 A common use case would be to use the throttle filter to throttle events before 3 and
 after 5 while using multiple fields for the key and then use the drop filter to remove
 throttled events. This configuration might appear as:
+
 [source,ruby]
+-----
     filter {
       throttle {
         before_count => 3
@@ -89,11 +103,14 @@ throttled events. This configuration might appear as:
         drop { }
       }
     }
+-----
 
 Another case would be to store all events, but only email non-throttled events
 so the op's inbox isn't flooded with emails in the event of a system error.
 This configuration might appear as:
+
 [source,ruby]
+-----
     filter {
       throttle {
         before_count => 3
@@ -120,6 +137,7 @@ This configuration might appear as:
         port => "19200"
       }
     }
+-----
 
 When an event is received, the event key is stored in a key_cache.  The key references
 a timeslot_cache.  The event is allocated to a timeslot (created dynamically) based on
@@ -211,12 +229,16 @@ Field names can be dynamic and include parts of the event using the `%{field}`.
 
 Example:
 [source,ruby]
+-----
     filter {
       throttle {
         add_field => { "foo_%{somefield}" => "Hello world, from %{host}" }
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple fields at once:
     filter {
       throttle {
@@ -226,6 +248,7 @@ Example:
         }
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add field `foo_hello` if it is present, with the
@@ -244,18 +267,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       throttle {
         add_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also add multiple tags at once:
     filter {
       throttle {
         add_tag => [ "foo_%{somefield}", "taggedy_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would add a tag `foo_hello` (and the second example would of course add a `taggedy_tag` tag).
@@ -375,20 +403,26 @@ control mechanism.  Set to false if you like your VM to go (B)OOM.
 
 If this filter is successful, remove arbitrary fields from this event.
 Fields names can be dynamic and include parts of the event using the %{field}
+
 Example:
 [source,ruby]
+-----
     filter {
       throttle {
         remove_field => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple fields at once:
     filter {
       throttle {
         remove_field => [ "foo_%{somefield}", "my_extraneous_field" ]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the field with name `foo_hello` if it is present. The second
@@ -406,18 +440,23 @@ syntax.
 
 Example:
 [source,ruby]
+-----
     filter {
       throttle {
         remove_tag => [ "foo_%{somefield}" ]
       }
     }
+-----
+
 [source,ruby]
+-----
     # You can also remove multiple tags at once:
     filter {
       throttle {
         remove_tag => [ "foo_%{somefield}", "sad_unwanted_tag"]
       }
     }
+-----
 
 If the event has field `"somefield" == "hello"` this filter, on success,
 would remove the tag `foo_hello` if it is present. The second example


### PR DESCRIPTION
Fix formatting in preparation for conversion to asciidoctor:

*filter-ruby
*filter-sleep
*filter-split
*filter-syslog_pri
*filter-throttle

Merge targets: 1.5-5.4



