### PR TITLE
Update docs for Logstash release 7.5.0

### DIFF
--- a/docs/plugins/filters/tld.asciidoc
+++ b/docs/plugins/filters/tld.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.3
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-tld/blob/v3.0.3/CHANGELOG.md
+:version: v3.1.0
+:release_date: 2019-11-07
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-tld/blob/v3.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v9.0.0
-:release_date: 2019-01-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kafka/blob/v9.0.0/CHANGELOG.md
+:version: v10.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -62,6 +62,8 @@ The following metadata from Kafka broker are added under the `[@metadata]` field
 * `[@metadata][kafka][key]`: Record key, if any.
 * `[@metadata][kafka][timestamp]`: Timestamp in the Record. Depending on your broker configuration, this can be either when the record was created (default) or when it was received by the broker. See more about property log.message.timestamp.type at https://kafka.apache.org/10/documentation.html#brokerconfigs
 
+Metadata is only added to the event if the `decorate_events` option is set to true (it defaults to false).
+
 Please note that `@metadata` fields are not part of any of your events at output time. If you need these information to be 
 inserted into your original event, you'll have to use the `mutate` filter to manually copy the required fields into your `event`.
 
@@ -104,6 +106,7 @@ https://kafka.apache.org/documentation for more details.
 | <<plugins-{type}s-{plugin}-reconnect_backoff_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
@@ -419,6 +422,24 @@ retries are exhausted.
 
 The amount of time to wait before attempting to retry a failed fetch request
 to a given topic partition. This avoids repeated fetching-and-failing in a tight loop.
+
+[id="plugins-{type}s-{plugin}-sasl_jaas_config"]
+===== `sasl_jaas_config` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+JAAS configuration setting local to this plugin instance, as opposed to settings using config file configured using `jaas_path`, which are shared across the JVM. This allows each plugin instance to have its own configuration. 
+
+If both `sasl_jaas_config` and `jaas_path` configurations are set, the setting here takes precedence.
+
+Example (setting for Azure Event Hub):
+[source,ruby]
+    input {
+      kafka {
+        sasl_jaas_config => "org.apache.kafka.common.security.plain.PlainLoginModule required username='auser'  password='apassword';"
+      }
+    }
 
 [id="plugins-{type}s-{plugin}-sasl_kerberos_service_name"]
 ===== `sasl_kerberos_service_name` 

--- a/docs/plugins/inputs/rabbitmq.asciidoc
+++ b/docs/plugins/inputs/rabbitmq.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.0.3
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/blob/v6.0.3/CHANGELOG.md
+:version: v7.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/integrations/kafka.asciidoc
+++ b/docs/plugins/integrations/kafka.asciidoc
@@ -1,0 +1,29 @@
+:plugin: kafka
+:type: integration
+:default_plugin: 1
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v10.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.0.0/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Kafka Integration Plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The Kafka Integration Plugin provides integrated plugins for working with the https://kafka.apache.org/[Kafka] distributed streaming platform.
+
+This plugin uses Kafka Client 2.1.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference]. If the linked compatibility wiki is not up-to-date, please contact Kafka support/community to confirm compatibility.
+
+:no_codec!:

--- a/docs/plugins/integrations/rabbitmq.asciidoc
+++ b/docs/plugins/integrations/rabbitmq.asciidoc
@@ -1,0 +1,30 @@
+:plugin: rabbitmq
+:type: integration
+:default_plugin: 1
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v7.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.0.0/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Rabbitmq Integration Plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The RabbitMQ Integration Plugin provides integrated plugins for working with http://www.rabbitmq.com/[RabbitMQ].
+
+ - {logstash-ref}/plugins-inputs-rabbitmq.html[RabbitMQ Input Plugin]
+ - {logstash-ref}/plugins-outputs-rabbitmq.html[RabbitMQ Output Plugin]
+
+:no_codec!:

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v8.0.1
-:release_date: 2019-02-12
-:changelog_url: https://github.com/logstash-plugins/logstash-output-kafka/blob/v8.0.1/CHANGELOG.md
+:version: v10.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -79,6 +79,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-sasl_jaas_config>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_kerberos_service_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sasl_mechanism>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-security_protocol>> |<<string,string>>, one of `["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]`|No
@@ -298,6 +299,24 @@ A value less than zero is a configuration error.
   * Default value is `100`
 
 The amount of time to wait before attempting to retry a failed produce request to a given topic partition.
+
+[id="plugins-{type}s-{plugin}-sasl_jaas_config"]
+===== `sasl_jaas_config` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+JAAS configuration setting local to this plugin instance, as opposed to settings using config file configured using `jaas_path`, which are shared across the JVM. This allows each plugin instance to have its own configuration. 
+
+If both `sasl_jaas_config` and `jaas_path` configurations are set, the setting here takes precedence.
+
+Example (setting for Azure Event Hub):
+[source,ruby]
+    output {
+      kafka {
+        sasl_jaas_config => "org.apache.kafka.common.security.plain.PlainLoginModule required username='auser'  password='apassword';"
+      }
+    }
 
 [id="plugins-{type}s-{plugin}-sasl_kerberos_service_name"]
 ===== `sasl_kerberos_service_name` 

--- a/docs/plugins/outputs/rabbitmq.asciidoc
+++ b/docs/plugins/outputs/rabbitmq.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.1
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/blob/v5.1.1/CHANGELOG.md
+:version: v7.0.0
+:release_date: 2019-10-15
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -169,11 +169,14 @@ Key to route to by default. Defaults to 'logstash'
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Add properties to be set per-message here, such as 'Content-Type', 'Priority'
+Add properties to be set per-message here, such as 'content_type', 'priority'
 
 Example:
 [source,ruby]
-    message_properties => { "priority" => "1" }
+    message_properties => {
+      "content_type" => "application/json"  
+      "priority" => 1
+    }
 
 
 [id="plugins-{type}s-{plugin}-passive"]


### PR DESCRIPTION
this PR updates the docs in preparation for 7.5.0

It introduces the rabbitmq and kafka integration plugins