### PR TITLE
updated docs for 7.x

### DIFF
--- a/docs/plugins/inputs/file.asciidoc
+++ b/docs/plugins/inputs/file.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.2.3
-:release_date: 2020-12-01
-:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.2.3/CHANGELOG.md
+:version: v4.2.4
+:release_date: 2021-03-23
+:changelog_url: https://github.com/logstash-plugins/logstash-input-file/blob/v4.2.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/log4j.asciidoc
+++ b/docs/plugins/inputs/log4j.asciidoc
@@ -26,13 +26,13 @@ NOTE: This plugin is deprecated. It is recommended that you use filebeat to coll
 
 The following section is a guide for how to migrate from SocketAppender to use filebeat.
 
-To migrate away from log4j SocketAppender to using filebeat, you will need to make these changes:
+To migrate away from log4j SocketAppender to using filebeat, you will need to make 3 changes:
 
-* Configure your log4j.properties (in your app) to write to a local file.
-* Install and configure filebeat to collect those logs and ship them to Logstash
-* Configure Logstash to use the beats input.
+1) Configure your log4j.properties (in your app) to write to a local file.
+2) Install and configure filebeat to collect those logs and ship them to Logstash
+3) Configure Logstash to use the beats input.
 
-===== Configuring log4j for writing to local files
+.Configuring log4j for writing to local files
 
 In your log4j.properties file, remove SocketAppender and replace it with RollingFileAppender. 
 
@@ -48,10 +48,10 @@ For example, you can use the following log4j.properties configuration to write d
 
 Configuring log4j.properties in more detail is outside the scope of this migration guide.
 
-===== Configuring filebeat
+.Configuring filebeat
 
 Next,
-https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-installation-configuration.html[install
+https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
 filebeat]. Based on the above log4j.properties, we can use this filebeat
 configuration:
 
@@ -67,9 +67,9 @@ configuration:
         hosts: ["your-logstash-host:5000"]
 
 For more details on configuring filebeat, see 
-https://www.elastic.co/guide/en/beats/filebeat/{branch}/configuring-howto-filebeat.html[Configure Filebeat].
+https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
 
-===== Configuring Logstash to receive from filebeat
+.Configuring Logstash to receive from filebeat
 
 Finally, configure Logstash with a beats input:
 
@@ -84,7 +84,7 @@ It is strongly recommended that you also enable TLS in filebeat and logstash
 beats input for protection and safety of your log data..
 
 For more details on configuring the beats input, see
-https://www.elastic.co/guide/en/logstash/{branch}/plugins-inputs-beats.html[the logstash beats input documentation].
+https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
 
 ==== Description
 

--- a/docs/plugins/inputs/syslog.asciidoc
+++ b/docs/plugins/inputs/syslog.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.4.5
-:release_date: 2021-01-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-syslog/blob/v3.4.5/CHANGELOG.md
+:version: v3.5.0
+:release_date: 2021-03-22
+:changelog_url: https://github.com/logstash-plugins/logstash-input-syslog/blob/v3.5.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -48,6 +48,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-facility_labels>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-grok_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
@@ -64,6 +65,20 @@ Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options suppo
 input plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (for example, `priority` for syslog priority)
+    ** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[log][syslog][priority]`)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the
+{ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
 ===== `facility_labels`
@@ -85,6 +100,9 @@ the facility_label is not added to the event.
 
   * Value type is <<string,string>>
   * Default value is `"<%{POSINT:priority}>%{SYSLOGLINE}"`
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"<%{POSINT:priority}>%{SYSLOGLINE}"`
+    ** ECS Compatibility enabled: `"<%{POSINT:[log][syslog][priority]:int}>%{SYSLOGLINE}"`
 
 The default value should read and properly parse syslog lines which are
 fully compliant with http://www.ietf.org/rfc/rfc3164.txt[RFC3164].

--- a/docs/plugins/inputs/tcp.asciidoc
+++ b/docs/plugins/inputs/tcp.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.0.7
-:release_date: 2021-02-09
-:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.7/CHANGELOG.md
+:version: v6.0.8
+:release_date: 2021-03-23
+:changelog_url: https://github.com/logstash-plugins/logstash-input-tcp/blob/v6.0.8/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -203,7 +203,9 @@ For input, sets the field `sslsubject` to that of the client certificate.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Instruct the socket to use TCP keep alives. Uses OS defaults for keep alive settings.
+Instruct the socket to use TCP keep alive. If it's `true` then the underlying socket
+will use the OS defaults settings for keep alive. If it's `false` it doesn't configure any
+keep alive setting for the underlying socket.
 
 [id="plugins-{type}s-{plugin}-dns_reverse_lookup_enabled"]
 ===== `dns_reverse_lookup_enabled`


### PR DESCRIPTION
Generated docs to test the impact of a second file in the input-tcp `/docs/` directory. All appears in order and as expected. The second file is ignored and appears to have no impact on the docgen process. 