### PR TITLE
Remove link to ea limitations topic for master

### DIFF
--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -102,15 +102,6 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
-//Content for Elastic Agent
-ifeval::["{plugin}"!="beats"]
-[id="plugins-{type}s-{plugin}-limitations"]
-===== Elastic Agent and Fleet limitations
-
-Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
-For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
-endif::[]
-
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]

--- a/docs/plugins/inputs/elastic_agent.asciidoc
+++ b/docs/plugins/inputs/elastic_agent.asciidoc
@@ -102,15 +102,6 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
-//Content for Elastic Agent
-ifeval::["{plugin}"!="beats"]
-[id="plugins-{type}s-{plugin}-limitations"]
-===== Elastic Agent and Fleet limitations
-
-Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
-For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
-endif::[]
-
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]


### PR DESCRIPTION
As Elastic Agent matures, limitations are being removed. The topic targeted from the link will be going away, and so the link must be deleted, too.