### PR TITLE
Fix formatting for code samples for output-circonus

### DIFF
--- a/docs/plugins/outputs/circonus.asciidoc
+++ b/docs/plugins/outputs/circonus.asciidoc
@@ -59,10 +59,16 @@ All values will be passed through `event.sprintf`
 
 Example:
 [source,ruby]
+-----
   ["title":"Logstash event", "description":"Logstash event for %{host}"]
+-----
+
 or
+
 [source,ruby]
+-----
   ["title":"Logstash event", "description":"Logstash event for %{host}", "parent_id", "1"]
+-----
 
 [id="plugins-{type}s-{plugin}-api_token"]
 ===== `api_token` 


### PR DESCRIPTION
Changes from https://github.com/logstash-plugins/logstash-output-circonus/pull/5