### PR TITLE
VPR: Add input-elastic_agent landing page

### DIFF
--- a/docs/versioned-plugins/inputs-index.asciidoc
+++ b/docs/versioned-plugins/inputs-index.asciidoc
@@ -15,6 +15,8 @@ include::inputs/dead_letter_queue-index.asciidoc[]
 
 include::inputs/drupal_dblog-index.asciidoc[]
 
+include::inputs/elastic_agent-index.asciidoc[]
+
 include::inputs/elasticsearch-index.asciidoc[]
 
 include::inputs/eventlog-index.asciidoc[]

--- a/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
+++ b/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
@@ -13,6 +13,5 @@ The `input-elastic_agent` plugin is the next generation of the
 <<input-beats-index,input-beats plugin>>, and is based on the
 https://github.com/logstash-plugins/logstash-input-beats[the same github repository].
 
-<<input-beats-index,Beats plugins>> versioned v6.1.3 and higher have an {type}-{plugin} counterpart.
 To see which plugin version you have installed, run 
 `bin/logstash-plugin list --verbose`.

--- a/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
+++ b/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
@@ -13,6 +13,6 @@ The `input-elastic_agent` plugin is the next generation of the
 <<input-beats-index,input-beats plugin>>, and is based on the
 https://github.com/logstash-plugins/logstash-input-beats[the same github repository].
 
-<<input-beats-index,Beats plugins>> versioned v.6.1.3 and higher have an {type}-{plugin} counterpart.
+<<input-beats-index,Beats plugins>> versioned v6.1.3 and higher have an {type}-{plugin} counterpart.
 To see which plugin version you have installed, run 
 `bin/logstash-plugin list --verbose`.

--- a/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
+++ b/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
@@ -1,0 +1,19 @@
+:plugin: elastic_agent
+:type: input
+
+[id="{type}-{plugin}-index"]
+
+== Versioned {plugin} {type} plugin
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+The `input-elastic_agent` plugin is the next generation of the
+<<input-beats-index,input-beats plugin>>, and is based on the
+https://github.com/logstash-plugins/logstash-input-beats[beats repository].
+
+<<input-beats-index,Beats plugins>> versioned v.6.1.3 and higher have an {type}-{plugin} counterpart.
+To see which plugin version you have installed, run 
+`bin/logstash-plugin list --verbose`.
+

--- a/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
+++ b/docs/versioned-plugins/inputs/elastic_agent-index.asciidoc
@@ -11,9 +11,8 @@
 
 The `input-elastic_agent` plugin is the next generation of the
 <<input-beats-index,input-beats plugin>>, and is based on the
-https://github.com/logstash-plugins/logstash-input-beats[beats repository].
+https://github.com/logstash-plugins/logstash-input-beats[the same github repository].
 
 <<input-beats-index,Beats plugins>> versioned v.6.1.3 and higher have an {type}-{plugin} counterpart.
 To see which plugin version you have installed, run 
 `bin/logstash-plugin list --verbose`.
-


### PR DESCRIPTION
The input-elastic_agent page in the Logstash Reference needs to link to the corresponding page in the Versioned Plugin Reference.  (Related: https://github.com/elastic/logstash-docs/pull/1011). 

This PR creates a static landing page. Note that the versioned documents/link won't be generated programmatically at the this time because docs tooling relies on a version bump and published gem as a trigger. We can evaluate that enhancement for later if we want to. 

**PREVIEW:** https://logstash-docs_1021.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/current/input-elastic_agent-index.html