### PR TITLE
Update plugin docs for 7.2

### DIFF
--- a/docs/plugins/codecs/gzip_lines.asciidoc
+++ b/docs/plugins/codecs/gzip_lines.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.3
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/blob/v3.0.3/CHANGELOG.md
+:version: v3.0.4
+:release_date: 2019-07-23
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/blob/v3.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/codecs/protobuf.asciidoc
+++ b/docs/plugins/codecs/protobuf.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.1
-:release_date: 2019-05-28
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.2.1/CHANGELOG.md
+:version: v1.2.2
+:release_date: 2019-07-11
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.2.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,29 +29,31 @@ For protobuf 3 use the https://developers.google.com/protocol-buffers/docs/refer
 
 The following shows a usage example (protobuf v2) for decoding events from a kafka stream:
 [source,ruby]
-kafka 
-{
- topic_id => "..."
- key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
- value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
- codec => protobuf 
- {
-   class_name => "Animals::Mammals::Unicorn"
-   include_path => ['/path/to/protobuf/definitions/UnicornProtobuf.pb.rb']
- }
-}
-
-Usage example for protobuf v3:
-[source,ruby]
-kafka 
+kafka
 {
   topic_id => "..."
   key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
   value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
-  codec => protobuf 
+  codec => protobuf
+  {
+    class_name => "Animals::Mammals::Unicorn"
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn.pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
+  }
+}
+
+Decoder usage example for protobuf v3:
+[source,ruby]
+kafka
+{
+  topic_id => "..."
+  key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  codec => protobuf
   {
     class_name => "Animals.Mammals.Unicorn"
-    include_path => ['/path/to/pb_definitions/Animal_pb.rb', '/path/to/pb_definitions/Unicorn_pb.rb']
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
     protobuf_version => 3
   }
 }
@@ -61,10 +63,29 @@ The codec can be used in input and output plugins. +
 When using the codec in the kafka input plugin please set the deserializer classes as shown above. +
 When using the codec in an output plugin:
 
-* make sure to include all the desired fields in the protobuf definition, including timestamp. 
-  Remove fields that are not part of the protobuf definition from the event by using the mutate filter.
+* make sure to include all the desired fields in the protobuf definition, including timestamp.
+  Remove fields that are not part of the protobuf definition from the event by using the mutate filter. Encoding will fail if the event has fields which are not in the protobuf definition.
 * the `@` symbol is currently not supported in field names when loading the protobuf definitions for encoding. Make sure to call the timestamp field `timestamp`
   instead of `@timestamp` in the protobuf file. Logstash event fields will be stripped of the leading `@` before conversion.
+* fields with a nil value will automatically be removed from the event. Empty fields will not be removed.
+* it is recommended to set the config option `pb3_encoder_autoconvert_types` to true. Otherwise any type mismatch between your data and the protobuf definition will cause an event to be lost. The auto typeconversion does not alter your data. It just tries to convert obviously identical data into the expected datatype, such as converting integers to floats where floats are expected, or "true" / "false" strings into booleans where booleans are expected.
+* When writing to Kafka: set the serializer class: `value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"`
+
+Encoder usage example (protobufg v3):
+
+[source,ruby]
+kafka
+  {
+    codec => protobuf
+    {
+      class_name => "Animals.Mammals.Unicorn"
+      class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+      protobuf_root_directory => "/path/to/pb_definitions/"
+      protobuf_version => 3
+    }
+    value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"
+  }
+}
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -74,14 +95,18 @@ When using the codec in an output plugin:
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-class_name>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-include_path>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-class_file>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-protobuf_root_directory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-include_path>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-protobuf_version>> |<<number,number>>|Yes
+| <<plugins-{type}s-{plugin}-stop_on_error>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types>> |<<boolean,boolean>>|No
 |=======================================================================
 
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-class_name"]
-===== `class_name` 
+===== `class_name`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -100,18 +125,45 @@ For protobuf v3, you can copy the class name from the Descriptorpool registratio
 [source,ruby]
 Animals.Mammals.Unicorn = Google::Protobuf::DescriptorPool.generated_pool.lookup("Animals.Mammals.Unicorn").msgclass
 
-
 If your class references other definitions: you only have to add the name of the main class here.
 
-[id="plugins-{type}s-{plugin}-include_path"]
-===== `include_path` 
+[id="plugins-{type}s-{plugin}-class_file"]
+===== `class_file`
 
