### PR TITLE
[Doc][Backport]Fix links to repos and docs source for integration plugins

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -30,8 +30,8 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-http,http>> | Provides integration with external web services/REST APIs | https://github.com/logstash-plugins/logstash-filter-http[logstash-filter-http]
 | <<plugins-filters-i18n,i18n>> | Removes special characters from a field | https://github.com/logstash-plugins/logstash-filter-i18n[logstash-filter-i18n]
 | <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
-| <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-filter-jdbc_static[logstash-filter-jdbc_static]
-| <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-filter-jdbc_streaming[logstash-filter-jdbc_streaming]
+| <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
+| <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-filters-json,json>> | Parses JSON events | https://github.com/logstash-plugins/logstash-filter-json[logstash-filter-json]
 | <<plugins-filters-json_encode,json_encode>> | Serializes a field to JSON | https://github.com/logstash-plugins/logstash-filter-json_encode[logstash-filter-json_encode]
 | <<plugins-filters-kv,kv>> | Parses key-value pairs | https://github.com/logstash-plugins/logstash-filter-kv[logstash-filter-kv]
@@ -122,10 +122,10 @@ include::filters/i18n.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/filters/java_uuid.asciidoc
 include::../../../logstash/docs/static/core-plugins/filters/java_uuid.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/filter-jdbc_static.asciidoc
 include::filters/jdbc_static.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/filter-jdbc_streaming.asciidoc
 include::filters/jdbc_streaming.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/docs/index.asciidoc

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -29,17 +29,17 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-irc,irc>> | Reads events from an IRC server | https://github.com/logstash-plugins/logstash-input-irc[logstash-input-irc]
 | <<plugins-inputs-java_generator,java_generator>> | Generates synthetic log events | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/inputs/Generator.java[core plugin]
 | <<plugins-inputs-java_stdin,java_stdin>> | Reads events from standard input| https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/inputs/Stdin.java[core plugin]
-| <<plugins-inputs-jdbc,jdbc>> | Creates events from JDBC data | https://github.com/logstash-plugins/logstash-input-jdbc[logstash-input-jdbc]
+| <<plugins-inputs-jdbc,jdbc>> | Creates events from JDBC data | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-inputs-jms,jms>> | Reads events from a Jms Broker | https://github.com/logstash-plugins/logstash-input-jms[logstash-input-jms]
 | <<plugins-inputs-jmx,jmx>> | Retrieves metrics from remote Java applications over JMX | https://github.com/logstash-plugins/logstash-input-jmx[logstash-input-jmx]
-| <<plugins-inputs-kafka,kafka>> | Reads events from a Kafka topic | https://github.com/logstash-plugins/logstash-input-kafka[logstash-input-kafka]
+| <<plugins-inputs-kafka,kafka>> | Reads events from a Kafka topic | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-inputs-kinesis,kinesis>> | Receives events through an AWS Kinesis stream | https://github.com/logstash-plugins/logstash-input-kinesis[logstash-input-kinesis]
 | <<plugins-inputs-log4j,log4j>> | Reads events over a TCP socket from a Log4j `SocketAppender` object | https://github.com/logstash-plugins/logstash-input-log4j[logstash-input-log4j]
 | <<plugins-inputs-lumberjack,lumberjack>> | Receives events using the Lumberjack protocl | https://github.com/logstash-plugins/logstash-input-lumberjack[logstash-input-lumberjack]
 | <<plugins-inputs-meetup,meetup>> | Captures the output of command line tools as an event | https://github.com/logstash-plugins/logstash-input-meetup[logstash-input-meetup]
 | <<plugins-inputs-pipe,pipe>> | Streams events from a long-running command pipe | https://github.com/logstash-plugins/logstash-input-pipe[logstash-input-pipe]
 | <<plugins-inputs-puppet_facter,puppet_facter>> | Receives facts from a Puppet server | https://github.com/logstash-plugins/logstash-input-puppet_facter[logstash-input-puppet_facter]
-| <<plugins-inputs-rabbitmq,rabbitmq>> | Pulls events from a RabbitMQ exchange | https://github.com/logstash-plugins/logstash-input-rabbitmq[logstash-input-rabbitmq]
+| <<plugins-inputs-rabbitmq,rabbitmq>> | Pulls events from a RabbitMQ exchange | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 | <<plugins-inputs-redis,redis>> | Reads events from a Redis instance | https://github.com/logstash-plugins/logstash-input-redis[logstash-input-redis]
 | <<plugins-inputs-relp,relp>> | Receives RELP events over a TCP socket | https://github.com/logstash-plugins/logstash-input-relp[logstash-input-relp]
 | <<plugins-inputs-rss,rss>> | Captures the output of command line tools as an event | https://github.com/logstash-plugins/logstash-input-rss[logstash-input-rss]
