### PR TITLE
Add input-google_cloud_storage to list of input plugins

### DIFF
--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -19,6 +19,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-gelf,gelf>> | Reads GELF-format messages from Graylog2 as events | https://github.com/logstash-plugins/logstash-input-gelf[logstash-input-gelf]
 | <<plugins-inputs-generator,generator>> | Generates random log events for test purposes | https://github.com/logstash-plugins/logstash-input-generator[logstash-input-generator]
 | <<plugins-inputs-github,github>> | Reads events from a GitHub webhook | https://github.com/logstash-plugins/logstash-input-github[logstash-input-github]
+| <<plugins-inputs-google_cloud_storage,google_cloud_storage>> | Extract events from files in a Google Cloud Storage bucket | https://github.com/logstash-plugins/logstash-input-google_cloud_storage[logstash-input-google_cloud_storage]
 | <<plugins-inputs-google_pubsub,google_pubsub>> | Consume events from a Google Cloud PubSub service | https://github.com/logstash-plugins/logstash-input-google_pubsub[logstash-input-google_pubsub]
 | <<plugins-inputs-graphite,graphite>> | Reads metrics from the `graphite` tool | https://github.com/logstash-plugins/logstash-input-graphite[logstash-input-graphite]
 | <<plugins-inputs-heartbeat,heartbeat>> | Generates heartbeat events for testing | https://github.com/logstash-plugins/logstash-input-heartbeat[logstash-input-heartbeat]
@@ -94,6 +95,9 @@ include::inputs/generator.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/docs/index.asciidoc
 include::inputs/github.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-input-google_cloud_storage/edit/master/docs/index.asciidoc
+include::inputs/google_cloud_storage.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/docs/index.asciidoc
 include::inputs/google_pubsub.asciidoc[]


### PR DESCRIPTION
Add index entry to pull docs for input-google_cloud_storage into the Logstash Reference

**PREVIEW:**  http://logstash-docs_836.docs-preview.app.elstc.co/guide/en/logstash/6.8/input-plugins.html