### PR TITLE
Add entries for app_search and workplace_search to 7.13

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -7,6 +7,7 @@ The following output plugins are available below. For a list of Elastic supporte
 
 |=======================================================================
 | Plugin | Description | Github repository
+| <<plugins-outputs-elastic_app_search,app_search>> | Sends events to the https://www.elastic.co/app-search/[Elastic App Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-boundary,boundary>> | Sends annotations to Boundary based on Logstash events | https://github.com/logstash-plugins/logstash-output-boundary[logstash-output-boundary]
 | <<plugins-outputs-circonus,circonus>> | Sends annotations to Circonus based on Logstash events | https://github.com/logstash-plugins/logstash-output-circonus[logstash-output-circonus]
 | <<plugins-outputs-cloudwatch,cloudwatch>> | Aggregates and sends metric data to AWS CloudWatch | https://github.com/logstash-plugins/logstash-output-cloudwatch[logstash-output-cloudwatch]
@@ -61,6 +62,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-udp,udp>> | Sends events over UDP | https://github.com/logstash-plugins/logstash-output-udp[logstash-output-udp]
 | <<plugins-outputs-webhdfs,webhdfs>> | Sends Logstash events to HDFS using the `webhdfs` REST API | https://github.com/logstash-plugins/logstash-output-webhdfs[logstash-output-webhdfs]
 | <<plugins-outputs-websocket,websocket>> | Publishes messages to a websocket | https://github.com/logstash-plugins/logstash-output-websocket[logstash-output-websocket]
+| <<plugins-outputs-elastic_workplace_search,workplace_search>> | Sends events to the https://www.elastic.co/enterprise-search[Elastic Workplace Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-xmpp,xmpp>> | Posts events over XMPP | https://github.com/logstash-plugins/logstash-output-xmpp[logstash-output-xmpp]
 | <<plugins-outputs-zabbix,zabbix>> | Sends events to a Zabbix server | https://github.com/logstash-plugins/logstash-output-zabbix[logstash-output-zabbix]
 |=======================================================================


### PR DESCRIPTION
Add entries for app_search and workplace_search in addition to official names (elastic_app_search and elastic_workplace search) so that users won't overlook them in a quick scan

Backports #1052 to 7.13