### PR TITLE
TEST VPR attributes and branchsets - DO NOT MERGE

### DIFF
--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.1.asciidoc
@@ -19,6 +19,46 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 include::{include_path}/plugin_header.asciidoc[]
 
+==== TEST TEST TEST TEST
+
+Link/branch testing
+
+Test notes:  This file doesn't have any additional file-level attributes set (or cleared).
+
+===== Links using full attributes
+
+{ref}/modules-transport.html[communication between nodes] from Line 53
+
+Using the {ref}/java-clients.html[transport protocol] from Line 54
+
+See {logstash-ref}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+===== Hard-coded links using `{branch}` attribute
+
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes] from Line 53
+
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol] from Line 54
+
+See https://www.elastic.co/guide/en/logstash/{branch}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+API key API] from Line 356.
+
+
+===== Hard-coded links
+
+See https://www.elastic.co/guide/en/logstash/7.10/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-create-api-key.html[Create
+API key API] from Line 356.
+
+
+
+
 ==== Description
 
 If you plan to use the Kibana web interface to analyze data transformed by

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.6.2.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -18,6 +19,46 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 === Elasticsearch output plugin {version}
 
 include::{include_path}/plugin_header.asciidoc[]
+
+
+==== TEST TEST TEST TEST
+
+Experiment: Setting `{branch}` attribute at beginning of file, but not clearing it
+at the end to test for spillover.
+
+===== Links using full attributes
+
+{ref}/modules-transport.html[communication between nodes] from Line 53
+
+Using the {ref}/java-clients.html[transport protocol] from Line 54
+
+See {logstash-ref}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+===== Hard-coded links using `{branch}` attribute
+
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes] from Line 53
+
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol] from Line 54
+
+See https://www.elastic.co/guide/en/logstash/{branch}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+API key API] from Line 356.
+
+
+===== Hard-coded links
+
+See https://www.elastic.co/guide/en/logstash/7.10/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-create-api-key.html[Create
+API key API] from Line 356.
+
+
+
 
 ==== Description
 

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -22,6 +22,69 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== TEST TEST TEST TEST
 
+Link/branch testing:
+
+* Full attributes (such as `{ref}` and `{logstash-ref}`)
+* Hard-codes links with `{branch}` attribute (set at beginning and cleared at end of each file)
+* Hard-coded links
+
+Verify:
+
+* Effectiveness. Does the approach produce the results we want?
+* Spillover. Do settings spill over into next files?
+** Test case: Try setting, but not clearing a branch attribute 
+* Make sure that clearing the document-level branch setting doesn't clear the
+global setting.
+
+Ease of use:
+
+* Which approach will make it easier to fix when `current` cutover breaks links?
+* Which approach will be most obvious and straightforward if somebody else has to make a quick fix? 
+
+Thoughts and ramblings:
+
+* We could conditionally add a branch attribute to VPR, but we would have to clear it
+outside of the VPR include file. Probably more trouble than it's worth.
+** What would happen if we set it and left it blank?  Maybe we could set it to
+`current` and then override by setting attribute value if links break.
+* Fix at break time by adding one of the previous link formats and possibly a
+branch attribute (set and clear).
+
+Final thoughts:
+
+* Whatever we decide, we need to document the approach for consistency and repeatability.
+
+
+===== Links using full attributes
+
+{ref}/modules-transport.html[communication between nodes] from Line 53
+
+Using the {ref}/java-clients.html[transport protocol] from Line 54
+
+See {logstash-ref}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+===== Hard-coded links using `{branch}` attribute
+
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes] from Line 53
+
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol] from Line 54
+
+See https://www.elastic.co/guide/en/logstash/{branch}/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+API key API] from Line 356.
+
+
+===== Hard-coded links
+
+See https://www.elastic.co/guide/en/logstash/7.10/dead-letter-queues.html[dead-letter-queues] from Line 177
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-create-api-key.html[Create
+API key API] from Line 356.
 
 
 ==== Description

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -19,6 +20,10 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 include::{include_path}/plugin_header.asciidoc[]
 
+==== TEST TEST TEST TEST
+
+
+
 ==== Description
 
 If you plan to use the Kibana web interface to analyze data transformed by
@@ -29,8 +34,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/7.10/java-clients.html[transport protocol]
+{ref}/modules-transport.html[communication between nodes].
+Using the {ref}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -224,7 +229,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-http.html#modules-http[in
+{ref}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -325,7 +330,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -953,4 +958,5 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-index
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!:
 :no_codec!:


### PR DESCRIPTION
We have mechanisms in place to handle plugin branch versioning in the Logstash Reference Guide. The shared attributes pick up the appropriate stack version (7.10, 7.11, 7.x, etc.)

The plugin version/branch mismatch is an ongoing problem in the Versioned Plugin Reference where there is no concept of stack versions.  We've worked around this issue by setting branch to `current`, but that causes pain at release time when `current` cuts over to a branch that no longer has the target links.

This PR is designed to help us test and vet various approaches to stack versioning, including full attributes like `{ref}` and `{logstash-ref]`, links using `{branch}` attribute in path, and hard-coded paths with branches.


**PREVIEW:** https://logstash-docs_973.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/versioned_plugin_docs/output-elasticsearch-index.html