### PR TITLE
Add codec-csv to reference

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -13,6 +13,7 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-cloudfront,cloudfront>> | Reads AWS CloudFront reports | https://github.com/logstash-plugins/logstash-codec-cloudfront[logstash-codec-cloudfront]
 | <<plugins-codecs-cloudtrail,cloudtrail>> | Reads AWS CloudTrail log files| https://github.com/logstash-plugins/logstash-codec-cloudtrail[logstash-codec-cloudtrail]
 | <<plugins-codecs-collectd,collectd>> | Reads events from the `collectd` binary protocol using UDP. | https://github.com/logstash-plugins/logstash-codec-collectd[logstash-codec-collectd]
+| <<plugins-codecs-csv,csv>> | Takes CSV data, parses it, and passes it along. | https://github.com/logstash-plugins/logstash-codec-csv[logstash-codec-csv]
 | <<plugins-codecs-dots,dots>> | Sends 1 dot per event to `stdout` for performance tracking | https://github.com/logstash-plugins/logstash-codec-dots[logstash-codec-dots]
 | <<plugins-codecs-edn,edn>> | Reads EDN format data | https://github.com/logstash-plugins/logstash-codec-edn[logstash-codec-edn]
 | <<plugins-codecs-edn_lines,edn_lines>> | Reads newline-delimited EDN format data | https://github.com/logstash-plugins/logstash-codec-edn_lines[logstash-codec-edn_lines]
@@ -49,6 +50,9 @@ include::codecs/cloudtrail.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-codec-csv/edit/master/docs/index.asciidoc
+include::codecs/csv.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/docs/index.asciidoc
 include::codecs/dots.asciidoc[]


### PR DESCRIPTION
**PREVIEW:**. http://logstash-docs_837.docs-preview.app.elstc.co/guide/en/logstash/master/codec-plugins.html

Adds the codec-csv plugin to the [Logstash Reference](https://www.elastic.co/guide/en/logstash/7.6/codec-plugins.html). 
Related:  https://github.com/logstash-plugins/logstash-codec-csv/pull/4

**PENDING** docgen process to create the html file.  
This PR cannot be merged before the files are created, or it will break the doc build. 

I will generate the docs files after https://github.com/logstash-plugins/logstash-codec-csv/pull/4 is merged and published.

**UPDATE:** codec-csv has been published (2020-2-21). Moving forward with generating plugin docs. 

