### PR TITLE
Add integration-elastic_enterprise_search to integration index

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -6,10 +6,14 @@ filters and codecs--into one package.
 
 |=======================================================================
 | Integration Plugin | Description | Github repository
+| <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with Elastic Enterprise Search. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/master/docs/index.asciidoc
+include::integrations/elastic_enterprise_search.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/index.asciidoc
 include::integrations/jdbc.asciidoc[]

--- a/docs/plugins/integrations/elastic_enterprise_search.asciidoc
+++ b/docs/plugins/integrations/elastic_enterprise_search.asciidoc
@@ -26,6 +26,6 @@ The Elastic EnterpriseSearch Integration Plugin provides integrated plugins for 
 App Search and Workplace Search services:
 
 - {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
-- {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Workplace Search Output Plugin]
+- Workplace Search Output Plugin
 
 :no_codec!:

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
 :default_plugin: 1
@@ -18,7 +19,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === App Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/plugins/outputs/elastic_workplace_search.asciidoc
+++ b/docs/plugins/outputs/elastic_workplace_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_workplace_search
 :type: output
 :default_plugin: 1
@@ -18,7 +19,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Elastic Workplace Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 


### PR DESCRIPTION
**PREVIEW:** https://logstash-docs_1037.docs-preview.app.elstc.co/guide/en/logstash/master/plugin-integrations.html

No backport required!  A similar change was included in #1035.

- [x] Generate and verify files: #1032