-  * This is a required setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Absolute path to the directory that contains all compiled protobuf files. If the protobuf definitions are spread across multiple folders, this needs to point to the folder containing all those folders.
+
+[id="plugins-{type}s-{plugin}-protobuf_root_directory"]
+===== `protobuf_root_directory`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Absolute path to the root directory that contains all referenced/used dependencies of the main class (`class_name`) or any of its dependencies. Must be used in combination with the `class_file` setting, and can not be used in combination with the legacy loading mechanism `include_path`.
+
+Example:
+
+[source]
+ pb3
+   ├── header
+   │   └── header_pb.rb
+   ├── messageA_pb.rb
+
+In this case `messageA_pb.rb` has an embedded message from `header/header_pb.rb`.
+If `class_file` is set to `messageA_pb.rb`, and `class_name` to `MessageA`, `protobuf_root_directory` must be set to `/path/to/pb3`, which includes both definitions.
+
+
+[id="plugins-{type}s-{plugin}-include_path"]
+===== `include_path`
+
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-List of absolute pathes to files with protobuf definitions. 
-When using more than one file, make sure to arrange the files in reverse order of dependency so that each class is loaded before it is 
+Legacy protobuf definition loading mechanism for backwards compatibility:
+List of absolute pathes to files with protobuf definitions.
+When using more than one file, make sure to arrange the files in reverse order of dependency so that each class is loaded before it is
 refered to by another.
 
 Example: a class _Unicorn_ referencing another protobuf class _Wings_
@@ -130,13 +182,34 @@ include_path => ['/path/to/pb_definitions/wings.pb.rb','/path/to/pb_definitions/
 
 Please note that protobuf v2 files have the ending `.pb.rb` whereas files compiled for protobuf v3 end in `_pb.rb`.
 
+Cannot be used together with `protobuf_root_directory` or `class_file`.
+
 [id="plugins-{type}s-{plugin}-protobuf_version"]
-===== `protobuf_version` 
+===== `protobuf_version`
 
   * Value type is <<number,number>>
   * Default value is 2
 
 Protocol buffers version. Valid settings are 2, 3.
 
+[id="plugins-{type}s-{plugin}-stop_on_error"]
+===== `stop_on_error`
 
+  * Value type is <<boolean,boolean>>
+  * Default value is false
+
+Stop entire pipeline when encountering a non decodable message.
+
+[id="plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types"]
+===== `pb3_encoder_autoconvert_types`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is true
+
+Convert data types to match the protobuf definition (if possible).
+The protobuf encoder library is very strict with regards to data types. Example: an event has an integer field but the protobuf definition expects a float. This would lead to an exception and the event would be lost.
+This feature tries to convert the datatypes to the expectations of the protobuf definitions, without modifying the data whatsoever. Examples of conversions it might attempt:
+"true" string => true boolean
+17 int => 17.0 float
+12345 number => "12345" string
 

--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -67,11 +67,8 @@ simply `duration`. Further, a string `55.3.244.1` might identify the `client`
 making a request.
 
 For the above example, your grok filter would look something like this:
-
 [source,ruby]
------
 %{NUMBER:duration} %{IP:client}
------
 
 Optionally you can add a data type conversion to your grok pattern. By default
 all semantics are saved as strings. If you wish to convert a semantic's data type,
@@ -79,27 +76,19 @@ for example change a string to an integer then suffix it with the target data ty
 For example `%{NUMBER:num:int}` which converts the `num` semantic from a string to an
 integer. Currently the only supported conversions are `int` and `float`.
 
-Examples:
+.Examples:
 
 With that idea of a syntax and semantic, we can pull out useful fields from a
 sample log like this fictional http request log:
-
 [source,ruby]
------
     55.3.244.1 GET /index.html 15824 0.043
------
 
 The pattern for this could be:
-
 [source,ruby]
------
     %{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}
------
 
 A more realistic example, let's read these logs from a file:
-
 [source,ruby]
------
     input {
       file {
         path => "/var/log/http.log"
@@ -110,7 +99,6 @@ A more realistic example, let's read these logs from a file:
         match => { "message" => "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}" }
       }
     }
------
 
 After the grok filter, the event will have a few extra fields in it:
 
@@ -134,19 +122,13 @@ a few options.
 
 First, you can use the Oniguruma syntax for named capture which will
 let you match a piece of text and save it as a field:
-
 [source,ruby]
------
     (?<field_name>the pattern here)
------
 
 For example, postfix logs have a `queue id` that is an 10 or 11-character
 hexadecimal value. I can capture that easily like this:
-
 [source,ruby]
------
     (?<queue_id>[0-9A-F]{10,11})
------
 
 Alternately, you can create a custom patterns file.
 
@@ -156,30 +138,21 @@ Alternately, you can create a custom patterns file.
   the regexp for that pattern.
 
 For example, doing the postfix queue id example as above:
-
 [source,ruby]
------
     # contents of ./patterns/postfix:
     POSTFIX_QUEUEID [0-9A-F]{10,11}
------
 
 Then use the `patterns_dir` setting in this plugin to tell logstash where
 your custom patterns directory is. Here's a full example with a sample log:
-
 [source,ruby]
------
     Jan  1 06:25:43 mailserver14 postfix/cleanup[21403]: BEF25A72965: message-id=<20130101142543.5828399CCAF@mailserver14.example.com>
------
-
 [source,ruby]
------
     filter {
       grok {
         patterns_dir => ["./patterns"]
         match => { "message" => "%{SYSLOGBASE} %{POSTFIX_QUEUEID:queue_id}: %{GREEDYDATA:syslog_message}" }
       }
     }
------
 
 The above will match and result in the following fields:
 
@@ -250,12 +223,8 @@ If `true`, keep empty captures as event fields.
 
 A hash that defines the mapping of _where to look_, and with which patterns.
 
-For example, the following will match an existing value in the `message` field
-for the given pattern, and if a match is found will add the field `duration` to
-the event with the captured value:
-
+For example, the following will match an existing value in the `message` field for the given pattern, and if a match is found will add the field `duration` to the event with the captured value:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -263,13 +232,9 @@ the event with the captured value:
         }
       }
     }
