### PR TITLE
Include input-s3_sns_sqs plugin landing page

### DIFF
--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -44,6 +44,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-relp,relp>> | Receives RELP events over a TCP socket | https://github.com/logstash-plugins/logstash-input-relp[logstash-input-relp]
 | <<plugins-inputs-rss,rss>> | Captures the output of command line tools as an event | https://github.com/logstash-plugins/logstash-input-rss[logstash-input-rss]
 | <<plugins-inputs-s3,s3>> | Streams events from files in a S3 bucket | https://github.com/logstash-plugins/logstash-input-s3[logstash-input-s3]
+| <<plugins-inputs-s3_sns_sqs,s3_sns_sqs>> | Reads logs from AWS S3 buckets using sqs | https://github.com/cherweg/logstash-input-s3-sns-sqs[logstash-input-s3_sns-sqs]
 | <<plugins-inputs-salesforce,salesforce>> | Creates events based on a Salesforce SOQL query | https://github.com/logstash-plugins/logstash-input-salesforce[logstash-input-salesforce]
 | <<plugins-inputs-snmp,snmp>> | Polls network devices using Simple Network Management Protocol (SNMP) | https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp]
 | <<plugins-inputs-snmptrap,snmptrap>> | Creates events based on SNMP trap messages | https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap]
@@ -172,6 +173,9 @@ include::inputs/rss.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/master/docs/index.asciidoc
 include::inputs/s3.asciidoc[]
+
+:edit_url: 
+include::inputs/s3_sns_sqs.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/master/docs/index.asciidoc
 include::inputs/salesforce.asciidoc[]

--- a/docs/plugins/inputs/s3_sns_sqs.asciidoc
+++ b/docs/plugins/inputs/s3_sns_sqs.asciidoc
@@ -1,0 +1,47 @@
+:plugin: s3_sns_sqs
+:type: input
+:default_plugin: 0
+
+///////////////////////////////////////////
+REPLACES GENERATED VARIABLES
+///////////////////////////////////////////
+:changelog_url: https://github.com/cherweg/logstash-input-s3-sns-sqs/blob/master/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+:gem: https://rubygems.org/gems/logstash-input-s3-sns-sqss
+///////////////////////////////////////////
+END - REPLACES GENERATED VARIABLES
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== S3 via SNS/SQS plugin
+
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+* This plugin was created and is maintained by a contributor.
+* {changelog_url}[Change log]
+
+==== Installation
+
+For plugins not bundled by default, it is easy to install by running
++bin/logstash-plugin install logstash-{type}-{plugin}+. See
+{logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
+
+==== Description
+
+This plugin uses sqs to read logs from AWS S3 buckets in high availability
+setups with multiple Logstash instances.
+
+==== Documentation
+ 
+https://github.com/cherweg/logstash-input-s3-sns-sqs/blob/master/docs/index.asciidoc[
+Documentation] for the logstash-{type}-{plugin} plugin is maintained by the creator.
+
+==== Getting Help
+
+This is a third-party plugin. For bugs or feature requests, open an issue in the
+https://github.com/cherweg/logstash-input-s3-sns-sqs[plugins-{type}s-{plugin} Github repo].
+


### PR DESCRIPTION
Adds input-s3_sns_sqs plugin landing page with pointers to external repo and docs, and removes the "Edit Me" link. 