### PR TITLE
VPR: Add/modify overrides for stack doc attributes

### DIFF
--- a/docs/versioned-plugins/index.asciidoc
+++ b/docs/versioned-plugins/index.asciidoc
@@ -10,9 +10,6 @@
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-// Override ref and logstash-ref settings imported from shared/attributes.asciidoc
-:ref: http://www.elastic.co/guide/en/elasticsearch/reference/{branch}
-:logstash-ref: http://www.elastic.co/guide/en/logstash/{branch}
 
 [[logstash-plugin-reference]]
 = Logstash Versioned Plugin Reference

--- a/docs/versioned-plugins/index.asciidoc
+++ b/docs/versioned-plugins/index.asciidoc
@@ -10,8 +10,9 @@
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-// Override logstash-ref setting imported from shared/attributes.asciidoc
-:logstash-ref: http://www.elastic.co/guide/en/logstash/current
+// Override ref and logstash-ref settings imported from shared/attributes.asciidoc
+:ref: http://www.elastic.co/guide/en/elasticsearch/reference/{branch}
+:logstash-ref: http://www.elastic.co/guide/en/logstash/{branch}
 
 [[logstash-plugin-reference]]
 = Logstash Versioned Plugin Reference


### PR DESCRIPTION
These overrides with a `{branch}` attribute give us more flexibility in managing version mismatches between plugin and stack. Thanks for consulting on the best approach, @dedemorton 