### PR TITLE
Restore links from VPR to ECS docs

### DIFF
--- a/docs/versioned-plugins/filters/grok-v4.4.0.asciidoc
+++ b/docs/versioned-plugins/filters/grok-v4.4.0.asciidoc
@@ -178,7 +178,7 @@ filter. This newly defined patterns in `pattern_definitions` will not be availab
 [id="{version}-plugins-{type}s-{plugin}-ecs"]
 ==== Migrating to Elastic Common Schema (ECS)
 
-To ease migration to the Elastic Common Schema (ECS), the filter
+To ease migration to the {ecs-ref}[Elastic Common Schema (ECS)], the filter
 plugin offers a new set of ECS-compliant patterns in addition to the existing
 patterns. The new ECS pattern definitions capture event field names that are
 compliant with the schema.
@@ -240,7 +240,7 @@ parsing different things), then set this to false.
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the Elastic Common Schema (ECS).
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 The value of this setting affects extracted event field names when a composite pattern (such as `HTTPD_COMMONLOG`) is matched.
 
 [id="{version}-plugins-{type}s-{plugin}-keep_empty_captures"]

--- a/docs/versioned-plugins/inputs/beats-v6.1.0.asciidoc
+++ b/docs/versioned-plugins/inputs/beats-v6.1.0.asciidoc
@@ -164,7 +164,7 @@ Close Idle clients after X seconds of inactivity.
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the Elastic Common Schema (ECS).
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 The value of this setting affects the keys for the Beats connection's metadata on the event:
 
 .Metadata Location by `ecs_compatibility` value


### PR DESCRIPTION
We removed some links (#984 and #985) to clear doc build failures.  This PR restores the links after fix #986 . 

**Previews:**
* https://logstash-docs_987.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/versioned_plugin_docs/v4.4.0-plugins-filters-grok.html
* https://logstash-docs_987.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/versioned_plugin_docs/v6.1.0-plugins-inputs-beats.html
