### PR TITLE
Updated docs for master with regressions removed

### DIFF
--- a/docs/plugins/filters/xml.asciidoc
+++ b/docs/plugins/filters/xml.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.1.1
-:release_date: 2020-06-03
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-xml/blob/v4.1.1/CHANGELOG.md
+:version: v4.1.2
+:release_date: 2021-06-23
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-xml/blob/v4.1.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -35,7 +35,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-force_array>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-force_content>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-namespaces>> |<<hash,hash>>|No
-| <<plugins-{type}s-{plugin}-parser_options>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-parse_options>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-remove_namespaces>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-store_xml>> |<<boolean,boolean>>|No
@@ -89,13 +89,13 @@ filter {
   }
 }
 
-[id="plugins-{type}s-{plugin}-parser_options"]
-===== `parser_options`
+[id="plugins-{type}s-{plugin}-parse_options"]
+===== `parse_options`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-Setting XML parser options allows for more control of the parsing process.
+Setting XML parse options allows for more control of the parsing process.
 By default the parser is not strict and thus accepts some invalid content.
 Currently supported options are:
 

--- a/docs/plugins/inputs/kinesis.asciidoc
+++ b/docs/plugins/inputs/kinesis.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.1.2
-:release_date: 2020-09-01
-:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.1.2/CHANGELOG.md
+:version: v2.2.0
+:release_date: 2021-06-28
+:changelog_url: https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -93,9 +93,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-application_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-checkpoint_interval_seconds>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-http_proxy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-initial_position_in_stream>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-kinesis_stream_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-metrics>> |<<string,string>>, one of `[nil, "cloudwatch"]`|No
+| <<plugins-{type}s-{plugin}-non_proxy_hosts>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-profile>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-role_arn>> |<<string,string>>|No
@@ -125,6 +127,14 @@ unique for this kinesis stream.
 
 How many seconds between worker checkpoints to dynamodb.
 
+[id="plugins-{type}s-{plugin}-http_proxy"]
+===== `http_proxy`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Proxy support for Kinesis, DynamoDB, and CloudWatch (if enabled).
+
 [id="plugins-{type}s-{plugin}-initial_position_in_stream"]
 ===== `initial_position_in_stream`
 
@@ -150,6 +160,14 @@ The kinesis stream name.
 
 Worker metric tracking. By default this is disabled, set it to "cloudwatch"
 to enable the cloudwatch integration in the Kinesis Client Library.
+
+[id="plugins-{type}s-{plugin}-non_proxy_hosts"]
+===== `non_proxy_hosts`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Hosts that should be excluded from proxying, separated by the "|" (pipe) character.
 
 [id="plugins-{type}s-{plugin}-profile"]
 ===== `profile`
@@ -207,7 +225,7 @@ To set the dynamodb read and write capacity values, use these functions:
 
 [source,text]
 ----
-additional_settings => {"initial_lease_table_read_capacity" => 25, "initial_lease_table_write_capacity" => 100}
+additional_settings => {"initial_lease_table_read_capacity" => 25 "initial_lease_table_write_capacity" => 100}
 ----
 
 

--- a/docs/plugins/inputs/s3.asciidoc
+++ b/docs/plugins/inputs/s3.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.6.0
-:release_date: 2021-03-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-s3/blob/v3.6.0/CHANGELOG.md
+:version: v3.7.0
+:release_date: 2021-06-24
+:changelog_url: https://github.com/logstash-plugins/logstash-input-s3/blob/v3.7.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -32,6 +32,21 @@ Files ending in `.gz` are handled as gzip'ed files.
 
 Files that are archived to AWS Glacier will be skipped.
 
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
+==== Event Metadata and the Elastic Common Schema (ECS)
+This plugin adds cloudfront metadata to event.
+When ECS compatibility is disabled, the value is stored in the root level.
+When ECS is enabled, the value is stored in the `@metadata` where it can be used by other plugins in your pipeline.
+
+Here’s how ECS compatibility mode affects output.
+[cols="<l,<l,e,<e"]
+|=======================================================================
+| ECS disabled | ECS v1 | Availability | Description
+
+| cloudfront_fields | [@metadata][s3][cloudfront][fields] | available when the file is a CloudFront log | column names of log
+| cloudfront_version | [@metadata][s3][cloudfront][version] | available when the file is a CloudFront log | version of log
+|=======================================================================
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== S3 Input Configuration Options
 
