### PR TITLE
Include output-dynatrace

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -14,6 +14,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-csv,csv>> | Writes events to disk in a delimited format | https://github.com/logstash-plugins/logstash-output-csv[logstash-output-csv]
 | <<plugins-outputs-datadog,datadog>> | Sends events to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog[logstash-output-datadog]
 | <<plugins-outputs-datadog_metrics,datadog_metrics>> | Sends metrics to DataDogHQ based on Logstash events | https://github.com/logstash-plugins/logstash-output-datadog_metrics[logstash-output-datadog_metrics]
+| <<plugins-outputs-dynatrace,dynatrace>> | Sends events to Dynatrace based on Logstash events | https://github.com/dynatrace-oss/logstash-output-dynatrace[logstash-output-dynatrace]
 | <<plugins-outputs-elastic_app_search,elastic_app_search>> | Sends events to the https://www.elastic.co/app-search/[Elastic App Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-elastic_workplace_search,elastic_workplace_search>> | Sends events to the https://www.elastic.co/enterprise-search[Elastic Workplace Search] solution | https://github.com/logstash-plugins/logstash-output-elastic_app_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-outputs-elasticsearch,elasticsearch>> | Stores logs in Elasticsearch | https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch]

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -86,6 +86,9 @@ include::outputs/datadog.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
 
+:edit_url: 
+include::outputs/dynatrace.asciidoc[]
+
 :edit_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/edit/master/docs/index.asciidoc
 include::outputs/elastic_app_search.asciidoc[]
 

--- a/docs/plugins/outputs/dynatrace.asciidoc
+++ b/docs/plugins/outputs/dynatrace.asciidoc
@@ -32,7 +32,7 @@ For plugins not bundled by default, it is easy to install by running
 
 ==== Description
 
-This plugin send Logstah events to the Dynatrace Generic log ingest API v2. 
+This plugin sends Logstash events to the Dynatrace Generic log ingest API v2. 
 
 ==== Documentation
  

--- a/docs/plugins/outputs/dynatrace.asciidoc
+++ b/docs/plugins/outputs/dynatrace.asciidoc
@@ -1,0 +1,46 @@
+:plugin: dynatrace
+:type: output
+:default_plugin: 0
+
+///////////////////////////////////////////
+REPLACES GENERATED VARIABLES
+///////////////////////////////////////////
+:changelog_url: https://github.com/dynatrace-oss/logstash-output-dynatrace/blob/master/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+:gem: https://rubygems.org/gems/logstash-output-dynatrace
+///////////////////////////////////////////
+END - REPLACES GENERATED VARIABLES
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Dynatrace plugin
+
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+* This plugin was created and is maintained by a contributor.
+* {changelog_url}[Change log]
+
+==== Installation
+
+For plugins not bundled by default, it is easy to install by running
++bin/logstash-plugin install logstash-{type}-{plugin}+. See
+{logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
+
+==== Description
+
+This plugin send Logstah events to the Dynatrace Generic log ingest API v2. 
+
+==== Documentation
+ 
+https://github.com/dynatrace-oss/logstash-output-dynatrace/blob/main/docs/index.asciidoc[
+Documentation] for the logstash-{type}-{plugin} plugin is maintained by the creator.
+
+==== Getting Help
+
+This is a third-party plugin. For bugs or feature requests, open an issue in the
+https://github.com/dynatrace-oss/logstash-output-dynatrace[plugins-{type}s-{plugin} Github repo].
+


### PR DESCRIPTION
This PR add Dynatrace output plugin, proposal in https://github.com/elastic/logstash/issues/12947

**PREVIEW:** https://logstash-docs_1062.docs-preview.app.elstc.co/guide/en/logstash/master/plugins-outputs-dynatrace.html