### PR TITLE
Set branch for es-filter in Versioned Plugin Reference

### DIFF
--- a/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
@@ -319,7 +319,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/con
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
@@ -1,6 +1,5 @@
 :plugin: elasticsearch
 :type: filter
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -260,7 +259,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -310,7 +309,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -320,9 +319,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
-
-:branch!:
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.7.0.asciidoc
@@ -1,5 +1,6 @@
 :plugin: elasticsearch
 :type: filter
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -259,7 +260,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -309,7 +310,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -319,9 +320,9 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-
+:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.7.1.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.7.1.asciidoc
@@ -1,5 +1,6 @@
 :plugin: elasticsearch
 :type: filter
+:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -259,7 +260,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -309,7 +310,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -319,9 +320,9 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-
+:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.7.1.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.7.1.asciidoc
@@ -1,6 +1,5 @@
 :plugin: elasticsearch
 :type: filter
-:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -260,7 +259,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/7.8/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -310,7 +309,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -320,9 +319,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/c
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
-
-:branch!:
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.8.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.8.0.asciidoc
@@ -1,5 +1,6 @@
 :plugin: elasticsearch
 :type: filter
+:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -169,7 +170,7 @@ Example:
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file`
@@ -268,7 +269,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -318,7 +319,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -328,9 +329,9 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-
+:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.8.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.8.0.asciidoc
@@ -1,6 +1,5 @@
 :plugin: elasticsearch
 :type: filter
-:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -170,7 +169,7 @@ Example:
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.9/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file`
@@ -269,7 +268,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -319,7 +318,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -329,9 +328,8 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/c
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.9.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.9.0.asciidoc
@@ -1,6 +1,5 @@
 :plugin: elasticsearch
 :type: filter
-:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -171,7 +170,7 @@ Example:
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-proxy"]
 ===== `proxy`
@@ -280,7 +279,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -330,7 +329,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.10/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -340,9 +339,8 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/c
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/7.10/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/elasticsearch-v3.9.0.asciidoc
+++ b/docs/versioned-plugins/filters/elasticsearch-v3.9.0.asciidoc
@@ -1,5 +1,6 @@
 :plugin: elasticsearch
 :type: filter
+:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -170,7 +171,7 @@ Example:
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-proxy"]
 ===== `proxy`
@@ -279,7 +280,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 
 [id="{version}-plugins-{type}s-{plugin}-result_size"]
 ===== `result_size`
@@ -329,7 +330,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -339,9 +340,9 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
-
+:branch!:
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
Our use of `current` in the plugin docs frequently causes problems when we cut over to a new minor or major version.

This PR:

- fixes links that would be broken for 7.10
- sets an appropriate stack branch to "future proof" against broken links

PREVIEW: https://logstash-docs_958.docs-preview.app.elstc.co/diff

Notes:

* 3.70 -> 7.7
* 3.7.1 - > 7.8
* 3.8.0 -> 7.9
* 3.9.0 -> 7.10