------
 
-If you need to match multiple patterns against a single field, the value can be
-an array of patterns:
-
+If you need to match multiple patterns against a single field, the value can be an array of patterns:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -280,7 +245,6 @@ an array of patterns:
         }
       }
     }
------
 
 [id="plugins-{type}s-{plugin}-named_captures_only"]
 ===== `named_captures_only` 
@@ -302,16 +266,13 @@ This allows you to overwrite a value in a field that already exists.
 
 For example, if you have a syslog line in the `message` field, you can
 overwrite the `message` field with part of the match like so:
-
 [source,ruby]
------
     filter {
       grok {
         match => { "message" => "%{SYSLOGBASE} %{DATA:message}" }
         overwrite => [ "message" ]
       }
     }
------
 
 In this case, a line like `May 29 16:37:11 sadness logger: hello world`
 will be parsed and `hello world` will overwrite the original message.
@@ -339,25 +300,16 @@ necessarily need to define this yourself unless you are adding additional
 patterns. You can point to multiple pattern directories using this setting.
 Note that Grok will read all files in the directory matching the patterns_files_glob
 and assume it's a pattern file (including any tilde backup files). 
-
 [source,ruby]
------
     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
------
 
 Pattern files are plain text with format:
-
 [source,ruby]
------
     NAME PATTERN
------
 
 For example:
-
 [source,ruby]
------
     NUMBER \d+
------
 
 The patterns are loaded when the pipeline is created.
 

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.7
-:release_date: 2019-05-30
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.7/CHANGELOG.md
+:version: v1.0.6
+:release_date: 2019-05-01
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -23,12 +23,11 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This filter executes a SQL query and store the result set in the field
 specified as `target`.
-It will cache the results locally in an LRU cache with expiry.
+It will cache the results locally in an LRU cache with expiry
 
-For example, you can load a row based on an id in the event.
+For example you can load a row based on an id from in the event
 
 [source,ruby]
