### PR TITLE
Add entries for appsearch and workplace search

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -7,6 +7,7 @@ The following output plugins are available below. For a list of Elastic supporte
 
 |=======================================================================
 | Plugin | Description | Github repository
+| <<plugins-outputs-elastic_app_search,app_search>> | Sends events to the https://www.elastic.co/app-search/[Elastic App Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-boundary,boundary>> | Sends annotations to Boundary based on Logstash events | https://github.com/logstash-plugins/logstash-output-boundary[logstash-output-boundary]
 | <<plugins-outputs-circonus,circonus>> | Sends annotations to Circonus based on Logstash events | https://github.com/logstash-plugins/logstash-output-circonus[logstash-output-circonus]
 | <<plugins-outputs-cloudwatch,cloudwatch>> | Aggregates and sends metric data to AWS CloudWatch | https://github.com/logstash-plugins/logstash-output-cloudwatch[logstash-output-cloudwatch]
@@ -61,6 +62,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-udp,udp>> | Sends events over UDP | https://github.com/logstash-plugins/logstash-output-udp[logstash-output-udp]
 | <<plugins-outputs-webhdfs,webhdfs>> | Sends Logstash events to HDFS using the `webhdfs` REST API | https://github.com/logstash-plugins/logstash-output-webhdfs[logstash-output-webhdfs]
 | <<plugins-outputs-websocket,websocket>> | Publishes messages to a websocket | https://github.com/logstash-plugins/logstash-output-websocket[logstash-output-websocket]
+| <<plugins-outputs-elastic_workplace_search,workplace_search>> | Sends events to the https://www.elastic.co/enterprise-search[Elastic Workplace Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-xmpp,xmpp>> | Posts events over XMPP | https://github.com/logstash-plugins/logstash-output-xmpp[logstash-output-xmpp]
 | <<plugins-outputs-zabbix,zabbix>> | Sends events to a Zabbix server | https://github.com/logstash-plugins/logstash-output-zabbix[logstash-output-zabbix]
 |=======================================================================


### PR DESCRIPTION
**PREVIEW:**  https://logstash-docs_1052.docs-preview.app.elstc.co/guide/en/logstash/master/output-plugins.html

The list of output plugins is quite long. While I was hooking up and testing the docs for the enterprise search integration, I kept looking for "workplace search" in the w's instead of the e's. Like... a lot.  I also found myself looking for app_search in the a's, but at least that's within scanning distance of "enterprise_app_search". 

This PR adds entries for both app_search and workplace_search so that a casual user doesn't overlook them. 

Another option would be to set up those entries like "See elastic_workplace_search," but why not get users to their intended destination without that extra click? And we're reinforcing the official "elastic" name in the description, so I think we're good.