### PR TITLE
[DOC][VPR]Fix broken links to beats docs

### DIFF
--- a/docs/versioned-plugins/inputs/log4j-v3.0.6.asciidoc
+++ b/docs/versioned-plugins/inputs/log4j-v3.0.6.asciidoc
@@ -49,7 +49,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 .Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/5.5/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -65,7 +65,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/5.5/filebeat-configuration.html[Configure filebeat].
 
 .Configuring Logstash to receive from filebeat
 
@@ -82,7 +82,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/5.5/plugins-inputs-beats.html[the logstash beats input documentation].
 
 '''
 

--- a/docs/versioned-plugins/inputs/log4j-v3.1.0.asciidoc
+++ b/docs/versioned-plugins/inputs/log4j-v3.1.0.asciidoc
@@ -49,7 +49,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 .Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/6.0/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -65,7 +65,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/6.0/filebeat-configuration.html[Configure filebeat].
 
 .Configuring Logstash to receive from filebeat
 
@@ -82,7 +82,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/6.0/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/log4j-v3.1.1.asciidoc
+++ b/docs/versioned-plugins/inputs/log4j-v3.1.1.asciidoc
@@ -49,7 +49,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 .Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/6.0/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -65,7 +65,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/6.0/filebeat-configuration.html[Configure filebeat].
 
 .Configuring Logstash to receive from filebeat
 
@@ -82,7 +82,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/6.0/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/log4j-v3.1.2.asciidoc
+++ b/docs/versioned-plugins/inputs/log4j-v3.1.2.asciidoc
@@ -49,7 +49,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 .Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/6.1/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -65,7 +65,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/6.1/filebeat-configuration.html[Configure filebeat].
 
 .Configuring Logstash to receive from filebeat
 
@@ -82,7 +82,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/6.1/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/log4j-v3.1.3.asciidoc
+++ b/docs/versioned-plugins/inputs/log4j-v3.1.3.asciidoc
@@ -50,7 +50,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 .Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/7.8/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -66,7 +66,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/7.8/filebeat-configuration.html[Configure filebeat].
 
 .Configuring Logstash to receive from filebeat
 
@@ -83,7 +83,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/7.8/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 


### PR DESCRIPTION
Recent doc improvements in Beats broke some links from legacy input-log4j plugin docs. This PR updates the links to replace `/current/` with an appropriate stack version. 

**PREVIEW:** https://logstash-docs_917.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/versioned_plugin_docs/input-log4j-index.html