------
 filter {
   jdbc_streaming {
     jdbc_driver_library => "/path/to/mysql-connector-java-5.1.34-bin.jar"
@@ -41,7 +40,7 @@ filter {
     target => "country_details"
   }
 }
------
+
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Jdbc_streaming Filter Configuration Options
@@ -80,15 +79,13 @@ filter plugins.
   * Value type is <<number,number>>
   * Default value is `5.0`
 
-The minimum number of seconds any entry should remain in the cache. Defaults to 5 seconds.
-
-A numeric value. You can use decimals for example: `cache_expiration => 0.25`.
-If there are transient jdbc errors, the cache will store empty results for a
-given parameter set and bypass the jbdc lookup. This will merge the default_hash
-into the event until the cache entry expires. Then the jdbc lookup will be tried
-again for the same parameters. Conversely, while the cache contains valid results,
-any external problem that would cause jdbc errors will not be noticed for the
-cache_expiration period.
+The minimum number of seconds any entry should remain in the cache, defaults to 5 seconds
+A numeric value, you can use decimals for example `{ "cache_expiration" => 0.25 }`
+If there are transient jdbc errors the cache will store empty results for a given
+parameter set and bypass the jbdc lookup, this merges the default_hash into the event, until
+the cache entry expires, then the jdbc lookup will be tried again for the same parameters
+Conversely, while the cache contains valid results any external problem that would cause
+jdbc errors, will not be noticed for the cache_expiration period.
 
 [id="plugins-{type}s-{plugin}-cache_size"]
 ===== `cache_size` 
@@ -96,8 +93,8 @@ cache_expiration period.
   * Value type is <<number,number>>
   * Default value is `500`
 
-The maximum number of cache entries that will be stored. Defaults to 500 entries.
-The least recently used entry will be evicted.
+The maximum number of cache entries are stored, defaults to 500 entries
+The least recently used entry will be evicted
 
 [id="plugins-{type}s-{plugin}-default_hash"]
 ===== `default_hash` 
@@ -106,7 +103,7 @@ The least recently used entry will be evicted.
   * Default value is `{}`
 
 Define a default object to use when lookup fails to return a matching row.
-Ensure that the key names of this object match the columns from the statement.
+ensure that the key names of this object match the columns from the statement
 
 [id="plugins-{type}s-{plugin}-jdbc_connection_string"]
 ===== `jdbc_connection_string` 
@@ -133,8 +130,8 @@ JDBC driver class to load, for example "oracle.jdbc.OracleDriver" or "org.apache
   * There is no default value for this setting.
 
 Tentative of abstracting JDBC logic to a mixin
-for potential reuse in other plugins (input/output).
-This method is called when someone includes this module.
+for potential reuse in other plugins (input/output)
+This method is called when someone includes this module
 Add these methods to the 'base' given.
 JDBC driver library path to third party driver library.
 
@@ -170,7 +167,7 @@ Validate connection before use.
   * Default value is `3600`
 
 Connection pool configuration.
-How often to validate a connection (in seconds).
+How often to validate a connection (in seconds)
 
 [id="plugins-{type}s-{plugin}-parameters"]
 ===== `parameters` 
@@ -178,7 +175,7 @@ How often to validate a connection (in seconds).
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Hash of query parameter, for example `{ "id" => "id_field" }`.
+Hash of query parameter, for example `{ "id" => "id_field" }`
 
 [id="plugins-{type}s-{plugin}-statement"]
 ===== `statement` 
@@ -188,7 +185,7 @@ Hash of query parameter, for example `{ "id" => "id_field" }`.
   * There is no default value for this setting.
 
 Statement to execute.
-To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABLE WHERE ID = :id".
+To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABLE WHERE ID = :id"
 
 [id="plugins-{type}s-{plugin}-tag_on_default_use"]
 ===== `tag_on_default_use` 
@@ -196,7 +193,7 @@ To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABL
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingdefaultsused"]`
 
-Append values to the `tags` field if no record was found and default values were used.
+Append values to the `tags` field if no record was found and default values were used
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
 ===== `tag_on_failure` 
@@ -204,7 +201,7 @@ Append values to the `tags` field if no record was found and default values were
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingfailure"]`
 
-Append values to the `tags` field if sql error occurred.
+Append values to the `tags` field if sql error occured
 
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target` 
@@ -213,8 +210,8 @@ Append values to the `tags` field if sql error occurred.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-Define the target field to store the extracted result(s).
-Field is overwritten if exists.
+Define the target field to store the extracted result(s)
+Field is overwritten if exists
 
 [id="plugins-{type}s-{plugin}-use_cache"]
 ===== `use_cache` 
@@ -222,7 +219,7 @@ Field is overwritten if exists.
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-Enable or disable caching, boolean true or false. Defaults to true.
+Enable or disable caching, boolean true or false, defaults to true
 
 
 

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.1
-:release_date: 2019-05-31
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-memcached/blob/v1.0.1/CHANGELOG.md
+:version: v1.0.0
+:release_date: 2019-02-04
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-memcached/blob/v1.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/useragent.asciidoc
+++ b/docs/plugins/filters/useragent.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.4
-:release_date: 2019-05-24
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.2.4/CHANGELOG.md
+:version: v3.2.3
+:release_date: 2018-09-24
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.2.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.1.2
-:release_date: 2019-05-28
-:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.1.2/CHANGELOG.md
+:version: v1.1.1
+:release_date: 2019-05-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -260,7 +260,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -260,7 +260,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#sliced-scroll[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/faq.html[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/inode-reuse-issue.html[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/plugins/inputs/jms.asciidoc
+++ b/docs/plugins/inputs/jms.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.0
-:release_date: 2019-06-17
-:changelog_url: https://github.com/logstash-plugins/logstash-input-jms/blob/v3.1.0/CHANGELOG.md
+:version: v3.1.1
+:release_date: 2019-07-08
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jms/blob/v3.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -36,7 +36,6 @@ JMS configurations can be done either entirely in the Logstash configuration fil
 
 
 ==== Sample Configuration using Logstash Configuration Only
-
 
 Configurations can be configured either entirely in Logstash configuration, or via a combination of Logstash configuration
 and yaml file, which can be useful for sharing similar configurations across multiple inputs and outputs.
@@ -87,7 +86,6 @@ The JMS plugin can also be configured using JNDI if desired.
 <7> Keystore and Truststore to use when connecting to the JMS provider, if required.
 <8> Parts of the JMS Message to include in the event - headers, properties and the message body can be included or
     excluded from the event.
-
 <9> Message selector: Use this to filter messages to be processed. The whole selector query should be double-quoted,
     string property values should be single quoted, and numeric property vaues should not be quoted.
     See JMS provider documentation for exact syntax.
@@ -352,6 +350,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-durable_subscriber_client_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-durable_subscriber_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-factory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-factory_settings>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-include_body>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_header>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_properties>> |<<boolean,boolean>>|No
@@ -444,6 +443,18 @@ is set to `true`. Please consult your JMS Provider documentation for constraints
   * There is no default value for this setting.
 
 Full name (including package name) of Java connection factory used to create a connection with your JMS provider.
+
+[id="plugins-{type}s-{plugin}-factory_settings"]
+===== `factory_settings`
+
+  * Value type is <<hash,hash>>
+  * There is no default value for this setting.
+
+Hash of implementation specific configuration values to set on the connection factory of the JMS provider. Each JMS
+ Provider will have its own set of parameters that can be used here. These parameters are mapped to `set` methods on
+ the provided connection factory, and can be supplied in either 'snake' or 'camel' case. For example, a hash including
+ `exclusive_consumer => true` would call `setExclusiveConsumer(true)` on the supplied connection factory.
+ See your JMS provider documentation for implementation specific details.
 
 [id="plugins-{type}s-{plugin}-include_body"]
 ===== `include_body`

--- a/docs/plugins/inputs/jmx.asciidoc
+++ b/docs/plugins/inputs/jmx.asciidoc
@@ -27,7 +27,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-==== Configuration
+==== The configuration
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing

--- a/docs/plugins/inputs/redis.asciidoc
+++ b/docs/plugins/inputs/redis.asciidoc
@@ -1,14 +1,13 @@
 :plugin: redis
 :type: input
 :default_plugin: 1
-:default_codec: json
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.4.1
-:release_date: 2019-02-04
-:changelog_url: https://github.com/logstash-plugins/logstash-input-redis/blob/v3.4.1/CHANGELOG.md
+:version: v3.1.4
+:release_date: 2017-08-16
+:changelog_url: https://github.com/logstash-plugins/logstash-input-redis/blob/v3.1.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -47,14 +46,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-data_type>> |<<string,string>>, one of `["list", "channel", "pattern_channel"]`|Yes
 | <<plugins-{type}s-{plugin}-db>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-threads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-command_map>> |<<hash,hash>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -63,7 +59,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-batch_count"]
-===== `batch_count`
+===== `batch_count` 
 
   * Value type is <<number,number>>
   * Default value is `125`
@@ -71,18 +67,18 @@ input plugins.
 The number of events to return from Redis using EVAL.
 
 [id="plugins-{type}s-{plugin}-data_type"]
-===== `data_type`
+===== `data_type` 
 
   * This is a required setting.
   * Value can be any of: `list`, `channel`, `pattern_channel`
   * There is no default value for this setting.
 
-Specify either list or channel.  If `data_type` is `list`, then we will BLPOP the
-key.  If `data_type` is `channel`, then we will SUBSCRIBE to the key.
-If `data_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
+Specify either list or channel.  If `redis\_type` is `list`, then we will BLPOP the
+key.  If `redis\_type` is `channel`, then we will SUBSCRIBE to the key.
+If `redis\_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 
 [id="plugins-{type}s-{plugin}-db"]
-===== `db`
+===== `db` 
 
   * Value type is <<number,number>>
   * Default value is `0`
@@ -90,24 +86,15 @@ If `data_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 The Redis database number.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host`
+===== `host` 
 
   * Value type is <<string,string>>
   * Default value is `"127.0.0.1"`
 
 The hostname of your Redis server.
 
-[id="plugins-{type}s-{plugin}-path"]
-===== `path`
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-  * Path will override Host configuration if both specified.
-
-The unix socket path of your Redis server.
-
 [id="plugins-{type}s-{plugin}-key"]
-===== `key`
+===== `key` 
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -116,7 +103,7 @@ The unix socket path of your Redis server.
 The name of a Redis list or channel.
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password`
+===== `password` 
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -124,24 +111,15 @@ The name of a Redis list or channel.
 Password to authenticate with. There is no authentication by default.
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port`
+===== `port` 
 
   * Value type is <<number,number>>
   * Default value is `6379`
 
 The port to connect on.
 
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
-
-Enable SSL support.
-
-
 [id="plugins-{type}s-{plugin}-threads"]
-===== `threads`
+===== `threads` 
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -149,24 +127,14 @@ Enable SSL support.
 
 
 [id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout`
+===== `timeout` 
 
   * Value type is <<number,number>>
   * Default value is `5`
 
 Initial connection timeout in seconds.
 
-[id="plugins-{type}s-{plugin}-command_map"]
-===== `command_map`
 
-  * Value type is <<hash,hash>>
-  * There is no default value for this setting.
-  * key is the default command name, value is the renamed command.
-
-Configure renamed redis commands in the form of "oldname" => "newname".
-Redis allows for the renaming or disabling of commands in its protocol, see:  https://redis.io/topics/security
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
-
-:default_codec!:

--- a/docs/plugins/inputs/snmp.asciidoc
+++ b/docs/plugins/inputs/snmp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2019-05-29
-:changelog_url: https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.2.0/CHANGELOG.md
+:version: v1.1.0
+:release_date: 2019-03-28
+:changelog_url: https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -60,10 +60,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-mib_paths>> |<<path,path>>|No
-| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-oid_path_length>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-walk>> |<<array,array>>|No
-| <<plugins-{type}s-{plugin}-tables>> |<<array,array>>|No
 |=======================================================================
 
 ==== SNMPv3 Authentication Options
@@ -171,21 +169,10 @@ If you require other MIBs, you need to import them. See <<plugins-{type}s-{plugi
 [id="plugins-{type}s-{plugin}-oid_root_skip"]
 ===== `oid_root_skip` 
 
-The `oid_root_skip` option specifies the number of OID root digits to ignore in the event field name.
+The `oid_root_skip` option specifies the  number of OID root digits to ignore in event field name.
 For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the first 5 digits could be ignored by setting `oid_root_skip => 5`
 which would result in a field name "1.1.1.0". Similarly when a MIB is used an OID such
 "1.3.6.1.2.mib-2.system.sysDescr.0" would become "mib-2.system.sysDescr.0"
-
-* Value type is <<number,number>>
-* Default value is `0`
-
-[id="plugins-{type}s-{plugin}-oid_path_length"]
-===== `oid_path_length`
-
-The `oid_path_length` option specifies the number of OID root digits to retain in the event field name.
-For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the last 2 digits could be retained by setting `oid_path_length => 2`
-which would result in a field name "1.0". Similarly when a MIB is used an OID such
-"1.3.6.1.2.mib-2.system.sysDescr.0" would become "sysDescr.0"
 
 * Value type is <<number,number>>
 * Default value is `0`
@@ -207,41 +194,6 @@ Example
   snmp {
     walk => ["1.3.6.1.2.1.1"]
     hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
-  }
-}
------
-
-[id="plugins-{type}s-{plugin}-tables"]
-===== `tables`
-
-The `tables` option is used to query for tabular values for the given column OID(s).
-
-Each table definition is a hash and must define the name key and value and the columns to return.
-
-* Value type is <<array,array>>
-* There is no default value for this setting
-* Results are returned under a field using the table name
-
-*Specifying a single table*
-
-[source,ruby]
------
-input {
-  snmp {
-    hosts => [{host => "udp:127.0.0.1/161" community => "public" version => "2c"  retries => 2  timeout => 1000}]
-    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]} ]
-  }
-}
------
-
-*Specifying multiple tables*
-
-[source,ruby]
------
-input {
-  snmp {
-    get => ["1.3.6.1.2.1.1.1.0"]
-    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]}, {"name" => "ltmPoolStatTable" "columns" => ["1.3.6.1.4.1.3375.2.2.5.2.3.1.1", "1.3.6.1.4.1.3375.2.2.5.2.3.1.6"]} ]
   }
 }
 -----
