### PR TITLE
Activate links

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -6,7 +6,7 @@ filters and codecs--into one package.
 
 |=======================================================================
 | Integration Plugin | Description | Github repository
-| <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with Elastic Enterprise Search. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
+| <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with https://www.elastic.co/enterprise-search[Elastic Enterprise Search]. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]

--- a/docs/plugins/integrations/elastic_enterprise_search.asciidoc
+++ b/docs/plugins/integrations/elastic_enterprise_search.asciidoc
@@ -25,7 +25,7 @@ include::{include_path}/plugin_header.asciidoc[]
 The Elastic Enterprise Search integration plugin provides integrated plugins for working with Elastic App Search and Elastic Workplace Search services:
 
 * {logstash-ref}/plugins-outputs-elastic_app_search.html[Elastic App Search output plugin]
-* Elastic Workplace Search output plugin
+* {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Elastic Workplace Search output plugin]
 
 
 :no_codec!:


### PR DESCRIPTION
Add link to enterprise search page on elastic.co
Activate link from enterprise search integration to workplace search output
