### PR TITLE
update docs for the 6.8 release branch

### DIFF
--- a/docs/plugins/codecs/gzip_lines.asciidoc
+++ b/docs/plugins/codecs/gzip_lines.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.3
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/blob/v3.0.3/CHANGELOG.md
+:version: v3.0.4
+:release_date: 2019-07-23
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/blob/v3.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/codecs/protobuf.asciidoc
+++ b/docs/plugins/codecs/protobuf.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.1
-:release_date: 2019-05-28
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.2.1/CHANGELOG.md
+:version: v1.2.2
+:release_date: 2019-07-11
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.2.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,29 +29,31 @@ For protobuf 3 use the https://developers.google.com/protocol-buffers/docs/refer
 
 The following shows a usage example (protobuf v2) for decoding events from a kafka stream:
 [source,ruby]
-kafka 
-{
- topic_id => "..."
- key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
- value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
- codec => protobuf 
- {
-   class_name => "Animals::Mammals::Unicorn"
-   include_path => ['/path/to/protobuf/definitions/UnicornProtobuf.pb.rb']
- }
-}
-
-Usage example for protobuf v3:
-[source,ruby]
-kafka 
+kafka
 {
   topic_id => "..."
   key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
   value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
-  codec => protobuf 
+  codec => protobuf
+  {
+    class_name => "Animals::Mammals::Unicorn"
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn.pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
+  }
+}
+
+Decoder usage example for protobuf v3:
+[source,ruby]
+kafka
+{
+  topic_id => "..."
+  key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  codec => protobuf
   {
     class_name => "Animals.Mammals.Unicorn"
-    include_path => ['/path/to/pb_definitions/Animal_pb.rb', '/path/to/pb_definitions/Unicorn_pb.rb']
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
     protobuf_version => 3
   }
 }
@@ -61,10 +63,29 @@ The codec can be used in input and output plugins. +
 When using the codec in the kafka input plugin please set the deserializer classes as shown above. +
 When using the codec in an output plugin:
 
-* make sure to include all the desired fields in the protobuf definition, including timestamp. 
-  Remove fields that are not part of the protobuf definition from the event by using the mutate filter.
+* make sure to include all the desired fields in the protobuf definition, including timestamp.
+  Remove fields that are not part of the protobuf definition from the event by using the mutate filter. Encoding will fail if the event has fields which are not in the protobuf definition.
 * the `@` symbol is currently not supported in field names when loading the protobuf definitions for encoding. Make sure to call the timestamp field `timestamp`
   instead of `@timestamp` in the protobuf file. Logstash event fields will be stripped of the leading `@` before conversion.
+* fields with a nil value will automatically be removed from the event. Empty fields will not be removed.
+* it is recommended to set the config option `pb3_encoder_autoconvert_types` to true. Otherwise any type mismatch between your data and the protobuf definition will cause an event to be lost. The auto typeconversion does not alter your data. It just tries to convert obviously identical data into the expected datatype, such as converting integers to floats where floats are expected, or "true" / "false" strings into booleans where booleans are expected.
+* When writing to Kafka: set the serializer class: `value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"`
+
+Encoder usage example (protobufg v3):
+
+[source,ruby]
+kafka
+  {
+    codec => protobuf
+    {
+      class_name => "Animals.Mammals.Unicorn"
+      class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+      protobuf_root_directory => "/path/to/pb_definitions/"
+      protobuf_version => 3
+    }
+    value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"
+  }
+}
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -74,14 +95,18 @@ When using the codec in an output plugin:
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-class_name>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-include_path>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-class_file>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-protobuf_root_directory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-include_path>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-protobuf_version>> |<<number,number>>|Yes
+| <<plugins-{type}s-{plugin}-stop_on_error>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types>> |<<boolean,boolean>>|No
 |=======================================================================
 
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-class_name"]
-===== `class_name` 
+===== `class_name`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -100,18 +125,45 @@ For protobuf v3, you can copy the class name from the Descriptorpool registratio
 [source,ruby]
 Animals.Mammals.Unicorn = Google::Protobuf::DescriptorPool.generated_pool.lookup("Animals.Mammals.Unicorn").msgclass
 
-
 If your class references other definitions: you only have to add the name of the main class here.
 
-[id="plugins-{type}s-{plugin}-include_path"]
-===== `include_path` 
+[id="plugins-{type}s-{plugin}-class_file"]
+===== `class_file`
 
-  * This is a required setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Absolute path to the directory that contains all compiled protobuf files. If the protobuf definitions are spread across multiple folders, this needs to point to the folder containing all those folders.
+
+[id="plugins-{type}s-{plugin}-protobuf_root_directory"]
+===== `protobuf_root_directory`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Absolute path to the root directory that contains all referenced/used dependencies of the main class (`class_name`) or any of its dependencies. Must be used in combination with the `class_file` setting, and can not be used in combination with the legacy loading mechanism `include_path`.
+
+Example:
+
+[source]
+ pb3
+   ├── header
+   │   └── header_pb.rb
+   ├── messageA_pb.rb
+
+In this case `messageA_pb.rb` has an embedded message from `header/header_pb.rb`.
+If `class_file` is set to `messageA_pb.rb`, and `class_name` to `MessageA`, `protobuf_root_directory` must be set to `/path/to/pb3`, which includes both definitions.
+
+
+[id="plugins-{type}s-{plugin}-include_path"]
+===== `include_path`
+
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-List of absolute pathes to files with protobuf definitions. 
-When using more than one file, make sure to arrange the files in reverse order of dependency so that each class is loaded before it is 
+Legacy protobuf definition loading mechanism for backwards compatibility:
+List of absolute pathes to files with protobuf definitions.
+When using more than one file, make sure to arrange the files in reverse order of dependency so that each class is loaded before it is
 refered to by another.
 
 Example: a class _Unicorn_ referencing another protobuf class _Wings_