@@ -300,25 +252,6 @@ The `security_level` option specifies the SNMPv3 security level between Authenti
 
 * Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
 * There is no default value for this setting
-
-*Specifying SNMPv3 settings*
-
-[source,ruby]
------
-input {
-  snmp {
-    hosts => [{host => "udp:127.0.0.1/161" version => "3"}]
-    get => ["1.3.6.1.2.1.1.1.0"]
-    security_name => "mySecurityName"
-    auth_protocol => "sha"
-    auth_pass => "ShaPassword"
-    priv_protocol => "aes"
-    priv_pass => "AesPasword"
-    security_level => "authPriv"
-  }
-}
-
------
 
 ==== More configuration examples
 

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.0.3
-:release_date: 2019-06-05
-:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.3/CHANGELOG.md
+:version: v6.0.2
+:release_date: 2019-03-09
+:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/circonus.asciidoc
+++ b/docs/plugins/outputs/circonus.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.5
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-circonus/blob/v3.0.5/CHANGELOG.md
+:version: v3.0.6
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-circonus/blob/v3.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,14 +1,14 @@
 :plugin: elastic_app_search
 :type: output
 :default_plugin: 1
-:no_codec:
+:default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.0
-:release_date: 2019-06-12
-:changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.0.0/CHANGELOG.md
+:version: v1.0.0.beta1
+:release_date: 2018-11-06
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.0.0.beta1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -22,9 +22,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the Elastic App Search solution, 
-both the https://www.elastic.co/downloads/app-search[self-managed] or 
-the https://www.elastic.co/cloud/app-search-service[managed] service.
+This output lets you send events to the Elastic App Search solution.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the App Search bulk API
 to index multiple events in one request.
