### PR TITLE
[VPR]Update vpr index to include integration plugins

### DIFF
--- a/docs/versioned-plugins/index.asciidoc
+++ b/docs/versioned-plugins/index.asciidoc
@@ -18,6 +18,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :edit_url!:
 
+include::integrations-index.asciidoc[] 
+
 include::inputs-index.asciidoc[]
 
 include::outputs-index.asciidoc[]


### PR DESCRIPTION
Pulls `integrations-index.asciidoc into the Versioned Plugin Reference index.

DO NOT MERGE until #810 has been merged. 