### PR TITLE
Remove edit_me link

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -167,7 +167,7 @@ include::filters/split.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/docs/index.asciidoc
 include::filters/syslog_pri.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-threats_classiifer/edit/master/docs/index.asciidoc
+:edit_url: 
 include::filters/threats_classifier.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/docs/index.asciidoc


### PR DESCRIPTION
Threats_classifier is a partner plugin, and the docs are maintained by the partner. This PR removes the `edit_me` link on the docs page to correct a 404. 

PREVIEW: http://logstash-docs_819.docs-preview.app.elstc.co/guide/en/logstash/master/plugins-filters-threats_classifier.html