@@ -50,10 +48,8 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-engine>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-path>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-timestamp_destination>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -93,15 +89,6 @@ The Engine name. Engine is your search engine created in App Search, an informat
   * There is no default value
 
 The hostname of the App Search API that is associated with your App Search account.
-Set this when using the https://www.elastic.co/cloud/app-search-service[Elastic App Search managed service].
-
-[id="plugins-{type}s-{plugin}-path"]
-===== `path`
-
-  * Value type is <<string,string>>
-  * Default value is `/api/as/v1/`
-
-The path that is appended to the `url` parameter when connecting to a https://www.elastic.co/downloads/app-search[self-managed Elastic App Search].
 
 [id="plugins-{type}s-{plugin}-timestamp_destination"]
 ===== `timestamp_destination`
@@ -117,16 +104,8 @@ by default, the `@timestamp` field will be deleted.
 
 To keep the timestamp field, set this value to the name of the field where you want `@timestamp` copied.
 
-[id="plugins-{type}s-{plugin}-url"]
-===== `url`
-
-  * Value type is <<string,string>>
-  * There is no default value
-
-The value of the API endpoint in the form of a URL. Note: The value of the of the `path` setting will be will be appended to this URL.
-Set this when using the https://www.elastic.co/downloads/app-search[self-managed Elastic App Search].
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:no_codec!:
+:default_codec!:

