### PR TITLE
Fix links to Beats docs

### DIFF
--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -17,11 +17,11 @@ NOTE: This plugin is deprecated. It is recommended that you use filebeat to coll
 
 The following section is a guide for how to migrate from SocketAppender to use filebeat.
 
-To migrate away from log4j SocketAppender to using filebeat, you will need to make 3 changes:
+To migrate away from log4j SocketAppender to using filebeat, you will need to make these changes:
 
-1. Configure your log4j.properties (in your app) to write to a local file.
-2. Install and configure filebeat to collect those logs and ship them to Logstash
-3. Configure Logstash to use the beats input.
+* Configure your log4j.properties (in your app) to write to a local file.
+* Install and configure filebeat to collect those logs and ship them to Logstash
+* Configure Logstash to use the beats input.
 
 ===== Configuring log4j for writing to local files
 
@@ -42,7 +42,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 ===== Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+https://www.elastic.co/guide/en/beats/filebeat/5.4/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -58,7 +58,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/5.4/filebeat-configuration.html[the filebeat configuration guide].
 
 ===== Configuring Logstash to receive from filebeat
 
@@ -75,7 +75,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/5.4/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 

--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -58,7 +58,7 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/5.4/filebeat-configuration.html[the filebeat configuration guide].
+https://www.elastic.co/guide/en/beats/filebeat/5.4/filebeat-configuration.html[Configure Filebeat].
 
 ===== Configuring Logstash to receive from filebeat
 


### PR DESCRIPTION
Incorporates some elements of #921 

Recent doc improvements in Beats broke some links from the input-log4j plugin docs.
This work updates the links to point to locations that are branch appropriate.

Fixed some formatting issues to make the text render correctly.