@@ -129,7 +129,7 @@ include::../../../logstash/docs/static/core-plugins/inputs/java_generator.asciid
 :edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/inputs/java_stdin.asciidoc
 include::../../../logstash/docs/static/core-plugins/inputs/java_stdin.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/input-jdbc.asciidoc
 include::inputs/jdbc.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-jms/edit/master/docs/index.asciidoc
@@ -138,7 +138,7 @@ include::inputs/jms.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/docs/index.asciidoc
 include::inputs/jmx.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/master/docs/input-kafka.asciidoc
 include::inputs/kafka.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/master/docs/index.asciidoc
@@ -159,7 +159,7 @@ include::inputs/pipe.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/master/docs/index.asciidoc
 include::inputs/puppet_facter.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/master/docs/input-rabbitmq.asciidoc
 include::inputs/rabbitmq.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/master/docs/index.asciidoc

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -31,7 +31,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-sink,sink>> | Discards any events received | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/outputs/Sink.java[core plugin]
 | <<plugins-outputs-java_stdout,java_stdout>> | Prints events to the STDOUT of the shell | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/outputs/Stdout.java[core plugin]
 | <<plugins-outputs-juggernaut,juggernaut>> | Pushes messages to the Juggernaut websockets server | https://github.com/logstash-plugins/logstash-output-juggernaut[logstash-output-juggernaut]
-| <<plugins-outputs-kafka,kafka>> | Writes events to a Kafka topic | https://github.com/logstash-plugins/logstash-output-kafka[logstash-output-kafka]
+| <<plugins-outputs-kafka,kafka>> | Writes events to a Kafka topic | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-outputs-librato,librato>> | Sends metrics, annotations, and alerts to Librato based on Logstash events | https://github.com/logstash-plugins/logstash-output-librato[logstash-output-librato]
 | <<plugins-outputs-loggly,loggly>> | Ships logs to Loggly | https://github.com/logstash-plugins/logstash-output-loggly[logstash-output-loggly]
 | <<plugins-outputs-lumberjack,lumberjack>> | Sends events using the `lumberjack` protocol | https://github.com/logstash-plugins/logstash-output-lumberjack[logstash-output-lumberjack]
@@ -42,7 +42,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-opentsdb,opentsdb>> | Writes metrics to OpenTSDB | https://github.com/logstash-plugins/logstash-output-opentsdb[logstash-output-opentsdb]
 | <<plugins-outputs-pagerduty,pagerduty>> | Sends notifications based on preconfigured services and escalation policies | https://github.com/logstash-plugins/logstash-output-pagerduty[logstash-output-pagerduty]
 | <<plugins-outputs-pipe,pipe>> | Pipes events to another program's standard input | https://github.com/logstash-plugins/logstash-output-pipe[logstash-output-pipe]
-| <<plugins-outputs-rabbitmq,rabbitmq>> | Pushes events to a RabbitMQ exchange | https://github.com/logstash-plugins/logstash-output-rabbitmq[logstash-output-rabbitmq]
+| <<plugins-outputs-rabbitmq,rabbitmq>> | Pushes events to a RabbitMQ exchange | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 | <<plugins-outputs-redis,redis>> | Sends events to a Redis queue using the `RPUSH` command | https://github.com/logstash-plugins/logstash-output-redis[logstash-output-redis]
 | <<plugins-outputs-redmine,redmine>> | Creates tickets using the Redmine API | https://github.com/logstash-plugins/logstash-output-redmine[logstash-output-redmine]
 | <<plugins-outputs-riak,riak>> | Writes events to the Riak distributed key/value store | https://github.com/logstash-plugins/logstash-output-riak[logstash-output-riak]
@@ -136,7 +136,7 @@ include::../../../logstash/docs/static/core-plugins/outputs/java_stdout.asciidoc
 :edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/master/docs/output-kafka.asciidoc
 include::outputs/kafka.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/docs/index.asciidoc
@@ -169,7 +169,7 @@ include::outputs/pagerduty.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/docs/index.asciidoc
 include::outputs/pipe.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/master/docs/output-rabbitmq.asciidoc
 include::outputs/rabbitmq.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/docs/index.asciidoc


### PR DESCRIPTION
When we introduced integration plugins, the doc source files moved.
This work updates edit_me links in the generated docs to point to correct source
files, and updates plugin lists to point to integration repos.

Backports: #866