--- a/docs/plugins/outputs/google_bigquery.asciidoc
+++ b/docs/plugins/outputs/google_bigquery.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.1
-:release_date: 2018-10-25
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.1/CHANGELOG.md
+:version: v4.1.3
+:release_date: 2019-10-17
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/google_cloud_storage.asciidoc
+++ b/docs/plugins/outputs/google_cloud_storage.asciidoc
@@ -1,14 +1,14 @@
 :plugin: google_cloud_storage
 :type: output
 :default_plugin: 0
-:default_codec: plain
+:default_codec: line
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.0.1
-:release_date: 2019-06-24
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/blob/v4.0.1/CHANGELOG.md
+:version: v4.1.0
+:release_date: 2019-08-08
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/blob/v4.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -102,7 +102,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-max_concurrent_uploads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-max_file_size_kbytes>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain"]`|No
+| <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain", nil]`|__Deprecated__
 | <<plugins-{type}s-{plugin}-service_account>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-temp_directory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-uploader_interval_secs>> |<<number,number>>|No
@@ -265,10 +265,17 @@ Sets max file size in kbytes. 0 disable max file check.
 [id="plugins-{type}s-{plugin}-output_format"]
 ===== `output_format` 
 
-  * Value can be any of: `json`, `plain`
-  * Default value is `"plain"`
+  * Value can be any of: `json`, `plain`, or no value
+  * Default value is no value
+
+**Deprecated**, this feature will be removed in the next major release. Use codecs instead.
+
+  * If you are using the `json` value today, switch to the `json_lines` codec.
+  * If you are using the `plain` value today, switch to the `line` codec.
 
 The event format you want to store in files. Defaults to plain text.
