### PR TITLE
Fix experimental flag for asciidoctor

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -123,8 +123,7 @@ Logstash has the following flags. You can use the `--help` flag to display this 
   The default is 3 seconds.
   
 *`--allow-env`*::
-  experimental[]
-  Enables templating of environment variable
+  experimental[] Enables templating of environment variable
   values. Instances of `${VAR}` in strings will be replaced
   with the respective environment variable value named "VAR".
   The default is false.


### PR DESCRIPTION
Asciidoctor isn't able to deduce the right version of the experimental
tag when it is written on its own line. This moves it to the line below.