### PR TITLE
Updated plugins for 7.x with regressions removed 

### DIFF
--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.2
-:release_date: 2021-06-22
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v6.2.2/CHANGELOG.md
+:version: v6.2.3
+:release_date: 2021-07-29
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v6.2.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -485,9 +485,7 @@ If the codec handles data from a variety of sources, the ECS recommendation is t
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the
-{ecs-ref}[Elastic Common Schema (ECS)]
-(ECS)].
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 

--- a/docs/plugins/codecs/multiline.asciidoc
+++ b/docs/plugins/codecs/multiline.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.11
-:release_date: 2021-06-23
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.11/CHANGELOG.md
+:version: v3.1.0
+:release_date: 2021-07-27
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -103,13 +103,14 @@ following line.
 
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Multiline Codec Configuration Options
+==== Multiline codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-auto_flush_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-max_bytes>> |<<bytes,bytes>>|No
 | <<plugins-{type}s-{plugin}-max_lines>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-multiline_tag>> |<<string,string>>|No
@@ -144,6 +145,19 @@ This setting is useful if your log files are in `Latin-1` (aka `cp1252`)
 or in another character set other than `UTF-8`.
 
 This only affects "plain" format logs since JSON is `UTF-8` already.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: plugin only sets the `message` field
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-max_bytes"]
 ===== `max_bytes` 

--- a/docs/plugins/codecs/plain.asciidoc
+++ b/docs/plugins/codecs/plain.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.6
-:release_date: 2017-12-19
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-plain/blob/v3.0.6/CHANGELOG.md
+:version: v3.1.0
+:release_date: 2021-07-27
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-plain/blob/v3.1.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -24,15 +24,16 @@ include::{include_path}/plugin_header.asciidoc[]
 The "plain" codec is for plain text with no delimiting between events.
 
 This is mainly useful on inputs and outputs that already have a defined
-framing in their transport protocol (such as zeromq, rabbitmq, redis, etc)
+framing in their transport protocol (such as zeromq, rabbitmq, redis, etc).
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Plain Codec Configuration Options
+==== Plain codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>|No
 |=======================================================================
 
@@ -51,6 +52,19 @@ This setting is useful if your log files are in `Latin-1` (aka `cp1252`)
 or in another character set other than `UTF-8`.
 
 This only affects "plain" format logs since json is `UTF-8` already.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: plugin only sets the `message` field
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-format"]
 ===== `format` 

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -102,6 +102,15 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
+//Content for Elastic Agent
+ifeval::["{plugin}"!="beats"]
+[id="plugins-{type}s-{plugin}-limitations"]
+===== Elastic Agent and Fleet limitations
+
+Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
+For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
+endif::[]
+
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -102,15 +102,6 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
-//Content for Elastic Agent
-ifeval::["{plugin}"!="beats"]
-[id="plugins-{type}s-{plugin}-limitations"]
-===== Elastic Agent and Fleet limitations
-
-Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
-For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
-endif::[]
-
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]


### PR DESCRIPTION
Starts with generated docs in #1121
Removes file containing regressions