### PR TITLE
updated docs - manual docgen for 7.x plugins

### DIFF
--- a/docs/plugins/filters/fingerprint.asciidoc
+++ b/docs/plugins/filters/fingerprint.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.2.3
-:release_date: 2021-03-11
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/blob/v3.2.3/CHANGELOG.md
+:version: v3.2.4
+:release_date: 2021-05-14
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/blob/v3.2.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -157,7 +157,7 @@ the cryptographic hash function with the same name will be used to generate
 the fingerprint. When a key set, the keyed-hash (HMAC) digest function will
 be used.
 
-If set to `MURMUR3` the non-cryptographic MurmurHash function will be used.
+If set to `MURMUR3` the non-cryptographic 64 bit MurmurHash function will be used.
 
 If set to `IPV4_NETWORK` the input data needs to be a IPv4 address and
 the hash value will be the masked-out address using the number of bits

--- a/docs/plugins/filters/geoip.asciidoc
+++ b/docs/plugins/filters/geoip.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.1.1
-:release_date: 2021-05-11
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-geoip/blob/v7.1.1/CHANGELOG.md
+:version: v7.1.2
+:release_date: 2021-05-17
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-geoip/blob/v7.1.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -37,25 +37,6 @@ from MaxMind's website and use the `database` option to specify their location. 
 can be https://dev.maxmind.com/geoip/geoip2/geolite2[downloaded from here].
 
 If you would like to get Autonomous System Number(ASN) information, you can use the GeoLite2-ASN database.
-
-[id="plugins-{type}s-{plugin}-database_license"]
-==== Database License
-
-https://www.maxmind.com[MaxMind] changed from releasing the GeoIP database under
-a Creative Commons (CC) license to a proprietary end-user license agreement
-(EULA).  The MaxMind EULA requires Logstash to update the MaxMind database
-within 30 days of a database update. If Logstash fails to download the database
-for 30 days, it will stop the pipeline in order to maintain compliance.
-
-The GeoIP filter plugin can manage the database for users running the Logstash default
-distribution, or you can manage
-database updates on your own. The behavior is controlled by the `database` setting.
-When you use the default `database` setting, the auto-update feature ensures that the plugin is
-using the latest version of the database.
-Otherwise, you are responsible for maintaining compliance.
-
-The Logstash open source distribution uses the MaxMind Creative Commons license
-database by default.
 
 ==== Details
 
@@ -130,16 +111,14 @@ number of cache misses and waste memory.
 ===== `database`
 
   * Value type is <<path,path>>
-  * If not specified, the database defaults to the GeoLite2 City database that ships with Logstash.
+  * There is no default value for this setting.
 
 The path to MaxMind's database file that Logstash should use. The default database is GeoLite2-City.
 GeoLite2-City, GeoLite2-Country, GeoLite2-ASN are the free databases from MaxMind that are supported.
 GeoIP2-City, GeoIP2-ISP, GeoIP2-Country are the commercial databases from MaxMind that are supported.
 
-Database auto-update applies to default distribution. When `database` points to user's database path,
-auto-update will be disabled.
-See
-<<plugins-{type}s-{plugin}-database_license,Database License>> for more information.
+If not specified, this will default to the GeoLite2 City database that ships
+with Logstash.
 
 [id="plugins-{type}s-{plugin}-default_database_type"]
 ===== `default_database_type`

--- a/docs/plugins/filters/jdbc_static.asciidoc
+++ b/docs/plugins/filters/jdbc_static.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.7
-:release_date: 2021-04-15
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.0.7/CHANGELOG.md
+:version: v5.1.1
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -423,7 +423,7 @@ according to the table below.
 |=======================================================================
 |Setting |Input type|Required
 | id|string|No
-| table|string|Yes
+| local_table|string|Yes
 | query|string|Yes
 | max_rows|number|No
 | jdbc_connection_string|string|No
@@ -439,7 +439,7 @@ id::
 An optional identifier. This is used to identify the loader that is
 generating error messages and log lines.
 
