### PR TITLE
[DOC][VPR]Add new integration plugin header file to the Versioned Plugin Reference

### DIFF
--- a/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
@@ -11,21 +11,21 @@ ifeval::["{versioned_docs}"=="true"]
 ++++
 endif::[]
 
-* A component of the <<{plugin}-{type},{plugin} integration plugin>> 
+* A component of the <<integration-{integration}-index,{integration} integration plugin>>  
 * Integration version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]
 
 ifeval::["{versioned_docs}"!="true"]
 
-For other versions, see the
-{lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
+For other plugin versions, see the
+{lsplugindocs}/{type}-{plugin}-index.html[Versioned {plugin} {type} plugin docs].
 
 endif::[]
 
 ifeval::["{versioned_docs}"=="true"]
 
-For other versions, see the <<integration-{plugin}-index,overview list>>.
+For other versions, see the <<{type}-{plugin}-index,overview list>>.
 
 To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
 
@@ -34,6 +34,6 @@ endif::[]
 ==== Getting Help
 
 For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. 
-For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{plugin}[Github].
+For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{integration}[Github].
 For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
 

--- a/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
@@ -1,0 +1,39 @@
+ifeval::["{versioned_docs}"!="true"]
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+endif::[]
+ifeval::["{versioned_docs}"=="true"]
+[subs="attributes"]
+++++
+<titleabbrev>{version}</titleabbrev>
+++++
+endif::[]
+
+* A component of the <<{plugin}-{type},{plugin} integration plugin>> 
+* Integration version: {version}
+* Released on: {release_date}
+* {changelog_url}[Changelog]
+
+ifeval::["{versioned_docs}"!="true"]
+
+For other versions, see the
+{lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
+
+endif::[]
+
+ifeval::["{versioned_docs}"=="true"]
+
+For other versions, see the <<integration-{plugin}-index,overview list>>.
+
+To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
+
+endif::[]
+
+==== Getting Help
+
+For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. 
+For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{plugin}[Github].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
+


### PR DESCRIPTION
Integration plugins need a header that is different from the stand-alone plugin header. 
For example, the plugin docs should to point to the integration repo rather than the input, 
output, filter, or codec repo. The new header also includes boilerplate text to indicate that 
the individual plugin is part of an integration rather than stand-alone. This work implements 
needed changes.

This PR mirrors the integration header changes added to the Logstash Reference in https://github.com/elastic/logstash/pull/11891.

**Testing:**
By itself, the PR doesn't do anything except add a header file that we'll call from the integration plugin docs. Testing is tricky and a bit contrived.

1. Check out the `versioned_plugin_docs` branch and pull the latest.
2. Check out this PR for review as usual. 
3. Dummy up some doc files in the `versioned_plugin_docs` branch by adding the `:integration:` attribute and replacing the old plugin header with `plugin-header-integration.asciidoc`.  You can decide how many you need to feel comfortable. 
I used JDBC because it's the most unique test case. Theoretically, Kafka and RabbitMQ could render false positives because the PluginName=IntegrationName.

Examples: 
* JDBC: https://github.com/logstash-plugins/logstash-integration-jdbc/pull/40
* Kafka: https://github.com/logstash-plugins/logstash-integration-kafka/pull/46
* RabbitMQ: https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/34

4. Run the VPR docs build command to build locally. 
5. Verify that the new header is working and populating content properly. 
6. Check links to be sure they are resolving properly. 
TIP: Be sure to navigate to topics from TOC nav. Internal links take you to content on elastic.co, and you won't be testing content from the PR. 


 