@@ -130,13 +182,34 @@ include_path => ['/path/to/pb_definitions/wings.pb.rb','/path/to/pb_definitions/
 
 Please note that protobuf v2 files have the ending `.pb.rb` whereas files compiled for protobuf v3 end in `_pb.rb`.
 
+Cannot be used together with `protobuf_root_directory` or `class_file`.
+
 [id="plugins-{type}s-{plugin}-protobuf_version"]
-===== `protobuf_version` 
+===== `protobuf_version`
 
   * Value type is <<number,number>>
   * Default value is 2
 
 Protocol buffers version. Valid settings are 2, 3.
 
+[id="plugins-{type}s-{plugin}-stop_on_error"]
+===== `stop_on_error`
 
+  * Value type is <<boolean,boolean>>
+  * Default value is false
+
+Stop entire pipeline when encountering a non decodable message.
+
+[id="plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types"]
+===== `pb3_encoder_autoconvert_types`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is true
+
+Convert data types to match the protobuf definition (if possible).
+The protobuf encoder library is very strict with regards to data types. Example: an event has an integer field but the protobuf definition expects a float. This would lead to an exception and the event would be lost.
+This feature tries to convert the datatypes to the expectations of the protobuf definitions, without modifying the data whatsoever. Examples of conversions it might attempt:
+"true" string => true boolean
+17 int => 17.0 float
+12345 number => "12345" string
 

--- a/docs/plugins/filters/aggregate.asciidoc
+++ b/docs/plugins/filters/aggregate.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.9.0
-:release_date: 2018-11-03
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-aggregate/blob/v2.9.0/CHANGELOG.md
+:version: v2.9.1
+:release_date: 2019-09-22
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-aggregate/blob/v2.9.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -229,7 +229,7 @@ In that case, you don't want to wait task timeout to flush aggregation map.
      aggregate {
        task_id => "%{country_name}"
        code => "
-         map['country_name'] = event.get('country_name')
+         map['country_name'] ||= event.get('country_name')
          map['towns'] ||= []
          map['towns'] << {'town_name' => event.get('town_name')}
          event.cancel()
@@ -242,7 +242,8 @@ In that case, you don't want to wait task timeout to flush aggregation map.
 
 * The key point is that each time aggregate plugin detects a new `country_name`, it pushes previous aggregate map as a new Logstash event, and then creates a new empty map for the next country
 * When 3s timeout comes, the last aggregate map is pushed as a new event
-* Finally, initial events (which are not aggregated) are dropped because useless (thanks to `event.cancel()`)
+* Initial events (which are not aggregated) are dropped because useless (thanks to `event.cancel()`)
+* Last point: if a field is not fulfilled for every event (say "town_postcode" field), the `||=` operator will let you to push into aggregate map, the first "not null" value. Example: `map['town_postcode'] ||= event.get('town_postcode')`
 
 
 [id="plugins-{type}s-{plugin}-example5"]
@@ -250,7 +251,7 @@ In that case, you don't want to wait task timeout to flush aggregation map.
 
 Fifth use case: like example #3, there is no end event.
 
-Events keep comming for an indefinite time and you want to push the aggregation map as soon as possible after the last user interaction without waiting for the `timeout`.
+Events keep coming for an indefinite time and you want to push the aggregation map as soon as possible after the last user interaction without waiting for the `timeout`.
 
 This allows to have the aggregated events pushed closer to real time.
 
@@ -261,7 +262,7 @@ We can track a user by its ID through the events, however once the user stops in
 
 There is no specific event indicating the end of the user's interaction.
 
-The user ineraction will be considered as ended when no events for the specified user (task_id) arrive after the specified inactivity_timeout`.
+The user interaction will be considered as ended when no events for the specified user (task_id) arrive after the specified inactivity_timeout`.
 
 If the user continues interacting for longer than `timeout` seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
 
@@ -296,7 +297,7 @@ filter {
    code => "map['clicks'] ||= 0; map['clicks'] += 1;"
    push_map_as_event_on_timeout => true
    timeout_task_id_field => "user_id"
-   timeout => 3600 # 1 hour timeout, user activity will be considered finished one hour after the first event, even if events keep comming
+   timeout => 3600 # 1 hour timeout, user activity will be considered finished one hour after the first event, even if events keep coming
    inactivity_timeout => 300 # 5 minutes timeout, user activity will be considered finished if no new events arrive 5 minutes after the last event
    timeout_tags => ['_aggregatetimeout']
    timeout_code => "event.set('several_clicks', event.get('clicks') > 1)"
@@ -327,7 +328,7 @@ filter {
 * in the final event, you can execute a last code (for instance, add map data to final event)
 * after the final event, the map attached to task is deleted (thanks to `end_of_task => true`)
 * an aggregate map is tied to one task_id value which is tied to one task_id pattern. So if you have 2 filters with different task_id patterns, even if you have same task_id value, they won't share the same aggregate map.
-* in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
+* in one filter configuration, it is recommended to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
 * if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
 * all timeout options have to be defined in only one aggregate filter per task_id pattern (per pipeline). Timeout options are : timeout, inactivity_timeout, timeout_code, push_map_as_event_on_timeout, push_previous_map_as_event, timeout_timestamp_field, timeout_task_id_field, timeout_tags
 * if `code` execution raises an exception, the error is logged and event is tagged '_aggregateexception'

--- a/docs/plugins/filters/cidr.asciidoc
+++ b/docs/plugins/filters/cidr.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.2
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-cidr/blob/v3.1.2/CHANGELOG.md
+:version: v3.1.3
+:release_date: 2019-09-18
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-cidr/blob/v3.1.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/dns.asciidoc
+++ b/docs/plugins/filters/dns.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.13
-:release_date: 2019-04-29
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-dns/blob/v3.0.13/CHANGELOG.md
+:version: v3.0.14
+:release_date: 2019-10-18
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-dns/blob/v3.0.14/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -130,7 +130,14 @@ number of times to retry a failed resolve/reverse
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`
+Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`.
+If `nameserver` is not specified then `/etc/resolv.conf` will be read to
+configure the resolver using the `nameserver`, `domain`,
+`search` and `ndots` directives in `/etc/resolv.conf`.
+
+Note that nameservers normally resolve fully qualified domain names (FQDN)
+and relying on `/etc/resolv.conf` can be useful to provide a domains search
+list to resolve underqualified host names for example.
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/docs/plugins/filters/geoip.asciidoc
+++ b/docs/plugins/filters/geoip.asciidoc
@@ -44,7 +44,7 @@ A `[geoip][location]` field is created if
 the GeoIP lookup returns a latitude and longitude. The field is stored in
 http://geojson.org/geojson-spec.html[GeoJSON] format. Additionally,
 the default Elasticsearch template provided with the
-<<plugins-outputs-elasticsearch,elasticsearch output>> maps
+<<plugins-outputs-elasticsearch,`elasticsearch` output>> maps
 the `[geoip][location]` field to an http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html#_mapping_options[Elasticsearch geo_point].
 
 As this field is a `geo_point` _and_ it is still valid GeoJSON, you get

--- a/docs/plugins/filters/grok.asciidoc
+++ b/docs/plugins/filters/grok.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.0
-:release_date: 2019-07-22
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.1.0/CHANGELOG.md
+:version: v4.1.1
+:release_date: 2019-08-08
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -67,11 +67,8 @@ simply `duration`. Further, a string `55.3.244.1` might identify the `client`
 making a request.
 
 For the above example, your grok filter would look something like this:
-
 [source,ruby]
------
 %{NUMBER:duration} %{IP:client}
------
 
 Optionally you can add a data type conversion to your grok pattern. By default
 all semantics are saved as strings. If you wish to convert a semantic's data type,
@@ -79,27 +76,19 @@ for example change a string to an integer then suffix it with the target data ty
 For example `%{NUMBER:num:int}` which converts the `num` semantic from a string to an
 integer. Currently the only supported conversions are `int` and `float`.
 
-Examples:
+.Examples:
 
 With that idea of a syntax and semantic, we can pull out useful fields from a
 sample log like this fictional http request log:
-
 [source,ruby]
------
     55.3.244.1 GET /index.html 15824 0.043
------
 
 The pattern for this could be:
-
 [source,ruby]
------
     %{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}
------
 
 A more realistic example, let's read these logs from a file:
-
 [source,ruby]
------
     input {
       file {
         path => "/var/log/http.log"
@@ -110,7 +99,6 @@ A more realistic example, let's read these logs from a file:
         match => { "message" => "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}" }
       }
     }
------
 
 After the grok filter, the event will have a few extra fields in it:
 
@@ -134,19 +122,13 @@ a few options.
 
 First, you can use the Oniguruma syntax for named capture which will
 let you match a piece of text and save it as a field:
-
 [source,ruby]
------
     (?<field_name>the pattern here)
------
 
 For example, postfix logs have a `queue id` that is an 10 or 11-character
 hexadecimal value. I can capture that easily like this:
-
 [source,ruby]
------
     (?<queue_id>[0-9A-F]{10,11})
------
 
 Alternately, you can create a custom patterns file.
 
@@ -156,12 +138,9 @@ Alternately, you can create a custom patterns file.
   the regexp for that pattern.
 
 For example, doing the postfix queue id example as above:
-
 [source,ruby]
------
     # contents of ./patterns/postfix:
     POSTFIX_QUEUEID [0-9A-F]{10,11}
------
 
 Then use the `patterns_dir` setting in this plugin to tell logstash where
 your custom patterns directory is. Here's a full example with a sample log:
@@ -250,12 +229,8 @@ If `true`, keep empty captures as event fields.
 
 A hash that defines the mapping of _where to look_, and with which patterns.
 
-For example, the following will match an existing value in the `message` field
-for the given pattern, and if a match is found will add the field `duration` to
-the event with the captured value:
-
+For example, the following will match an existing value in the `message` field for the given pattern, and if a match is found will add the field `duration` to the event with the captured value:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -263,13 +238,9 @@ the event with the captured value:
         }
       }
     }
------
 
-If you need to match multiple patterns against a single field, the value can be
-an array of patterns:
-
+If you need to match multiple patterns against a single field, the value can be an array of patterns:
 [source,ruby]
------
     filter {
       grok {
         match => {
@@ -280,7 +251,6 @@ an array of patterns:
         }
       }
     }
------
 
 [id="plugins-{type}s-{plugin}-named_captures_only"]
 ===== `named_captures_only` 
@@ -302,16 +272,13 @@ This allows you to overwrite a value in a field that already exists.
 
 For example, if you have a syslog line in the `message` field, you can
 overwrite the `message` field with part of the match like so:
-
 [source,ruby]
------
     filter {
       grok {
         match => { "message" => "%{SYSLOGBASE} %{DATA:message}" }
         overwrite => [ "message" ]
       }
     }
------
 
 In this case, a line like `May 29 16:37:11 sadness logger: hello world`
 will be parsed and `hello world` will overwrite the original message.
@@ -339,25 +306,16 @@ necessarily need to define this yourself unless you are adding additional
 patterns. You can point to multiple pattern directories using this setting.
 Note that Grok will read all files in the directory matching the patterns_files_glob
 and assume it's a pattern file (including any tilde backup files). 
-
 [source,ruby]
------
     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
------
 
 Pattern files are plain text with format:
-
 [source,ruby]
------
     NAME PATTERN
------
 
 For example:
-
 [source,ruby]
------
     NUMBER \d+
------
 
 The patterns are loaded when the pipeline is created.
 

--- a/docs/plugins/filters/http.asciidoc
+++ b/docs/plugins/filters/http.asciidoc
@@ -6,7 +6,7 @@
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 :version: v1.0.2
-:release_date: 2019-04-30
+:release_date: 2019-06-24
 :changelog_url: https://github.com/logstash-plugins/logstash-filter-http/blob/v1.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////

--- a/docs/plugins/filters/jdbc_static.asciidoc
+++ b/docs/plugins/filters/jdbc_static.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.6
-:release_date: 2018-10-29
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/blob/v1.0.6/CHANGELOG.md
+:version: v1.0.7
+:release_date: 2019-10-29
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/blob/v1.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.7
-:release_date: 2019-05-30
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.7/CHANGELOG.md
+:version: v1.0.10
+:release_date: 2019-10-29
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/v1.0.10/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -43,6 +43,47 @@ filter {
 }
 -----
 
+[id="plugins-{type}s-{plugin}-prepared_statements"]
+==== Prepared Statements
+
+Using server side prepared statements can speed up execution times as the server optimises the query plan and execution.
+
+NOTE: Not all JDBC accessible technologies will support prepared statements.
+
+With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
+
+Use the boolean setting `use_prepared_statements` to enable this execution mode.
+
+Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database.
+
+Use the `prepared_statement_bind_values` array setting to specify the bind values. Typically, these values are indirectly extracted from your event, i.e. the string in the array refers to a field name in your event. You can also use constant values like numbers or strings but ensure that any string constants (e.g. a locale constant of "en" or "de") is not also an event field name. It is a good idea to use the bracketed field reference syntax for fields and normal strings for constants, e.g. `prepared_statement_bind_values => ["[src_ip]", "tokyo"],`.
+
+There are 3 possible parameter schemes. Interpolated, field references and constants. Use interpolation when you are prefixing, suffixing or concatenating field values to create a value that exists in your database, e.g. "%{username}@%{domain}" -> "alice@example.org", "%{distance}km" -> "42km". Use field references for exact field values e.g. "[srcip]" -> "192.168.1.2". Use constants when a database column holds values that slice or categorise a number of similar records e.g. language translations.
+
+A boolean setting `prepared_statement_warn_on_constant_usage`, defaulting to true, controls whether you will see a WARN message logged that warns when constants could be missing the bracketed field reference syntax. If you have set your field references and constants correctly you should set `prepared_statement_warn_on_constant_usage` to false. This setting and code checks should be deprecated in a future major Logstash release.
+
+The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
+Some technologies may require connection string properties to be set, see MySQL example below.
+
+Example:
+[source,ruby]
+-----
+filter {
+  jdbc_streaming {
+    jdbc_driver_library => "/path/to/mysql-connector-java-5.1.34-bin.jar"
+    jdbc_driver_class => "com.mysql.jdbc.Driver"
+    jdbc_connection_string => "jdbc:mysql://localhost:3306/mydatabase?cachePrepStmts=true&prepStmtCacheSize=250&prepStmtCacheSqlLimit=2048&useServerPrepStmts=true"
+    jdbc_user => "me"
+    jdbc_password => "secret"
+    statement => "select * from WORLD.COUNTRY WHERE Code = ?"
+    use_prepared_statements => true
+    prepared_statement_name => "lookup_country_info"
+    prepared_statement_bind_values => ["[country_code]"]
+    target => "country_details"
+  }
+}
+-----
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Jdbc_streaming Filter Configuration Options
 
@@ -62,11 +103,16 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-jdbc_validate_connection>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-jdbc_validation_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-prepared_statement_bind_values>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-prepared_statement_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-prepared_statement_warn_on_constant_usage>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-sequel_opts>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-statement>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-tag_on_default_use>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-use_cache>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_prepared_statements>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -75,7 +121,7 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-cache_expiration"]
-===== `cache_expiration` 
+===== `cache_expiration`
 
   * Value type is <<number,number>>
   * Default value is `5.0`
@@ -91,7 +137,7 @@ any external problem that would cause jdbc errors will not be noticed for the
 cache_expiration period.
 
 [id="plugins-{type}s-{plugin}-cache_size"]
-===== `cache_size` 
+===== `cache_size`
 
   * Value type is <<number,number>>
   * Default value is `500`
@@ -100,7 +146,7 @@ The maximum number of cache entries that will be stored. Defaults to 500 entries
 The least recently used entry will be evicted.
 
 [id="plugins-{type}s-{plugin}-default_hash"]
-===== `default_hash` 
+===== `default_hash`
 
   * Value type is <<hash,hash>>
   * Default value is `{}`
@@ -109,7 +155,7 @@ Define a default object to use when lookup fails to return a matching row.
 Ensure that the key names of this object match the columns from the statement.
 
 [id="plugins-{type}s-{plugin}-jdbc_connection_string"]
-===== `jdbc_connection_string` 
+===== `jdbc_connection_string`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -118,7 +164,7 @@ Ensure that the key names of this object match the columns from the statement.
 JDBC connection string
 
 [id="plugins-{type}s-{plugin}-jdbc_driver_class"]
-===== `jdbc_driver_class` 
+===== `jdbc_driver_class`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -127,19 +173,15 @@ JDBC connection string
 JDBC driver class to load, for example "oracle.jdbc.OracleDriver" or "org.apache.derby.jdbc.ClientDriver"
 
 [id="plugins-{type}s-{plugin}-jdbc_driver_library"]
-===== `jdbc_driver_library` 
+===== `jdbc_driver_library`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-Tentative of abstracting JDBC logic to a mixin
-for potential reuse in other plugins (input/output).
-This method is called when someone includes this module.
-Add these methods to the 'base' given.
 JDBC driver library path to third party driver library.
 
 [id="plugins-{type}s-{plugin}-jdbc_password"]
-===== `jdbc_password` 
+===== `jdbc_password`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -147,7 +189,7 @@ JDBC driver library path to third party driver library.
 JDBC password
 
 [id="plugins-{type}s-{plugin}-jdbc_user"]
-===== `jdbc_user` 
+===== `jdbc_user`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -155,7 +197,7 @@ JDBC password
 JDBC user
 
 [id="plugins-{type}s-{plugin}-jdbc_validate_connection"]
-===== `jdbc_validate_connection` 
+===== `jdbc_validate_connection`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -164,7 +206,7 @@ Connection pool configuration.
 Validate connection before use.
 
 [id="plugins-{type}s-{plugin}-jdbc_validation_timeout"]
-===== `jdbc_validation_timeout` 
+===== `jdbc_validation_timeout`
 
   * Value type is <<number,number>>
   * Default value is `3600`
@@ -173,15 +215,55 @@ Connection pool configuration.
 How often to validate a connection (in seconds).
 
 [id="plugins-{type}s-{plugin}-parameters"]
-===== `parameters` 
+===== `parameters`
 
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
 Hash of query parameter, for example `{ "id" => "id_field" }`.
 
+[id="plugins-{type}s-{plugin}-prepared_statement_bind_values"]
+===== `prepared_statement_bind_values`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+Array of bind values for the prepared statement. Use field references and constants. See the section on <<plugins-{type}s-{plugin}-prepared_statements,prepared_statements>> for more info.
+
+[id="plugins-{type}s-{plugin}-prepared_statement_name"]
+===== `prepared_statement_name`
+
+  * Value type is <<string,string>>
+  * Default value is `""`
+
+Name given to the prepared statement. It must be unique in your config and in the database.
+You need to supply this if `use_prepared_statements` is true.
+
+[id="plugins-{type}s-{plugin}-prepared_statement_warn_on_constant_usage"]
+===== `prepared_statement_warn_on_constant_usage`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+A flag that controls whether a warning is logged if, in `prepared_statement_bind_values`,
+a String constant is detected that might be intended as a field reference.
+
+[id="plugins-{type}s-{plugin}-sequel_opts"]
+===== `sequel_opts`
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+General/Vendor-specific Sequel configuration options
+
+An example of an optional connection pool configuration
+   max_connections - The maximum number of connections the connection pool
+
+examples of vendor-specific options can be found in this documentation page:
+https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc
+
 [id="plugins-{type}s-{plugin}-statement"]
-===== `statement` 
+===== `statement`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -191,7 +273,7 @@ Statement to execute.
 To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABLE WHERE ID = :id".
 
 [id="plugins-{type}s-{plugin}-tag_on_default_use"]
-===== `tag_on_default_use` 
+===== `tag_on_default_use`
 
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingdefaultsused"]`
@@ -199,7 +281,7 @@ To use parameters, use named parameter syntax, for example "SELECT * FROM MYTABL
 Append values to the `tags` field if no record was found and default values were used.
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
-===== `tag_on_failure` 
+===== `tag_on_failure`
 
   * Value type is <<array,array>>
   * Default value is `["_jdbcstreamingfailure"]`
@@ -207,7 +289,7 @@ Append values to the `tags` field if no record was found and default values were
 Append values to the `tags` field if sql error occurred.
 
 [id="plugins-{type}s-{plugin}-target"]
-===== `target` 
+===== `target`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -217,14 +299,20 @@ Define the target field to store the extracted result(s).
 Field is overwritten if exists.
 
 [id="plugins-{type}s-{plugin}-use_cache"]
-===== `use_cache` 
+===== `use_cache`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 Enable or disable caching, boolean true or false. Defaults to true.
 
+[id="plugins-{type}s-{plugin}-use_prepared_statements"]
+===== `use_prepared_statements`
 
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to `true`, enables prepare statement usage
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/filters/kv.asciidoc
+++ b/docs/plugins/filters/kv.asciidoc
@@ -361,7 +361,7 @@ with the provided value (see: <<plugins-{type}s-{plugin}-timeout_millis>>).
 [id="plugins-{type}s-{plugin}-timeout_millis"]
 ===== `timeout_millis`
 
-  * Value type is <<number, number>>
+  * Value type is <<number,number>>
   * The default value for this setting is 30000 (30 seconds).
   * Set to zero (`0`) to disable timeouts
 

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references
@@ -130,7 +130,7 @@ filter {
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`
 
-For usages of this plugin that persist data to memcached (e.g., <<plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
+For usages of this plugin that persist data to memcached (e.g., <<#plugins-{type}s-{plugin}-set,`set`>>), the time-to-live in seconds
 
   * Value type is <<number,number>>
   * The default value is `0` (no expiry)

--- a/docs/plugins/filters/memcached.asciidoc
+++ b/docs/plugins/filters/memcached.asciidoc
@@ -111,7 +111,7 @@ filter {
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<#plugins-{type}s-{plugin}-ttl,ttl>>
+If specified, extracts the values from the given event fields, and sets the corresponding keys to those values in memcached with the configured <<plugins-{type}s-{plugin}-ttl,ttl>>
 
   * keys are interpolated (e.g., if the event has a field `foo` with value `bar`, the key `sand/%{foo}` will evaluate to `sand/bar`)
   * fields can be nested references

--- a/docs/plugins/filters/prune.asciidoc
+++ b/docs/plugins/filters/prune.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.3
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-prune/blob/v3.0.3/CHANGELOG.md
+:version: v3.0.4
+:release_date: 2019-09-12
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-prune/blob/v3.0.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -25,8 +25,8 @@ The prune filter is for removing fields from events based on
 whitelists or blacklist of field names or their values (names and
 values can also be regular expressions).
 
-This can e.g. be useful if you have a <<plugins-filters-json,json>>
-or <<plugins-filters-kv,kv>> filter that creates a number of fields
+This can e.g. be useful if you have a {logstash-ref}/plugins-filters-json.html[json]
+or {logstash-ref}/plugins-filters-kv.html[kv] filter that creates a number of fields
 with names that you don't necessarily know the names of beforehand,
 and you only want to keep a subset of them.
 
@@ -140,6 +140,7 @@ Include only fields only if their names match specified regexps, default to empt
 
 Include specified fields only if their values match one of the supplied regular expressions.
 In case field values are arrays, each array item is matched against the regular expressions and only matching array items will be included.
+By default all fields that are not listed in this setting are kept unless pruned by other settings.
 [source,ruby]
     filter {
       prune {

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.8
-:release_date: 2018-11-30
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.1.8/CHANGELOG.md
+:version: v5.1.9
+:release_date: 2019-10-02
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v5.1.9/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.3.1
-:release_date: 2019-05-01
-:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.3.1/CHANGELOG.md
+:version: v4.3.2
+:release_date: 2019-07-31
+:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.3.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/exec.asciidoc
+++ b/docs/plugins/inputs/exec.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.3.2
-:release_date: 2018-07-20
-:changelog_url: https://github.com/logstash-plugins/logstash-input-exec/blob/v3.3.2/CHANGELOG.md
+:version: v3.3.3
+:release_date: 2019-09-10
+:changelog_url: https://github.com/logstash-plugins/logstash-input-exec/blob/v3.3.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -28,6 +28,12 @@ Notes:
 
 * The `command` field of this event will be the command run.
 * The `message` field of this event will be the entire stdout of the command.
+
+===== IMPORTANT
+
+The exec input ultimately uses `fork` to spawn a child process.
+Using fork duplicates the parent process address space (in our case, **logstash and the JVM**); this is mitigated with OS copy-on-write but ultimately you can end up allocating lots of memory just for a "simple" executable.
+If the exec input fails with errors like `ENOMEM: Cannot allocate memory` it is an indication that there is not enough non-JVM-heap physical memory to perform the fork.
 
 
 Example:

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.10
-:release_date: 2019-03-12
-:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.1.10/CHANGELOG.md
+:version: v4.1.11
+:release_date: 2019-09-25
+:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.1.11/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/inode-reuse-issue.html[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -380,7 +380,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/inode-reuse-issue.html[FAQ about inode recycling].
+Filebeat has a {filebeat-ref}/faq.html#inode-reuse-issue[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/plugins/inputs/github.asciidoc
+++ b/docs/plugins/inputs/github.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.7
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-github/blob/v3.0.7/CHANGELOG.md
+:version: v3.0.8
+:release_date: 2019-07-18
+:changelog_url: https://github.com/logstash-plugins/logstash-input-github/blob/v3.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/imap.asciidoc
+++ b/docs/plugins/inputs/imap.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-input-imap/blob/v3.0.6/CHANGELOG.md
+:version: v3.0.7
+:release_date: 2019-09-17
+:changelog_url: https://github.com/logstash-plugins/logstash-input-imap/blob/v3.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -46,7 +46,9 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-secure>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-strip_attachments>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-uid_tracking>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-verify_cert>> |<<boolean,boolean>>|No
 |=======================================================================
@@ -57,7 +59,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-check_interval"]
-===== `check_interval` 
+===== `check_interval`
 
   * Value type is <<number,number>>
   * Default value is `300`
@@ -65,7 +67,7 @@ input plugins.
 
 
 [id="plugins-{type}s-{plugin}-content_type"]
-===== `content_type` 
+===== `content_type`
 
   * Value type is <<string,string>>
   * Default value is `"text/plain"`
@@ -74,7 +76,7 @@ For multipart messages, use the first part that has this
 content-type as the event message.
 
 [id="plugins-{type}s-{plugin}-delete"]
-===== `delete` 
+===== `delete`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -82,7 +84,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-expunge"]
-===== `expunge` 
+===== `expunge`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -90,7 +92,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-fetch_count"]
-===== `fetch_count` 
+===== `fetch_count`
 
   * Value type is <<number,number>>
   * Default value is `50`
@@ -98,7 +100,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-folder"]
-===== `folder` 
+===== `folder`
 
   * Value type is <<string,string>>
   * Default value is `"INBOX"`
@@ -106,7 +108,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -115,7 +117,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-lowercase_headers"]
-===== `lowercase_headers` 
+===== `lowercase_headers`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -123,7 +125,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password` 
+===== `password`
 
   * This is a required setting.
   * Value type is <<password,password>>
@@ -132,7 +134,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * Value type is <<number,number>>
   * There is no default value for this setting.
@@ -140,23 +142,52 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-secure"]
-===== `secure` 
+===== `secure`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 
 
+[id="plugins-{type}s-{plugin}-sincedb_path"]
+===== `sincedb_path`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Path of the sincedb database file (keeps track of the UID of the last processed
+mail) that will be written to disk. The default will write sincedb file to
+`<path.data>/plugins/inputs/imap` directory.
+NOTE: it must be a file path and not a directory path.
+
 [id="plugins-{type}s-{plugin}-strip_attachments"]
-===== `strip_attachments` 
+===== `strip_attachments`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
 
 
+[id="plugins-{type}s-{plugin}-uid_tracking"]
+===== `uid_tracking`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When the IMAP input plugin connects to the mailbox for the first time and
+the UID of the last processed mail is not yet known, the unread mails are
+first downloaded and the UID of the last processed mail is saved. From
+this point on, if `uid_tracking` is set to `true`, all new mail will be
+downloaded regardless of whether they are marked as read or unread. This
+allows users or other services to use the mailbox simultaneously with the
+IMAP input plugin. UID of the last processed mail is always saved regardles
+of the `uid_tracking` value, so you can switch its value as needed. In
+transition from the previous IMAP input plugin version, first process at least
+one mail with `uid_tracking` set to `false` to save the UID of the last
+processed mail and then switch `uid_tracking` to `true`.
+
 [id="plugins-{type}s-{plugin}-user"]
-===== `user` 
+===== `user`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -165,7 +196,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-verify_cert"]
-===== `verify_cert` 
+===== `verify_cert`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`

--- a/docs/plugins/inputs/jdbc.asciidoc
+++ b/docs/plugins/inputs/jdbc.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.3.13
-:release_date: 2018-09-04
-:changelog_url: https://github.com/logstash-plugins/logstash-input-jdbc/blob/v4.3.13/CHANGELOG.md
+:version: v4.3.18
+:release_date: 2019-10-27
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jdbc/blob/v4.3.18/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -33,6 +33,9 @@ Columns in the resultset are converted into fields in the event.
 This plugin does not come packaged with JDBC driver libraries. The desired
 jdbc driver library must be explicitly passed in to the plugin using the
 `jdbc_driver_library` configuration option.
+
+See the <<plugins-{type}s-{plugin}-jdbc_driver_library>> and <<plugins-{type}s-{plugin}-jdbc_driver_class>>
+options for more info.
 
 ==== Scheduling
 
@@ -141,6 +144,35 @@ input {
 }
 ---------------------------------------------------------------------------------------------------
 
+==== Prepared Statements
+
+Using server side prepared statements can speed up execution times as the server optimises the query plan and execution.
+
+NOTE: Not all JDBC accessible technologies will support prepared statements.
+
+With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
+Use the boolean setting `use_prepared_statements` to enable this execution mode. Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database. Use the `prepared_statement_bind_values` array setting to specify the bind values, use the exact string `:sql_last_value` (multiple times if necessary) for the predefined parameter mentioned before. The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
+
+NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
+
+Example:
+[source,ruby]
+---------------------------------------------------------------------------------------------------
+input {
+  jdbc {
+    statement => "SELECT * FROM mgd.seq_sequence WHERE _sequence_key > ? AND _sequence_key < ? + ? ORDER BY _sequence_key ASC"
+    prepared_statement_bind_values => [":sql_last_value", ":sql_last_value", 4]
+    prepared_statement_name => "foobar"
+    use_prepared_statements => true
+    use_column_value => true
+    tracking_column_type => "numeric"
+    tracking_column => "_sequence_key"
+    last_run_metadata_path => "/elastic/tmp/testing/confs/test-jdbc-int-sql_last_value.yml"
+    # ... other configuration bits
+  }
+}
+---------------------------------------------------------------------------------------------------
+
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Jdbc Input Configuration Options
@@ -170,6 +202,9 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-last_run_metadata_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-lowercase_column_names>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-plugin_timezone>> |<<string,string>>, one of `["local", "utc"]`|No
+| <<plugins-{type}s-{plugin}-prepared_statement_bind_values>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-prepared_statement_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-record_last_run>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sequel_opts>> |<<hash,hash>>|No
@@ -179,6 +214,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-tracking_column>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-tracking_column_type>> |<<string,string>>, one of `["numeric", "timestamp"]`|No
 | <<plugins-{type}s-{plugin}-use_column_value>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_prepared_statements>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -248,12 +284,34 @@ JDBC connection string
   * There is no default value for this setting.
 
 Timezone conversion.
-SQL does not allow for timezone data in timestamp fields.  This plugin will automatically
-convert your SQL timestamp fields to Logstash timestamps, in relative UTC time in ISO8601 format.
+Logstash (and Elasticsearch) expects that timestamps are expressed in UTC terms.
+If your database has recorded timestamps that are relative to another timezone,
+the database timezone if you will, then set this setting to be the timezone that
+the database is using. However, as SQL does not allow for timezone data in
+timestamp fields we can't figure this out on a record by record basis.  This plugin
+will automatically convert your SQL timestamp fields to Logstash timestamps,
+in relative UTC time in ISO8601 format.
 
 Using this setting will manually assign a specified timezone offset, instead
 of using the timezone setting of the local machine.  You must use a canonical
 timezone, *America/Denver*, for example.
+
+[id="plugins-{type}s-{plugin}-plugin_timezone"]
+===== `plugin_timezone`
+
+  * Value can be any of: `utc`, `local`
+  * Default value is `"utc"`
+
+If you want this plugin to offset timestamps to a timezone other than UTC, you
+can set this setting to `local` and the plugin will use the OS timezone for offset
+adjustments.
+
+Note: when specifying `plugin_timezone` and/or `jdbc_default_timezone`, offset
+adjustments are made in two places, if `sql_last_value` is a timestamp and it
+is used as a parameter in the statement then offset adjustment is done from the
+plugin timezone into the data timezone and while records are processed, timestamps
+are offset adjusted from the database timezone to the plugin timezone. If your
+database timezone is UTC then you do not need to set either of these settings.
 
 [id="plugins-{type}s-{plugin}-jdbc_driver_class"]
 ===== `jdbc_driver_class`
@@ -262,9 +320,13 @@ timezone, *America/Denver*, for example.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-JDBC driver class to load, for exmaple, "org.apache.derby.jdbc.ClientDriver"
-NB per https://github.com/logstash-plugins/logstash-input-jdbc/issues/43 if you are using
-the Oracle JDBC driver (ojdbc6.jar) the correct `jdbc_driver_class` is `"Java::oracle.jdbc.driver.OracleDriver"`
+JDBC driver class to load, for example, "org.apache.derby.jdbc.ClientDriver"
+
+NOTE: Per https://github.com/logstash-plugins/logstash-input-jdbc/issues/43, prepending `Java::` to the driver class
+ may be required if it appears that the driver is not being loaded correctly despite relevant jar(s) being provided by
+ either via the `jdbc_driver_library` setting or being placed in the Logstash  Java classpath. This is known to be the
+ case for the Oracle JDBC driver (ojdbc6.jar), where the correct `jdbc_driver_class` is
+ `"Java::oracle.jdbc.driver.OracleDriver"`, and may also be the case for other JDBC drivers.
 
 [id="plugins-{type}s-{plugin}-jdbc_driver_library"]
 ===== `jdbc_driver_library`
@@ -272,14 +334,12 @@ the Oracle JDBC driver (ojdbc6.jar) the correct `jdbc_driver_class` is `"Java::o
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-Tentative of abstracting JDBC logic to a mixin
-for potential reuse in other plugins (input/output)
-This method is called when someone includes this module
-Add these methods to the 'base' given.
 JDBC driver library path to third party driver library. In case of multiple libraries being
 required you can pass them separated by a comma.
 
-If not provided, Plugin will look for the driver class in the Logstash Java classpath.
+NOTE: If not provided, Plugin will look for the driver class in the Logstash Java classpath. Additionally, if the library
+ does not appear to be being loaded correctly via this setting, placing the relevant jar(s) in the Logstash Java
+ classpath rather than via this setting may help.
 
 [id="plugins-{type}s-{plugin}-jdbc_fetch_size"]
 ===== `jdbc_fetch_size`
@@ -387,6 +447,22 @@ Whether to force the lowercasing of identifier fields
 
 Hash of query parameter, for example `{ "target_id" => "321" }`
 
+[id="plugins-{type}s-{plugin}-prepared_statement_bind_values"]
+===== `prepared_statement_bind_values`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+Array of bind values for the prepared statement. `:sql_last_value` is a reserved predefined string
+
+[id="plugins-{type}s-{plugin}-prepared_statement_name"]
+===== `prepared_statement_name`
+
+  * Value type is <<string,string>>
+  * Default value is `""`
+
+Name given to the prepared statement. It must be unique in your config and in the database
+
 [id="plugins-{type}s-{plugin}-record_last_run"]
 ===== `record_last_run`
 
@@ -484,6 +560,13 @@ When set to `true`, uses the defined
 <<plugins-{type}s-{plugin}-tracking_column>> value as the `:sql_last_value`. When set
 to `false`, `:sql_last_value` reflects the last time the query was executed.
 
+[id="plugins-{type}s-{plugin}-use_prepared_statements"]
+===== `use_prepared_statements`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to `true`, enables prepare statement usage
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/plugins/inputs/jms.asciidoc
+++ b/docs/plugins/inputs/jms.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.1.0
-:release_date: 2019-06-17
-:changelog_url: https://github.com/logstash-plugins/logstash-input-jms/blob/v3.1.0/CHANGELOG.md
+:version: v3.1.1
+:release_date: 2019-07-08
+:changelog_url: https://github.com/logstash-plugins/logstash-input-jms/blob/v3.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -36,7 +36,6 @@ JMS configurations can be done either entirely in the Logstash configuration fil
 
 
 ==== Sample Configuration using Logstash Configuration Only
-
 
 Configurations can be configured either entirely in Logstash configuration, or via a combination of Logstash configuration
 and yaml file, which can be useful for sharing similar configurations across multiple inputs and outputs.
@@ -87,7 +86,6 @@ The JMS plugin can also be configured using JNDI if desired.
 <7> Keystore and Truststore to use when connecting to the JMS provider, if required.
 <8> Parts of the JMS Message to include in the event - headers, properties and the message body can be included or
     excluded from the event.
-
 <9> Message selector: Use this to filter messages to be processed. The whole selector query should be double-quoted,
     string property values should be single quoted, and numeric property vaues should not be quoted.
     See JMS provider documentation for exact syntax.
@@ -352,6 +350,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-durable_subscriber_client_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-durable_subscriber_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-factory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-factory_settings>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-include_body>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_header>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_properties>> |<<boolean,boolean>>|No
@@ -444,6 +443,18 @@ is set to `true`. Please consult your JMS Provider documentation for constraints
   * There is no default value for this setting.
 
 Full name (including package name) of Java connection factory used to create a connection with your JMS provider.
+
+[id="plugins-{type}s-{plugin}-factory_settings"]
+===== `factory_settings`
+
+  * Value type is <<hash,hash>>
+  * There is no default value for this setting.
+
+Hash of implementation specific configuration values to set on the connection factory of the JMS provider. Each JMS
+ Provider will have its own set of parameters that can be used here. These parameters are mapped to `set` methods on
+ the provided connection factory, and can be supplied in either 'snake' or 'camel' case. For example, a hash including
+ `exclusive_consumer => true` would call `setExclusiveConsumer(true)` on the supplied connection factory.
+ See your JMS provider documentation for implementation specific details.
 
 [id="plugins-{type}s-{plugin}-include_body"]
 ===== `include_body`

--- a/docs/plugins/inputs/jmx.asciidoc
+++ b/docs/plugins/inputs/jmx.asciidoc
@@ -27,7 +27,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-==== Configuration
+==== The configuration
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing

--- a/docs/plugins/outputs/circonus.asciidoc
+++ b/docs/plugins/outputs/circonus.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.5
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-circonus/blob/v3.0.5/CHANGELOG.md
+:version: v3.0.6
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-circonus/blob/v3.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/google_bigquery.asciidoc
+++ b/docs/plugins/outputs/google_bigquery.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.1
-:release_date: 2018-10-25
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.1/CHANGELOG.md
+:version: v4.1.3
+:release_date: 2019-10-17
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.1.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/google_pubsub.asciidoc
+++ b/docs/plugins/outputs/google_pubsub.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.0.1
-:release_date: 2018-09-25
-:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.1/CHANGELOG.md
+:version: v1.0.2
+:release_date: 2019-09-18
+:changelog_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.0.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -79,9 +79,9 @@ output {
     json_key_file => "service_account_key.json"
 
     # Options for configuring the upload
-    message_count_threshold => 10000
+    message_count_threshold => 1000
     delay_threshold_secs => 10
-    request_byte_threshold => 5MB
+    request_byte_threshold => 5000000
   }
 }
 ------------------------------------------------------------------------------
@@ -210,7 +210,7 @@ A value of 0 will cause messages to instantly be sent but will reduce total thro
 ===== `request_byte_threshold`
 
   * Value type is <<bytes,bytes>>
-  * Default is: `1_000_000`
+  * Default is: `1000000`
 
 Once the number of bytes in the batched request reaches this threshold, send all of the messages in
 a single call, even if neither the delay or message count thresholds have been exceeded yet.

--- a/docs/plugins/outputs/librato.asciidoc
+++ b/docs/plugins/outputs/librato.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-librato/blob/v3.0.6/CHANGELOG.md
+:version: v3.0.7
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-librato/blob/v3.0.7/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -131,6 +131,7 @@ Example:
 -----
     
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
+
 [source,ruby]
 -----
     {
@@ -161,6 +162,7 @@ Example:
         "name" => "apache_bytes"
     }
 -----
+
 Additionally, you can override the `measure_time` for the event. Must be a unix timestamp:
 
 [source,ruby]
@@ -172,6 +174,7 @@ Additionally, you can override the `measure_time` for the event. Must be a unix 
         "measure_time" => "%{my_unixtime_field}
     }
 -----
