### PR TITLE
Update plugin docs for 7.3

### DIFF
--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.0
-:release_date: 2019-07-22
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.1.0/CHANGELOG.md
+:version: v4.0.4
+:release_date: 2018-10-19
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -67,11 +67,8 @@ simply `duration`. Further, a string `55.3.244.1` might identify the `client`
 making a request.
 
 For the above example, your grok filter would look something like this:
-
 [source,ruby]
------
 %{NUMBER:duration} %{IP:client}
------
 
 Optionally you can add a data type conversion to your grok pattern. By default
 all semantics are saved as strings. If you wish to convert a semantic's data type,
@@ -79,27 +76,19 @@ for example change a string to an integer then suffix it with the target data ty
 For example `%{NUMBER:num:int}` which converts the `num` semantic from a string to an
 integer. Currently the only supported conversions are `int` and `float`.
 
-Examples:
+.Examples:
 
 With that idea of a syntax and semantic, we can pull out useful fields from a
 sample log like this fictional http request log:
-
 [source,ruby]
------
     55.3.244.1 GET /index.html 15824 0.043
------
 
 The pattern for this could be:
-
 [source,ruby]
------
     %{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}
------
 
 A more realistic example, let's read these logs from a file:
-
 [source,ruby]
------
     input {
       file {
         path => "/var/log/http.log"
@@ -110,7 +99,6 @@ A more realistic example, let's read these logs from a file:
         match => { "message" => "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}" }
       }
     }
------
 
 After the grok filter, the event will have a few extra fields in it:
 
@@ -134,19 +122,13 @@ a few options.
 
 First, you can use the Oniguruma syntax for named capture which will
 let you match a piece of text and save it as a field:
-
 [source,ruby]
------
     (?<field_name>the pattern here)
------
 
 For example, postfix logs have a `queue id` that is an 10 or 11-character
 hexadecimal value. I can capture that easily like this:
-
 [source,ruby]
------
     (?<queue_id>[0-9A-F]{10,11})
------
 
 Alternately, you can create a custom patterns file.
 
@@ -156,30 +138,21 @@ Alternately, you can create a custom patterns file.
   the regexp for that pattern.
 
 For example, doing the postfix queue id example as above:
-
 [source,ruby]
------
     # contents of ./patterns/postfix:
     POSTFIX_QUEUEID [0-9A-F]{10,11}
------
 
 Then use the `patterns_dir` setting in this plugin to tell logstash where
 your custom patterns directory is. Here's a full example with a sample log:
-
 [source,ruby]
------
     Jan  1 06:25:43 mailserver14 postfix/cleanup[21403]: BEF25A72965: message-id=<20130101142543.5828399CCAF@mailserver14.example.com>
------
-
 [source,ruby]
------
     filter {
       grok {
         patterns_dir => ["./patterns"]
         match => { "message" => "%{SYSLOGBASE} %{POSTFIX_QUEUEID:queue_id}: %{GREEDYDATA:syslog_message}" }
       }
     }
------
 
 The above will match and result in the following fields:
 
@@ -250,12 +223,8 @@ If `true`, keep empty captures as event fields.
 
 A hash that defines the mapping of _where to look_, and with which patterns.
 
-For example, the following will match an existing value in the `message` field
-for the given pattern, and if a match is found will add the field `duration` to
-the event with the captured value:
-
+For example, the following will match an existing value in the `message` field for the given pattern, and if a match is found will add the field `duration` to the event with the captured value:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -263,13 +232,9 @@ the event with the captured value:
         }
       }
     }
------
 
-If you need to match multiple patterns against a single field, the value can be
-an array of patterns:
-
+If you need to match multiple patterns against a single field, the value can be an array of patterns:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -280,7 +245,6 @@ an array of patterns:
         }
       }
     }
------
 
 [id="plugins-{type}s-{plugin}-named_captures_only"]
 ===== `named_captures_only` 
@@ -302,16 +266,13 @@ This allows you to overwrite a value in a field that already exists.
 
 For example, if you have a syslog line in the `message` field, you can
 overwrite the `message` field with part of the match like so:
-
 [source,ruby]
------
     filter {
       grok {
         match => { "message" => "%{SYSLOGBASE} %{DATA:message}" }
         overwrite => [ "message" ]
       }
     }
------
 
 In this case, a line like `May 29 16:37:11 sadness logger: hello world`
 will be parsed and `hello world` will overwrite the original message.