+
+Note: if you want to use a codec you MUST not set this value.
 
 [id="plugins-{type}s-{plugin}-service_account"]
 ===== `service_account` 

--- a/docs/plugins/outputs/google_pubsub.asciidoc
+++ b/docs/plugins/outputs/google_pubsub.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.1
-:release_date: 2018-09-25
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.1/CHANGELOG.md
+:version: v1.0.2
+:release_date: 2019-09-18
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -79,9 +79,9 @@ output {
     json_key_file => "service_account_key.json"
 
     # Options for configuring the upload
-    message_count_threshold => 10000
+    message_count_threshold => 1000
     delay_threshold_secs => 10
-    request_byte_threshold => 5MB
+    request_byte_threshold => 5000000
   }
 }
 ------------------------------------------------------------------------------
@@ -210,7 +210,7 @@ A value of 0 will cause messages to instantly be sent but will reduce total thro
 ===== `request_byte_threshold`
 
   * Value type is <<bytes,bytes>>
-  * Default is: `1_000_000`
+  * Default is: `1000000`
 
 Once the number of bytes in the batched request reaches this threshold, send all of the messages in
 a single call, even if neither the delay or message count thresholds have been exceeded yet.

--- a/docs/plugins/outputs/librato.asciidoc
+++ b/docs/plugins/outputs/librato.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-librato/blob/v3.0.6/CHANGELOG.md
+:version: v3.0.7
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-librato/blob/v3.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -131,6 +131,7 @@ Example:
 -----
     
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
+
 [source,ruby]
 -----
     {
@@ -161,6 +162,7 @@ Example:
         "name" => "apache_bytes"
     }
 -----
+
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
 
 [source,ruby]
@@ -172,6 +174,7 @@ Additionally, you can override the `measure_time` for the event. Must be a unix 
         "measure_time" => "%{my_unixtime_field}
     }
 -----
+
 Default is to use the event's timestamp
 
 

--- a/docs/plugins/outputs/riak.asciidoc
+++ b/docs/plugins/outputs/riak.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.4
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-riak/blob/v3.0.4/CHANGELOG.md
+:version: v3.0.5
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-riak/blob/v3.0.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -172,11 +172,11 @@ No mix and match
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-SSL Options
-Options for SSL connections
-Only applied if SSL is enabled
+Options for SSL connections.
+Only applied if SSL is enabled.
 Logstash hash that maps to the riak-client options
-here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak
+here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak.
+
 You'll likely want something like this:
 
 [source, ruby]

--- a/docs/plugins/outputs/riemann.asciidoc
+++ b/docs/plugins/outputs/riemann.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.4
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-riemann/blob/v3.0.4/CHANGELOG.md
+:version: v3.0.5
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-riemann/blob/v3.0.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -33,7 +33,9 @@ outputs
 You can learn about Riemann here:
 
 * http://riemann.io/
+
 You can see the author talk about it here:
+
 * http://vimeo.com/38377415
 
 


### PR DESCRIPTION
Updated plugin docs (manually generated).  There are several regressions driven by the lockfile (https://github.com/elastic/logstash/blob/7.2/Gemfile.jruby-2.5.lock.release). I manually overrode three of the regressions to avoid breaking the doc builds. 