### PR TITLE
VPR: Remove link to file that doesn't exist yet

### DIFF
--- a/docs/versioned-plugins/integrations/elastic_enterprise_search-v2.1.0.asciidoc
+++ b/docs/versioned-plugins/integrations/elastic_enterprise_search-v2.1.0.asciidoc
@@ -25,6 +25,6 @@ The Elastic EnterpriseSearch Integration Plugin provides integrated plugins for 
 App Search and Workplace Search services:
 
 - {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
-- {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Workplace Search Output Plugin]
+- Workplace Search Output Plugin
 
 :no_codec!:


### PR DESCRIPTION
We're adding a new output plugin to integration-workplace_search. The file we're linking to doesn't exist yet. 
Resolution: Hardcode the entry for now, and replace with updated link when file goes live. 