@@ -339,25 +300,16 @@ necessarily need to define this yourself unless you are adding additional
 patterns. You can point to multiple pattern directories using this setting.
 Note that Grok will read all files in the directory matching the patterns_files_glob
 and assume it's a pattern file (including any tilde backup files). 
-
 [source,ruby]
------
     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
------
 
 Pattern files are plain text with format:
-
 [source,ruby]
------
     NAME PATTERN
------
 
 For example:
-
 [source,ruby]
------
     NUMBER \d+
------
 
 The patterns are loaded when the pipeline is created.
 

--- a/docs/plugins/filters/http.asciidoc
+++ b/docs/plugins/filters/http.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.2
-:release_date: 2019-06-24
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-http/blob/v1.0.2/CHANGELOG.md
+:version: v1.0.1
+:release_date: 2019-02-06
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-http/blob/v1.0.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.7
-:release_date: 2019-05-30
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.7/CHANGELOG.md
+:version: v1.0.6
+:release_date: 2019-05-01
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -23,12 +23,11 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This filter executes a SQL query and store the result set in the field
 specified as `target`.
-It will cache the results locally in an LRU cache with expiry.
+It will cache the results locally in an LRU cache with expiry
 
-For example, you can load a row based on an id in the event.
+For example you can load a row based on an id from in the event
 
 [source,ruby]
