### PR TITLE
Fix document_type default values for Elasticsearch Output

### DIFF
--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -314,7 +314,8 @@ This sets the document type to write events to. Generally you should try to writ
 similar events to the same 'type'. String expansion `%{foo}` works here.
 If you don't set a value for this option:
 
-- for elasticsearch clusters 6.x and above: the value of 'doc' will be used;
+- for elasticsearch clusters 7.x and above: the value of '_doc' will be used;
+- for elasticsearch clusters 6.x: the value of 'doc' will be used;
 - for elasticsearch clusters 5.x and below: the event's 'type' field will be used, if the field is not present the value of 'doc' will be used.
 
 [id="plugins-{type}s-{plugin}-failure_type_logging_whitelist"]


### PR DESCRIPTION
In the v9.4.0 version of the ES output that ships with Logstash 6.8, when connecting to an ES 7.x cluster (or higher) the default document type will be `_doc`: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.4.0/lib/logstash/outputs/elasticsearch/common.rb#L259-L271