### PR TITLE
Fix formatting for code samples in output-librato

### DIFF
--- a/docs/plugins/outputs/librato.asciidoc
+++ b/docs/plugins/outputs/librato.asciidoc
@@ -74,17 +74,23 @@ All values will be passed through `event.sprintf`
 
 Example:
 [source,ruby]
+-----
   {
       "title" => "Logstash event on %{host}"
       "name" => "logstash_stream"
   }
+-----
+
 or
+
 [source,ruby]
+-----
    {
       "title" => "Logstash event"
       "description" => "%{message}"
       "name" => "logstash_stream"
    }
+-----
 
 [id="plugins-{type}s-{plugin}-api_token"]
 ===== `api_token` 
@@ -116,20 +122,25 @@ Send data to Librato as a counter
 
 Example:
 [source,ruby]
+-----
     {
         "value" => "1"
         "source" => "%{host}"
         "name" => "messages_received"
     }
+-----
     
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
 [source,ruby]
+-----
     {
         "value" => "1"
         "source" => "%{host}"
         "name" => "messages_received"
         "measure_time" => "%{my_unixtime_field}"
     }
+-----
+
 Default is to use the event's timestamp
 
 [id="plugins-{type}s-{plugin}-gauge"]
@@ -143,19 +154,24 @@ Send data to Librato as a gauge
 
 Example:
 [source,ruby]
+-----
     {
         "value" => "%{bytes_received}"
         "source" => "%{host}"
         "name" => "apache_bytes"
     }
+-----
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
+
 [source,ruby]
+-----
     {
         "value" => "%{bytes_received}"
         "source" => "%{host}"
         "name" => "apache_bytes"
         "measure_time" => "%{my_unixtime_field}
     }
+-----
 Default is to use the event's timestamp
 
 


### PR DESCRIPTION
Changes from https://github.com/logstash-plugins/logstash-output-librato/pull/9