### PR TITLE
Add reference to JDBC integration plugin (Backport of #813)

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -6,9 +6,13 @@ filters and codecs--into one package.
 
 |=======================================================================
 | Integration Plugin | Description | Github repository
+| <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/index.asciidoc
+include::integrations/jdbc.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/master/docs/index.asciidoc
 include::integrations/kafka.asciidoc[]


### PR DESCRIPTION
* Add reference to JDBC integration plugin

Adds link and reference to the JDBC integration plugin to the
integration plugin index page.

* Fix typo

Backport of #813