-table::
+local_table::
 The destination table in the local lookup database that the loader will fill.
 
 query::

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.7
-:release_date: 2021-04-15
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.0.7/CHANGELOG.md
+:version: v5.1.1
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/jdbc.asciidoc
+++ b/docs/plugins/inputs/jdbc.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.7
-:release_date: 2021-04-15
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.0.7/CHANGELOG.md
+:version: v5.1.1
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -212,6 +212,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-sql_log_level>> |<<string,string>>, one of `["fatal", "error", "warn", "info", "debug"]`|No
 | <<plugins-{type}s-{plugin}-statement>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-statement_filepath>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-target>> | {logstash-ref}/field-references-deepdive.html[field reference] | No
 | <<plugins-{type}s-{plugin}-tracking_column>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-tracking_column_type>> |<<string,string>>, one of `["numeric", "timestamp"]`|No
 | <<plugins-{type}s-{plugin}-use_column_value>> |<<boolean,boolean>>|No
@@ -535,6 +536,17 @@ with the `parameters` setting.
   * There is no default value for this setting.
 
 Path of file containing statement to execute
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+* Value type is {logstash-ref}/field-references-deepdive.html[field reference]
+* There is no default value for this setting.
+
+Without a `target`, events are created from each row column at the root level.
+When the `target` is set to a field reference, the column of each row is placed in the target field instead.
+
+This option can be useful to avoid populating unknown fields when a downstream schema such as ECS is enforced.
 
 [id="plugins-{type}s-{plugin}-tracking_column"]
 ===== `tracking_column`

--- a/docs/plugins/inputs/kafka.asciidoc
+++ b/docs/plugins/inputs/kafka.asciidoc
@@ -9,9 +9,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v10.7.4
-:release_date: 2021-04-14
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.4/CHANGELOG.md
+:version: v10.7.5
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -6,10 +6,14 @@ filters and codecs--into one package.
 
 |=======================================================================
 | Integration Plugin | Description | Github repository
+| <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with Elastic Enterprise Search. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/master/docs/index.asciidoc
+include::integrations/elastic_enterprise_search.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/index.asciidoc
 include::integrations/jdbc.asciidoc[]