------
 filter {
   jdbc_streaming {
     jdbc_driver_library => "/path/to/mysql-connector-java-5.1.34-bin.jar"
@@ -41,7 +40,7 @@ filter {
     target => "country_details"
   }
 }
------
+
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Jdbc_streaming Filter Configuration Options
@@ -80,15 +79,13 @@ filter plugins.
   * Value type is <<number,number>>
   * Default value is `5.0`
 
-The minimum number of seconds any entry should remain in the cache. Defaults to 5 seconds.
-
-A numeric value. You can use decimals for example: `cache_expiration => 0.25`.
-If there are transient jdbc errors, the cache will store empty results for a
-given parameter set and bypass the jbdc lookup. This will merge the default_hash
-into the event until the cache entry expires. Then the jdbc lookup will be tried
-again for the same parameters. Conversely, while the cache contains valid results,
-any external problem that would cause jdbc errors will not be noticed for the
-cache_expiration period.
+The minimum number of seconds any entry should remain in the cache, defaults to 5 seconds
+A numeric value, you can use decimals for example `{ "cache_expiration" => 0.25 }`
+If there are transient jdbc errors the cache will store empty results for a given
+parameter set and bypass the jbdc lookup, this merges the default_hash into the event, until
+the cache entry expires, then the jdbc lookup will be tried again for the same parameters
+Conversely, while the cache contains valid results any external problem that would cause
+jdbc errors, will not be noticed for the cache_expiration period.
 
 [id="plugins-{type}s-{plugin}-cache_size"]
 ===== `cache_size` 
@@ -96,8 +93,8 @@ cache_expiration period.
   * Value type is <<number,number>>
   * Default value is `500`
 
-The maximum number of cache entries that will be stored. Defaults to 500 entries.
-The least recently used entry will be evicted.
+The maximum number of cache entries are stored, defaults to 500 entries
+The least recently used entry will be evicted
 
 [id="plugins-{type}s-{plugin}-default_hash"]
 ===== `default_hash` 
@@ -106,7 +103,7 @@ The least recently used entry will be evicted.
   * Default value is `{}`
 
 Define a default object to use when lookup fails to return a matching row.
-Ensure that the key names of this object match the columns from the statement.
+ensure that the key names of this object match the columns from the statement
 
 [id="plugins-{type}s-{plugin}-jdbc_connection_string"]
 ===== `jdbc_connection_string` 
@@ -133,8 +130,8 @@ JDBC driver class to load, for example "oracle.jdbc.OracleDriver" or "org.apache
   * There is no default value for this setting.
 
 Tentative of abstracting JDBC logic to a mixin
-for potential reuse in other plugins (input/output).
-This method is called when someone includes this module.
+for potential reuse in other plugins (input/output)
+This method is called when someone includes this module
 Add these methods to the 'base' given.
 JDBC driver library path to third party driver library.
 
@@ -170,7 +167,7 @@ Validate connection before use.
   * Default value is `3600`
 
 Connection pool configuration.
-How often to validate a connection (in seconds).
+How often to validate a connection (in seconds)
 
 [id="plugins-{type}s-{plugin}-parameters"]
 ===== `parameters` 
@@ -178,7 +175,7 @@ How often to validate a connection (in seconds).
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Hash of query parameter, for example `{ "id" => "id_field" }`.
+Hash of query parameter, for example `{ "id" => "id_field" }`
 
 [id="plugins-{type}s-{plugin}-statement"]
 ===== `statement` 
@@ -188,7 +185,7 @@ Hash of query parameter, for example `{ "id" => "id_field" }`.
   * There is no default value for this setting.
 
 Statement to execute.
-To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABLE WHERE ID = :id".
+To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABLE WHERE ID = :id"
 
 [id="plugins-{type}s-{plugin}-tag_on_default_use"]
 ===== `tag_on_default_use` 
@@ -196,7 +193,7 @@ To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABL
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingdefaultsused"]`
 
-Append values to the `tags` field if no record was found and default values were used.
+Append values to the `tags` field if no record was found and default values were used
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
 ===== `tag_on_failure` 
@@ -204,7 +201,7 @@ Append values to the `tags` field if no record was found and default values were
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingfailure"]`
 
-Append values to the `tags` field if sql error occurred.
+Append values to the `tags` field if sql error occured
 
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target` 
@@ -213,8 +210,8 @@ Append values to the `tags` field if sql error occurred.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-Define the target field to store the extracted result(s).
-Field is overwritten if exists.
+Define the target field to store the extracted result(s)
+Field is overwritten if exists
 
 [id="plugins-{type}s-{plugin}-use_cache"]
 ===== `use_cache` 
@@ -222,7 +219,7 @@ Field is overwritten if exists.
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-Enable or disable caching, boolean true or false. Defaults to true.
+Enable or disable caching, boolean true or false, defaults to true
 
 
 

--- a/docs/plugins/filters/json.asciidoc
+++ b/docs/plugins/filters/json.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.0
-:release_date: 2019-06-17
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-json/blob/v3.1.0/CHANGELOG.md
+:version: v3.0.6
+:release_date: 2019-02-04
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-json/blob/v3.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/kv.asciidoc
+++ b/docs/plugins/filters/kv.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.4.0
-:release_date: 2019-07-22
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-kv/blob/v4.4.0/CHANGELOG.md
+:version: v4.3.1
+:release_date: 2019-04-15
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-kv/blob/v4.3.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -361,7 +361,7 @@ with the provided value (see: <<plugins-{type}s-{plugin}-timeout_millis>>).
 [id="plugins-{type}s-{plugin}-timeout_millis"]
 ===== `timeout_millis`
 
-  * Value type is <<number,number>>
+  * Value type is <<number, number>>
   * The default value for this setting is 30000 (30 seconds).
   * Set to zero (`0`) to disable timeouts
 

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.1
-:release_date: 2019-05-31
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-memcached/blob/v1.0.1/CHANGELOG.md
+:version: v1.0.0
+:release_date: 2019-02-04
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-memcached/blob/v1.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/mutate.asciidoc
+++ b/docs/plugins/filters/mutate.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.5.0
-:release_date: 2019-06-17
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.5.0/CHANGELOG.md
+:version: v3.4.0
+:release_date: 2019-02-04
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.4.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -84,7 +84,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-update>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-uppercase>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-capitalize>> |<<array,array>>|No
-| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -373,15 +372,6 @@ Example:
         capitalize => [ "fieldname" ]
       }
     }
-
-[id="plugins-{type}s-{plugin}-tag_on_failure"]
-===== `tag_on_failure`
-
-  * Value type is <<string,string>>
-  * The default value for this setting is `_mutate_error`
-
-If a failure occurs during the application of this mutate filter, the rest of
-the operations are aborted and the provided tag is added to the event.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/filters/useragent.asciidoc
+++ b/docs/plugins/filters/useragent.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.4
-:release_date: 2019-05-24
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.2.4/CHANGELOG.md
+:version: v3.2.3
+:release_date: 2018-09-24
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.2.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.1.2
-:release_date: 2019-05-28
-:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.1.2/CHANGELOG.md
+:version: v1.1.1
+:release_date: 2019-05-15
+:changelog_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -260,7 +260,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#sliced-scroll[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/faq.html[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v9.0.1
-:release_date: 2019-07-16
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v9.0.1/CHANGELOG.md
+:version: v9.0.0
+:release_date: 2019-01-11
+:changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v9.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -62,8 +62,6 @@ The following metadata from Kafka broker are added under the `[@metadata]` field
 * `[@metadata][kafka][key]`: Record key, if any.
 * `[@metadata][kafka][timestamp]`: Timestamp in the Record. Depending on your broker configuration, this can be either when the record was created (default) or when it was received by the broker. See more about property log.message.timestamp.type at https://kafka.apache.org/10/documentation.html#brokerconfigs
 
-Metadata is only added to the event if the `decorate_events` option is set to true (it defaults to false).
-
 Please note that `@metadata` fields are not part of any of your events at output time. If you need these information to be 
 inserted into your original event, you'll have to use the `mutate` filter to manually copy the required fields into your `event`.
 
@@ -106,7 +104,6 @@ https://kafka.apache.org/documentation for more details.
 | <<plugins-{type}s-{plugin}-reconnect_backoff_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
@@ -422,24 +419,6 @@ retries are exhausted.
 
 The amount of time to wait before attempting to retry a failed fetch request
 to a given topic partition. This avoids repeated fetching-and-failing in a tight loop.
-
-[id="plugins-{type}s-{plugin}-sasl_jaas_config"]
-===== `sasl_jaas_config`
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-JAAS configuration setting local to this plugin instance, as opposed to settings using config file configured using `jaas_path`, which are shared across the JVM. This allows each plugin instance to have its own configuration.
-
-If both `sasl_jaas_config` and `jaas_path` configurations are set, the setting here takes precedence.
-
-Example (setting for Azure Event Hub):
-[source,ruby]
-    input {
-      kafka {
-        sasl_jaas_config => "org.apache.kafka.common.security.plain.PlainLoginModule required username='auser'  password='apassword';"
-      }
-    }
 
 [id="plugins-{type}s-{plugin}-sasl_kerberos_service_name"]
 ===== `sasl_kerberos_service_name` 

--- a/docs/plugins/inputs/redis.asciidoc
+++ b/docs/plugins/inputs/redis.asciidoc
@@ -59,7 +59,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-batch_count"]
-===== `batch_count`
+===== `batch_count` 
 
   * Value type is <<number,number>>
   * Default value is `125`
@@ -67,18 +67,18 @@ input plugins.
 The number of events to return from Redis using EVAL.
 
 [id="plugins-{type}s-{plugin}-data_type"]
-===== `data_type`
+===== `data_type` 
 
   * This is a required setting.
   * Value can be any of: `list`, `channel`, `pattern_channel`
   * There is no default value for this setting.
 
-Specify either list or channel.  If `data_type` is `list`, then we will BLPOP the
-key.  If `data_type` is `channel`, then we will SUBSCRIBE to the key.
-If `data_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
+Specify either list or channel.  If `redis\_type` is `list`, then we will BLPOP the
+key.  If `redis\_type` is `channel`, then we will SUBSCRIBE to the key.
+If `redis\_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 
 [id="plugins-{type}s-{plugin}-db"]
-===== `db`
+===== `db` 
 
   * Value type is <<number,number>>
   * Default value is `0`
@@ -86,7 +86,7 @@ If `data_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 The Redis database number.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host`
+===== `host` 
 
   * Value type is <<string,string>>
   * Default value is `"127.0.0.1"`
@@ -94,7 +94,7 @@ The Redis database number.
 The hostname of your Redis server.
 
 [id="plugins-{type}s-{plugin}-key"]
-===== `key`
+===== `key` 
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -103,7 +103,7 @@ The hostname of your Redis server.
 The name of a Redis list or channel.
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password`
+===== `password` 
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -111,24 +111,15 @@ The name of a Redis list or channel.
 Password to authenticate with. There is no authentication by default.
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port`
+===== `port` 
 
   * Value type is <<number,number>>
   * Default value is `6379`
 
 The port to connect on.
 
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
-
-Enable SSL support.
-
-
 [id="plugins-{type}s-{plugin}-threads"]
-===== `threads`
+===== `threads` 
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -136,7 +127,7 @@ Enable SSL support.
 
 
 [id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout`
+===== `timeout` 
 
   * Value type is <<number,number>>
   * Default value is `5`

--- a/docs/plugins/inputs/snmp.asciidoc
+++ b/docs/plugins/inputs/snmp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2019-05-29
-:changelog_url: https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.2.0/CHANGELOG.md
+:version: v1.1.0
+:release_date: 2019-03-28
+:changelog_url: https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -60,10 +60,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-mib_paths>> |<<path,path>>|No
-| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-oid_path_length>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-walk>> |<<array,array>>|No
-| <<plugins-{type}s-{plugin}-tables>> |<<array,array>>|No
 |=======================================================================
 
 ==== SNMPv3 Authentication Options
@@ -171,21 +169,10 @@ If you require other MIBs, you need to import them. See <<plugins-{type}s-{plugi
 [id="plugins-{type}s-{plugin}-oid_root_skip"]
 ===== `oid_root_skip` 
 
-The `oid_root_skip` option specifies the number of OID root digits to ignore in the event field name.
+The `oid_root_skip` option specifies the  number of OID root digits to ignore in event field name.
 For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the first 5 digits could be ignored by setting `oid_root_skip => 5`
 which would result in a field name "1.1.1.0". Similarly when a MIB is used an OID such
 "1.3.6.1.2.mib-2.system.sysDescr.0" would become "mib-2.system.sysDescr.0"
-
-* Value type is <<number,number>>
-* Default value is `0`
-
-[id="plugins-{type}s-{plugin}-oid_path_length"]
-===== `oid_path_length`
-
-The `oid_path_length` option specifies the number of OID root digits to retain in the event field name.
-For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the last 2 digits could be retained by setting `oid_path_length => 2`
-which would result in a field name "1.0". Similarly when a MIB is used an OID such
-"1.3.6.1.2.mib-2.system.sysDescr.0" would become "sysDescr.0"
 
 * Value type is <<number,number>>
 * Default value is `0`
@@ -207,41 +194,6 @@ Example
   snmp {
     walk => ["1.3.6.1.2.1.1"]
     hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
-  }
-}
------
-
-[id="plugins-{type}s-{plugin}-tables"]
-===== `tables`
-
-The `tables` option is used to query for tabular values for the given column OID(s).
-
-Each table definition is a hash and must define the name key and value and the columns to return.
-
-* Value type is <<array,array>>
-* There is no default value for this setting
-* Results are returned under a field using the table name
-
-*Specifying a single table*
-
-[source,ruby]
------
-input {
-  snmp {
-    hosts => [{host => "udp:127.0.0.1/161" community => "public" version => "2c"  retries => 2  timeout => 1000}]
-    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]} ]
-  }
-}
------
-
-*Specifying multiple tables*
-
-[source,ruby]
------
-input {
-  snmp {
-    get => ["1.3.6.1.2.1.1.1.0"]
-    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]}, {"name" => "ltmPoolStatTable" "columns" => ["1.3.6.1.4.1.3375.2.2.5.2.3.1.1", "1.3.6.1.4.1.3375.2.2.5.2.3.1.6"]} ]
   }
 }
 -----
