### PR TITLE
Set branch for es-output in Versioned Plugin Reference

### DIFF
--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -96,7 +95,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -213,7 +212,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -309,7 +308,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -336,7 +335,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -346,7 +345,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -425,13 +424,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -888,12 +887,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -95,7 +96,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -212,7 +213,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -308,7 +309,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -335,7 +336,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +346,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -424,13 +425,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -660,7 +661,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -889,11 +890,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.0.asciidoc
@@ -660,9 +660,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -96,7 +95,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -213,7 +212,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -309,7 +308,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -336,7 +335,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -346,7 +345,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -425,13 +424,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -890,12 +889,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
@@ -662,9 +662,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.1.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -95,7 +96,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -212,7 +213,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -308,7 +309,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -335,7 +336,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +346,7 @@ For mode details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[cloud documentation]
+For mode details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -424,13 +425,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -662,7 +663,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -891,11 +892,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
@@ -662,9 +662,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -96,7 +95,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -213,7 +212,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -309,7 +308,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -336,7 +335,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -346,7 +345,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -425,13 +424,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -890,12 +889,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.2.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -95,7 +96,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -212,7 +213,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -308,7 +309,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -335,7 +336,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +346,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -424,13 +425,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -662,7 +663,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -891,11 +892,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -94,7 +95,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -211,7 +212,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -307,7 +308,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -334,7 +335,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -344,7 +345,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -423,13 +424,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -660,7 +661,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -889,11 +890,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
@@ -660,9 +660,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.3.3.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -95,7 +94,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -212,7 +211,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -308,7 +307,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -335,7 +334,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +344,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -424,13 +423,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -888,12 +887,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -94,7 +95,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -211,7 +212,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -307,7 +308,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -334,7 +335,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -344,7 +345,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -423,13 +424,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -660,7 +661,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -889,11 +890,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
@@ -660,9 +660,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.0.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -95,7 +94,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -212,7 +211,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -308,7 +307,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -335,7 +334,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +344,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -424,13 +423,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -888,12 +887,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -109,7 +110,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -226,7 +227,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -322,7 +323,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -349,7 +350,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -359,7 +360,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -438,13 +439,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -675,7 +676,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -904,11 +905,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
@@ -675,9 +675,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.1.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -110,7 +109,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -227,7 +226,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -323,7 +322,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -350,7 +349,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -360,7 +359,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -439,13 +438,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -903,12 +902,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -109,7 +110,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -226,7 +227,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -322,7 +323,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -349,7 +350,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -359,7 +360,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -438,13 +439,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -675,7 +676,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -904,11 +905,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
@@ -675,9 +675,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.4.2.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.7
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -110,7 +109,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.7/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -227,7 +226,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -323,7 +322,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -350,7 +349,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -360,7 +359,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.7/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -439,13 +438,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.7/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -903,12 +902,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.7/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -110,7 +109,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.8/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -227,7 +226,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -327,7 +326,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.8/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -337,7 +336,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.8/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -364,7 +363,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -374,7 +373,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -453,13 +452,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -917,12 +916,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.8/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
@@ -689,9 +689,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -109,7 +110,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -226,7 +227,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -326,7 +327,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -336,7 +337,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -363,7 +364,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -373,7 +374,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -452,13 +453,13 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`
     `["http://127.0.0.1"]`
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -689,7 +690,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -918,11 +919,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
@@ -673,9 +673,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -89,7 +90,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -206,7 +207,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -306,7 +307,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -316,7 +317,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -343,7 +344,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -353,7 +354,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -432,7 +433,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -442,7 +443,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -673,7 +674,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -902,11 +903,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.5.1.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.8
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -30,8 +29,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.8/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -90,7 +89,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.8/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -207,7 +206,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -307,7 +306,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.8/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -317,7 +316,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.8/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -344,7 +343,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -354,7 +353,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.8/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -433,7 +432,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -443,7 +442,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.8/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -901,12 +900,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.8/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -103,7 +104,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -220,7 +221,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -321,7 +322,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -331,7 +332,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -358,7 +359,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -368,7 +369,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -466,7 +467,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -476,7 +477,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -712,7 +713,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -944,11 +945,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -30,8 +29,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.9/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -104,7 +103,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.9/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -221,7 +220,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -322,7 +321,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -332,7 +331,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.9/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -359,7 +358,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -369,7 +368,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -467,7 +466,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -477,7 +476,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -943,12 +942,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.0.asciidoc
@@ -712,9 +712,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -103,7 +104,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -220,7 +221,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -321,7 +322,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -331,7 +332,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -358,7 +359,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -368,7 +369,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -466,7 +467,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -476,7 +477,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -712,7 +713,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -944,11 +945,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -30,8 +29,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.9/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -104,7 +103,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.9/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -221,7 +220,7 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 This plugin supports request and response compression. Response compression is enabled by default and
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
@@ -322,7 +321,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -332,7 +331,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.9/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -359,7 +358,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -369,7 +368,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -467,7 +466,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -477,7 +476,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -943,12 +942,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
@@ -712,9 +712,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
@@ -716,9 +716,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -30,8 +29,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.9/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -104,7 +103,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.9/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -225,7 +224,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -326,7 +325,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -336,7 +335,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.9/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -363,7 +362,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -373,7 +372,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.9/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -471,7 +470,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -481,7 +480,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -947,12 +946,11 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.9
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -103,7 +104,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -224,7 +225,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -325,7 +326,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -335,7 +336,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -362,7 +363,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -372,7 +373,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -470,7 +471,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -480,7 +481,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -716,7 +717,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -948,11 +949,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!: 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -29,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -103,7 +104,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -224,7 +225,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -325,7 +326,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -335,7 +336,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -362,7 +363,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -372,7 +373,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -470,7 +471,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -480,7 +481,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -716,7 +717,7 @@ Set max interval in seconds between bulk retries.
   * Default value is `1`
 
 The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
 for more info
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
@@ -948,11 +949,12 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+
 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -716,9 +716,7 @@ Set max interval in seconds between bulk retries.
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `1`
 
-The number of times Elasticsearch should internally retry an update/upserted document
-See the https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/partial-updates.html[partial updates]
-for more info
+The number of times Elasticsearch should internally retry an update/upserted document.
 
 [id="{version}-plugins-{type}s-{plugin}-routing"]
 ===== `routing`

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
-:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -30,8 +29,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.10/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -104,7 +103,7 @@ Example:
 
 **What to do in case there is no field in the event containing the destination index prefix?**
 
-You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata) to set
+You can use the `mutate` filter and conditionals to add a `[@metadata]` field (see https://www.elastic.co/guide/en/logstash/7.10/event-dependent-configuration.html#metadata) to set
 the destination index for each event. The `[@metadata]` fields will not be sent to Elasticsearch.
 
 Example:
@@ -225,7 +224,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -326,7 +325,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -336,7 +335,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -363,7 +362,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.10/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -373,7 +372,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/{branch
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/7.10/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -471,7 +470,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -481,7 +480,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list
+It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
@@ -947,7 +946,7 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-index_.html#_version_types
 
 
 

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -953,5 +953,4 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-index
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-
 :no_codec!:


### PR DESCRIPTION
Our use of `current` in the plugin docs frequently causes problems when we cut over to a new minor or major version.

This PR:

* fixes links that would be broken for 7.10
* sets an appropriate stack branch to "future proof" against broken links

PREVIEW: https://logstash-docs_960.docs-preview.app.elstc.co/diff

Versioning notes:
* 10.3.0 - 10.3.3. --> 7.7
* 10.4.0 - 10.4.2 --> 7.7
* 10.5.0 - 10.5.1 --> 7.8
* 10.6.0 - 10.6.2 --> 7.9
* 10.7.0 --> 7.10

ECS note:
* Starting with 10.6.1, these docs include links to ECS docs. ECS versioning differs from both plugin versioning and stack versioning.  For now, the ECS link still uses `current`.  

