### PR TITLE
Add include file and index listing for enterprise search integration for 7.13

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -6,10 +6,14 @@ filters and codecs--into one package.
 
 |=======================================================================
 | Integration Plugin | Description | Github repository
+| <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with Elastic Enterprise Search. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/master/docs/index.asciidoc
+include::integrations/elastic_enterprise_search.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/index.asciidoc
 include::integrations/jdbc.asciidoc[]


### PR DESCRIPTION
The integration isn't installed by default for 7.13, but is supported. This work adds the file and listing. 