### PR TITLE
[Backport] Temp fix for broken link

### DIFF
--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/faq.html[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`


### PR DESCRIPTION
Backport of #780.

Beats troubleshooting docs were restructured, causing a doc build break in `master`. The doc build will break again when the Beats auto-backports happen.  This PR removes the deep links to avoid doc build breaks in 7.x and 7.3. 

After Beats autobackports happen and the dust settles, the correct fix is here: #781.  