+
 Default is to use the event's timestamp
 
 

--- a/docs/plugins/outputs/riak.asciidoc
+++ b/docs/plugins/outputs/riak.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.4
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-riak/blob/v3.0.4/CHANGELOG.md
+:version: v3.0.5
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-riak/blob/v3.0.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -172,11 +172,11 @@ No mix and match
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-SSL Options
-Options for SSL connections
-Only applied if SSL is enabled
+Options for SSL connections.
+Only applied if SSL is enabled.
 Logstash hash that maps to the riak-client options
-here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak
+here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak.
+
 You'll likely want something like this:
 
 [source, ruby]

--- a/docs/plugins/outputs/riemann.asciidoc
+++ b/docs/plugins/outputs/riemann.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.4
-:release_date: 2018-04-06
-:changelog_url: https://github.com/logstash-plugins/logstash-output-riemann/blob/v3.0.4/CHANGELOG.md
+:version: v3.0.5
+:release_date: 2019-10-09
+:changelog_url: https://github.com/logstash-plugins/logstash-output-riemann/blob/v3.0.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -33,7 +33,9 @@ outputs
 You can learn about Riemann here:
 
 * http://riemann.io/
+
 You can see the author talk about it here:
+
 * http://vimeo.com/38377415
 
 

--- a/docs/plugins/outputs/s3.asciidoc
+++ b/docs/plugins/outputs/s3.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.9
-:release_date: 2019-04-15
-:changelog_url: https://github.com/logstash-plugins/logstash-output-s3/blob/v4.1.9/CHANGELOG.md
+:version: v4.1.10
+:release_date: 2019-08-20
+:changelog_url: https://github.com/logstash-plugins/logstash-output-s3/blob/v4.1.10/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -204,6 +204,7 @@ Specify the content encoding. Supports ("gzip"). Defaults to "none"
 The endpoint to connect to. By default it is constructed using the value of `region`.
 This is useful when connecting to S3 compatible services, but beware that these aren't
 guaranteed to work correctly with the AWS SDK.
+The endpoint should be an HTTP or HTTPS URL, e.g. https://example.com
 
 [id="plugins-{type}s-{plugin}-prefix"]
 ===== `prefix` 


### PR DESCRIPTION
This PR was generated locally, and the docs are failing on a memcache filter link

```
+ ../docs/build_docs --asciidoctor --respect_edit_url_overrides --doc docs/index.asciidoc --resource=../logstash-docs/docs/ --chunk 1
INFO:build_docs:The Asciidoctor migration is complete! --asciidoctor will emit this message
INFO:build_docs:forever in honor of our success but otherwise doesn't do anything.
INFO:build_docs:
INFO:build_docs:Building HTML from /doc/logstash/docs/index.asciidoc
INFO:build_docs:
INFO:build_docs:asciidoctor: WARNING: invalid reference: #plugins-filters-memcached-ttl

```