### PR TITLE
Fix link broken at current

### DIFF
--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -260,7 +260,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 


### PR DESCRIPTION
Link target changed at v7.3, breaking our calls to `current`. This PR updates the link.