@@ -300,25 +252,6 @@ The `security_level` option specifies the SNMPv3 security level between Authenti
 
 * Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
 * There is no default value for this setting
-
-*Specifying SNMPv3 settings*
-
-[source,ruby]
------
-input {
-  snmp {
-    hosts => [{host => "udp:127.0.0.1/161" version => "3"}]
-    get => ["1.3.6.1.2.1.1.1.0"]
-    security_name => "mySecurityName"
-    auth_protocol => "sha"
-    auth_pass => "ShaPassword"
-    priv_protocol => "aes"
-    priv_pass => "AesPasword"
-    security_level => "authPriv"
-  }
-}
-
------
 
 ==== More configuration examples
 

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.0.3
-:release_date: 2019-06-05
-:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.3/CHANGELOG.md
+:version: v6.0.2
+:release_date: 2019-03-09
+:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/twitter.asciidoc
+++ b/docs/plugins/inputs/twitter.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.0.1
-:release_date: 2019-07-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-twitter/blob/v4.0.1/CHANGELOG.md
+:version: v4.0.0
+:release_date: 2019-04-12
+:changelog_url: https://github.com/logstash-plugins/logstash-input-twitter/blob/v4.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Updated plugin docs (manually generated)

Notes to self:  
* The manual docgen process was wonky and threw lots of errors. I finally got some output, but I don't want to assume that the output is correct without a detailed review.
* The script picked up `output-monasca_log_api` as changed. Should I add it?

Lockfile: https://github.com/elastic/logstash/blob/7.3/Gemfile.jruby-2.5.lock.release