### PR TITLE
Update regressions removed and changes added

### DIFF
--- a/docs/plugins/inputs/rabbitmq.asciidoc
+++ b/docs/plugins/inputs/rabbitmq.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.2.0
-:release_date: 2021-01-11
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.2.0/CHANGELOG.md
+:version: v7.3.0
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.3.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/integrations/elastic_enterprise_search.asciidoc
+++ b/docs/plugins/integrations/elastic_enterprise_search.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.1.1
-:release_date: 2021-06-02
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.1/CHANGELOG.md
+:version: v2.1.2
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -22,7 +22,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-The Elastic Enterprise Search integration plugin provides integrated plugins for working with Elastic App Search and Elastic Workplace Search services:
+The Elastic Enterprise Search integration plugin provides integrated plugins for working with https://www.elastic.co/app-search[Elastic App Search] and https://www.elastic.co/workplace-search[Elastic Workplace Search] services:
 
 * {logstash-ref}/plugins-outputs-elastic_app_search.html[Elastic App Search output plugin]
 * {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Elastic Workplace Search output plugin]

--- a/docs/plugins/integrations/rabbitmq.asciidoc
+++ b/docs/plugins/integrations/rabbitmq.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.2.0
-:release_date: 2021-01-11
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.2.0/CHANGELOG.md
+:version: v7.3.0
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.3.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -7,8 +7,8 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2021-05-04
+:version: v2.1.2
+:release_date: 2021-06-07
 :changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
@@ -17,20 +17,20 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== App Search output plugin
+=== Elastic App Search output plugin
 
 include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the Elastic App Search solution, 
+This output lets you send events to the https://www.elastic.co/app-search[Elastic App Search] solution, 
 both the https://www.elastic.co/downloads/app-search[self-managed] or 
 the https://www.elastic.co/cloud/app-search-service[managed] service.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the App Search bulk API
 to index multiple events in one request.
 
-App Search doesn't allow fields to begin with `@timestamp`.
+Elastic App Search doesn't allow fields to begin with `@timestamp`.
 By default the `@timestamp` and `@version` fields will be removed from
 each event before the event is sent to App Search. If you want to keep
 the `@timestamp` field, you can use the
@@ -40,7 +40,7 @@ to store the timestamp in a different field.
 NOTE: This gem does not support codec customization.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== AppSearch Output Configuration Options
+==== App Search Output Configuration Options
 
 This plugin supports the following configuration options plus the
  <<plugins-{type}s-{plugin}-common-options>> described later.

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,6 +1,7 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
-:default_plugin: 0
+:default_plugin: 1
 :no_codec:
 
 ///////////////////////////////////////////
@@ -18,7 +19,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === App Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,7 +1,6 @@
-:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
-:default_plugin: 1
+:default_plugin: 0
 :no_codec:
 
 ///////////////////////////////////////////
@@ -19,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === App Search output plugin
 
-include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 

--- a/docs/plugins/outputs/elastic_workplace_search.asciidoc
+++ b/docs/plugins/outputs/elastic_workplace_search.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.1.1
-:release_date: 2021-06-02
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.1/CHANGELOG.md
+:version: v2.1.2
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v2.1.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the Elastic Workplace Search solution.
+This output lets you send events to the https://www.elastic.co/workplace-search[Elastic Workplace Search] solution.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the Workplace Search bulk API
 to index multiple events in one request.

--- a/docs/plugins/outputs/influxdb.asciidoc
+++ b/docs/plugins/outputs/influxdb.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.0.5
-:release_date: 2018-08-15
-:changelog_url: https://github.com/logstash-plugins/logstash-output-influxdb/blob/v5.0.5/CHANGELOG.md
+:version: v5.0.6
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-output-influxdb/blob/v5.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -231,7 +231,7 @@ The retention policy to use
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
 request should be considered metadata and given as tags. Tags are only sent when
-present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
+present in `data_points` or if `use_event_fields_for_data_points` is `true`. 
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl` 

--- a/docs/plugins/outputs/rabbitmq.asciidoc
+++ b/docs/plugins/outputs/rabbitmq.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v7.2.0
-:release_date: 2021-01-11
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.2.0/CHANGELOG.md
+:version: v7.3.0
+:release_date: 2021-06-07
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.3.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Based on docs generated in #1055 
Removes regressions to app_search output
Adds manual updates to address changes not being picked up properly. (See  https://github.com/elastic/docs-tools/issues/57 for issue). 