@@ -48,6 +63,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-backup_to_dir>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exclude_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-gzip_pattern>> |<<string,string>>|No
@@ -97,12 +113,12 @@ the connection to s3. See full list in https://docs.aws.amazon.com/sdkforruby/ap
 [source,ruby]
     input {
       s3 {
-        "access_key_id" => "1234"
-        "secret_access_key" => "secret"
-        "bucket" => "logstash-test"
-        "additional_settings" => {
-          "force_path_style" => true
-          "follow_redirects" => false
+        access_key_id => "1234"
+        secret_access_key => "secret"
+        bucket => "logstash-test"
+        additional_settings => {
+          force_path_style => true
+          follow_redirects => false
         }
       }
     }
@@ -167,6 +183,18 @@ The name of the S3 bucket.
   * Default value is `false`
 
 Whether to delete processed files from the original bucket.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+  ** `disabled`: does not use ECS-compatible field names
+  ** `v1`: uses metadata fields that are compatible with Elastic Common Schema
+
+Controls this plugin's compatibility with the
+{ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-endpoint"]
 ===== `endpoint`

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,13 +1,14 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
-:default_plugin: 0
+:default_plugin: 1
 :no_codec:
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v1.2.0
-:release_date: 2021-05-04
+:version: v2.1.2
+:release_date: 2021-06-07
 :changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
@@ -16,20 +17,20 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== App Search output plugin
+=== Elastic App Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the Elastic App Search solution, 
+This output lets you send events to the https://www.elastic.co/app-search[Elastic App Search] solution, 
 both the https://www.elastic.co/downloads/app-search[self-managed] or 
 the https://www.elastic.co/cloud/app-search-service[managed] service.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the App Search bulk API
 to index multiple events in one request.
 
-App Search doesn't allow fields to begin with `@timestamp`.
+Elastic App Search doesn't allow fields to begin with `@timestamp`.
 By default the `@timestamp` and `@version` fields will be removed from
 each event before the event is sent to App Search. If you want to keep
 the `@timestamp` field, you can use the
@@ -39,7 +40,7 @@ to store the timestamp in a different field.
 NOTE: This gem does not support codec customization.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== AppSearch Output Configuration Options
+==== App Search Output Configuration Options
 
 This plugin supports the following configuration options plus the
  <<plugins-{type}s-{plugin}-common-options>> described later.

--- a/docs/plugins/outputs/elastic_app_search.asciidoc
+++ b/docs/plugins/outputs/elastic_app_search.asciidoc
@@ -1,14 +1,13 @@
-:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
-:default_plugin: 1
+:default_plugin: 0
 :no_codec:
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v2.1.2
-:release_date: 2021-06-07
+:version: v1.2.0
+:release_date: 2021-05-04
 :changelog_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/blob/v1.2.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
@@ -17,20 +16,20 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Elastic App Search output plugin
+=== App Search output plugin
 
-include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-This output lets you send events to the https://www.elastic.co/app-search[Elastic App Search] solution, 
+This output lets you send events to the Elastic App Search solution, 
 both the https://www.elastic.co/downloads/app-search[self-managed] or 
 the https://www.elastic.co/cloud/app-search-service[managed] service.
 On receiving a batch of events from the Logstash pipeline, the plugin
 converts the events into documents and uses the App Search bulk API
 to index multiple events in one request.
 
-Elastic App Search doesn't allow fields to begin with `@timestamp`.
+App Search doesn't allow fields to begin with `@timestamp`.
 By default the `@timestamp` and `@version` fields will be removed from
 each event before the event is sent to App Search. If you want to keep
 the `@timestamp` field, you can use the
@@ -40,7 +39,7 @@ to store the timestamp in a different field.
 NOTE: This gem does not support codec customization.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== App Search Output Configuration Options
+==== AppSearch Output Configuration Options
 
 This plugin supports the following configuration options plus the
  <<plugins-{type}s-{plugin}-common-options>> described later.


### PR DESCRIPTION
Starts with generated docs (#1080)
Removes output-elastic_app_search doc that would introduce regressions (as noted in elastic/docs-tools#56 and elastic/docs-tools#57).