### PR TITLE
Expand info on thread setting for azure

### DIFF
--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -100,7 +100,8 @@ The number of threads should equal the number of Event Hubs plus one (or more).
 Each Event Hub needs at least one thread. An additional thread is needed to help
 coordinate the other threads. The number of threads should not exceed the number
 of Event Hubs multiplied by the number of partitions per Event Hub plus one.
-Threads are currently available only as a global setting.
+Threads are currently available only as a global setting. If you are using multiple 
+pipelines, the threads setting applies to each pipeline independently.
 ** Sample scenario: Event Hubs = 4. Partitions on each Event Hub = 3.
 Minimum threads is 5 (4 Event Hubs plus one). Maximum threads is 13 (4 Event
 Hubs times 3 partitions plus one). 


### PR DESCRIPTION
Doc expanded to include additional info in input-azure_event_hubs source.  The doc change was not picked up for 6.8 and 7.6 because of the lockfile settings. This PR gets that info in for current releases. 

**PREVIEW:**. http://logstash-docs_846.docs-preview.app.elstc.co/guide/en/logstash/7.6/plugins-inputs-azure_event_hubs.html#plugins-inputs-azure_event_hubs-best-practices

**Merge targets:**  6.8   7.6