### PR TITLE
Doc:Fix links to es broken at 7.9 cutover

### DIFF
--- a/docs/versioned-plugins/inputs/elasticsearch-v4.3.0.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.3.0.asciidoc
@@ -166,7 +166,7 @@ It will be removed in the next major version of Logstash.
 If document metadata storage is requested by enabling the `docinfo`
 option, this option lists the metadata fields to save in the current
 event. See
-http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_document_metadata.html[Document Metadata]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.1/mapping-fields.html[Document Metadata]
 in the Elasticsearch documentation for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo_target"]
@@ -196,7 +196,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.1/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -218,7 +218,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.1/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -260,7 +260,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/7.1/search-request-scroll.html[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.3.1.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.3.1.asciidoc
@@ -195,7 +195,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.2/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -217,7 +217,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.2/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -259,7 +259,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/7.2/search-request-scroll.html[Sliced Scroll API],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.3.2.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.3.2.asciidoc
@@ -195,7 +195,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.4/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -217,7 +217,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -258,8 +258,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using
+https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.3.3.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.3.3.asciidoc
@@ -195,7 +195,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -217,7 +217,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -259,7 +259,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.4.0.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.4.0.asciidoc
@@ -195,7 +195,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -217,7 +217,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -258,8 +258,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.5.0.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.5.0.asciidoc
@@ -125,7 +125,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.6/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -135,7 +135,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.6/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo"]
 ===== `docinfo`
@@ -216,7 +216,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.6/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -238,7 +238,7 @@ string authentication will be disabled.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.6/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -279,8 +279,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.6/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.6.0.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.6.0.asciidoc
@@ -126,7 +126,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -136,7 +136,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo"]
 ===== `docinfo`
@@ -217,7 +217,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -249,7 +249,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -290,8 +290,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.6.1.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.6.1.asciidoc
@@ -116,7 +116,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -126,7 +126,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo"]
 ===== `docinfo`
@@ -202,7 +202,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -234,7 +234,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -275,8 +275,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using
+https://www.elastic.co/guide/en/elasticsearch/reference/7.7/search-request-body.html#sliced-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.6.2.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.6.2.asciidoc
@@ -116,7 +116,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -126,7 +126,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo"]
 ===== `docinfo`
@@ -202,7 +202,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.8/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -234,7 +234,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.8/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -275,8 +275,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.8/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/docs/versioned-plugins/inputs/elasticsearch-v4.7.0.asciidoc
+++ b/docs/versioned-plugins/inputs/elasticsearch-v4.7.0.asciidoc
@@ -119,7 +119,8 @@ input plugins.
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file`
@@ -137,7 +138,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -147,7 +148,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-docinfo"]
 ===== `docinfo`
@@ -223,7 +224,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -255,7 +256,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="{version}-plugins-{type}s-{plugin}-schedule"]
@@ -296,8 +297,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 


### PR DESCRIPTION
Elasticsearch doc improvements and restructuring broke some Logstash links at 7.9 and before.  

This problem is recurring because we use `/current/`  in links as a work around for versioning incompatibilities between the stack and individual plugins.   When `current` resolves to a new branch, any link targets that no longer exist are broken.  For example, if a link exists in 7.7 but not in 7.8, it will break when `/current/`=7.8.  This situation is a nightmare when it happens on release day and the docs build breaks. 

In this PR I added links to more appropriate versions. These files are generated, and so fixing the output should make for a more evergreen fix over just changing the link to resolve for `current`.  

There's more to be done, and I'll make those changes in plugin source. 

**PREVIEWS:** https://logstash-docs_893.docs-preview.app.elstc.co/diff