--- a/docs/plugins/integrations/elastic_enterprise_search.asciidoc
+++ b/docs/plugins/integrations/elastic_enterprise_search.asciidoc
@@ -26,6 +26,6 @@ The Elastic EnterpriseSearch Integration Plugin provides integrated plugins for 
 App Search and Workplace Search services:
 
 - {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
-- {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Workplace Search Output Plugin]
+- Workplace Search Output Plugin
 
 :no_codec!:

--- a/docs/plugins/integrations/elastic_enterprise_search.asciidoc
+++ b/docs/plugins/integrations/elastic_enterprise_search.asciidoc
@@ -1,0 +1,31 @@
+:plugin: elastic_enterprise_search
+:type: integration
+:default_plugin: 1
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v2.1.0
+:release_date: 2021-05-18
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.0/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Elastic Enterprise Search integration plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+The Elastic EnterpriseSearch Integration Plugin provides integrated plugins for working with
+App Search and Workplace Search services:
+
+- {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
+- {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Workplace Search Output Plugin]
+
+:no_codec!:

--- a/docs/plugins/integrations/jdbc.asciidoc
+++ b/docs/plugins/integrations/jdbc.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.7
-:release_date: 2021-04-15
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.0.7/CHANGELOG.md
+:version: v5.1.1
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.1/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/integrations/kafka.asciidoc
+++ b/docs/plugins/integrations/kafka.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v10.7.4
-:release_date: 2021-04-14
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.4/CHANGELOG.md
+:version: v10.7.5
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
 :default_plugin: 1
@@ -6,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2021-05-04
-:changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.2.0/CHANGELOG.md
+:version: v2.1.0
+:release_date: 2021-05-18
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -16,14 +17,14 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== App Search output plugin
+=== Elastic App Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the Elastic App Search solution, 
-both the https://www.elastic.co/downloads/app-search[self-managed] or 
+This output lets you send events to the Elastic App Search solution,
+both the https://www.elastic.co/downloads/app-search[self-managed] or
 the https://www.elastic.co/cloud/app-search-service[managed] service.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the App Search bulk API
@@ -39,10 +40,10 @@ to store the timestamp in a different field.
 NOTE: This gem does not support codec customization.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== AppSearch Output Configuration Options
+==== AppSearch Output configuration options
 
 This plugin supports the following configuration options plus the
- <<plugins-{type}s-{plugin}-common-options>> described later.
+<<plugins-{type}s-{plugin}-common-options>> described later.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -64,16 +65,16 @@ output plugins.
 [id="plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
 
-  * Value type is <<password,password>>
-  * There is no default value
+* Value type is <<password,password>>
+* There is no default value
 
 The private API Key with write permissions. Visit the https://app.swiftype.com/as/credentials[Credentials] in the App Search dashboard to find the key associated with your account.
 
 [id="plugins-{type}s-{plugin}-document_id"]
 ===== `document_id`
 
-  * Value type is <<string,string>>
-  * There is no default value
+* Value type is <<string,string>>
+* There is no default value
 
 The id for app search documents. This can be an interpolated value
 like `myapp-%{sequence_id}`. Reusing ids will cause documents to be rewritten.
@@ -81,8 +82,8 @@ like `myapp-%{sequence_id}`. Reusing ids will cause documents to be rewritten.
 [id="plugins-{type}s-{plugin}-engine"]
 ===== `engine`
 
-  * Value type is <<string,string>>
-  * There is no default value
+* Value type is <<string,string>>
+* There is no default value
 
 The name of the search engine you created in App Search, an information
 repository that includes the indexed document records.
@@ -128,8 +129,8 @@ output {
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`
 
-  * Value type is <<string,string>>
-  * There is no default value
+* Value type is <<string,string>>
+* There is no default value
 
 The hostname of the App Search API that is associated with your App Search account.
 Set this when using the https://www.elastic.co/cloud/app-search-service[Elastic App Search managed service].
@@ -137,30 +138,30 @@ Set this when using the https://www.elastic.co/cloud/app-search-service[Elastic 
 [id="plugins-{type}s-{plugin}-path"]
 ===== `path`
 
-  * Value type is <<string,string>>
-  * Default value is `/api/as/v1/`
+* Value type is <<string,string>>
+* Default value is `/api/as/v1/`
 
 The path that is appended to the `url` parameter when connecting to a https://www.elastic.co/downloads/app-search[self-managed Elastic App Search].
 
 [id="plugins-{type}s-{plugin}-timestamp_destination"]
 ===== `timestamp_destination`
 
-  * Value type is <<string,string>>
-  * There is no default value
+* Value type is <<string,string>>
+* There is no default value
 
-Where to move the value from the `@timestamp` field. 
+Where to move the value from the `@timestamp` field.
 
 All Logstash events contain a `@timestamp` field.
-App Search doesn't support fields starting with `@timestamp`, and 
-by default, the `@timestamp` field will be deleted. 
+App Search doesn't support fields starting with `@timestamp`, and
+by default, the `@timestamp` field will be deleted.
 
 To keep the timestamp field, set this value to the name of the field where you want `@timestamp` copied.
 
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url`
 
-  * Value type is <<string,string>>
-  * There is no default value
+* Value type is <<string,string>>
+* There is no default value
 
 The value of the API endpoint in the form of a URL. Note: The value of the of the `path` setting will be will be appended to this URL.
 Set this when using the https://www.elastic.co/downloads/app-search[self-managed Elastic App Search].

--- a/docs/plugins/outputs/elastic_workplace_search.asciidoc
+++ b/docs/plugins/outputs/elastic_workplace_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_workplace_search
 :type: output
 :default_plugin: 1
@@ -18,7 +19,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Elastic Workplace Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc
 
 ==== Description
 

--- a/docs/plugins/outputs/elastic_workplace_search.asciidoc
+++ b/docs/plugins/outputs/elastic_workplace_search.asciidoc
@@ -1,0 +1,148 @@
+:plugin: elastic_workplace_search
+:type: output
+:default_plugin: 1
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v2.1.0
+:release_date: 2021-05-18
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.0/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Elastic Workplace Search output plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This output lets you send events to the Elastic Workplace Search solution.
+On receiving a batch of events from the Logstash pipeline, the plugin
+converts the events into documents and uses the Workplace Search bulk API
+to index multiple events in one request.
+
+Workplace Search doesn't allow fields to begin with `@timestamp`.
+By default the `@timestamp` and `@version` fields will be removed from
+each event before the event is sent to Workplace Search. If you want to keep
+the `@timestamp` field, you can use the
+<<plugins-{type}s-{plugin}-timestamp_destination,timestamp_destination>> option
+to store the timestamp in a different field.
+
+NOTE: This gem does not support codec customization.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Workplace Search Output Configuration Options
+
+This plugin supports the following configuration options plus the
+<<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-access_token>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-timestamp_destination>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-access_token"]
+===== `access_token`
+
+* Value type is <<password,password>>
+* There is no default value
+
+The source access token. Visit the source overview page in the Workplace Search dashboard to find the token associated with your source.
+
+[id="plugins-{type}s-{plugin}-document_id"]
+===== `document_id`
+
+* Value type is <<string,string>>
+* There is no default value
+
+The id for workplace search documents. This can be an interpolated value
+like `myapp-%{sequence_id}`. Reusing ids will cause documents to be rewritten.
+
+[id="plugins-{type}s-{plugin}-source"]
+===== `source`
+
+* Value type is <<string,string>>
+* There is no default value
+
+The ID of the source you created in Workplace Search.
+The `source` field supports
+{logstash-ref}/event-dependent-configuration.html#sprintf[sprintf format] to
+allow the source ID to be derived from a field value from each event, for
+example `%{source_id}`.
+
+Invalid source IDs cause ingestion to stop until the field value can be resolved into a valid source ID.
+This situation can happen if the interpolated field value resolves to a value without a matching source,
+or, if the field is missing from the event and cannot be resolved at all.
+
+TIP: Consider adding a "default" source type in the configuration to catch errors if
+the field is missing from the event.
+
+Example:
+
+
+
+[source,ruby]
+----------------------------------
+input {
+  stdin {
+    codec => json
+  }
+}
+
+filter {
+  if ![source_id] {
+    mutate {
+      add_field => {"source_id" => "default"}
+    }
+  }
+}
+
+output {
+  elastic_workplace_search {
+    source => "%{[source_id]}"
+  }
+}
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-timestamp_destination"]
+===== `timestamp_destination`
+
+* Value type is <<string,string>>
+* There is no default value
+
+Where to move the value from the `@timestamp` field.
+
+All Logstash events contain a `@timestamp` field.
+Workplace Search doesn't support fields starting with `@timestamp`, and
+by default, the `@timestamp` field will be deleted.
+
+To keep the timestamp field, set this value to the name of the field where you want `@timestamp` copied.
+
+[id="plugins-{type}s-{plugin}-url"]
+===== `url`
+
+* Value type is <<string,string>>
+* There is no default value
+
+The value of the API endpoint in the form of a URL.
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:no_codec!:

--- a/docs/plugins/outputs/http.asciidoc
+++ b/docs/plugins/outputs/http.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.2.4
-:release_date: 2019-01-30
-:changelog_url: https://github.com/logstash-plugins/logstash-output-http/blob/v5.2.4/CHANGELOG.md
+:version: v5.2.5
+:release_date: 2021-05-27
+:changelog_url: https://github.com/logstash-plugins/logstash-output-http/blob/v5.2.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -87,7 +87,10 @@ output plugins.
 
 How many times should the client retry a failing URL. We highly recommend NOT setting this value
 to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
-Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+Only IO related failures will be retried, such as connection timeouts and unreachable hosts.
+Valid but non 2xx HTTP responses will always be retried, regardless of the value of this setting,
+unless `retry_failed` is set.
+Note: if `retry_non_idempotent` is NOT set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert` 
@@ -317,6 +320,7 @@ Set this to false if you don't want this output to retry failed requests
   * Default value is `false`
 
 If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
+This only affects connectivity related errors (see related `automatic_retries` setting).
 
 [id="plugins-{type}s-{plugin}-retryable_codes"]
 ===== `retryable_codes` 

--- a/docs/plugins/outputs/kafka.asciidoc
+++ b/docs/plugins/outputs/kafka.asciidoc
@@ -9,9 +9,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v10.7.4
-:release_date: 2021-04-14
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.4/CHANGELOG.md
+:version: v10.7.5
+:release_date: 2021-05-26
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-kafka/blob/v10.7.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
**PREVIEW:** https://logstash-docs_1035.docs-preview.app.elstc.co/guide/en/logstash/7.x/plugins-integrations-elastic_enterprise_search.html

A broken link in the new integration-enterprise_search plugin is failing the docgen process. The only way around this failure is a manual build to generate files, a PR with new and updated files, and manual fixes to the remove the broken links. (After this PR is merged and the files are present, we can reinstate the links.) 

The on-demand job is failing because we have a broken link (because the file doesn't exist), and we can't get a clean docgen to create the files because the links are broken.  This PR is an attempt to move past the chicken-egg situation and get us back on track. 