### PR TITLE
Update docs for 7.14 with regression removed

### DIFF
--- a/docs/plugins/codecs/cef.asciidoc
+++ b/docs/plugins/codecs/cef.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.2
-:release_date: 2021-06-22
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v6.2.2/CHANGELOG.md
+:version: v6.2.3
+:release_date: 2021-07-29
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-cef/blob/v6.2.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -485,9 +485,7 @@ If the codec handles data from a variety of sources, the ECS recommendation is t
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the
-{ecs-ref}[Elastic Common Schema (ECS)]
-(ECS)].
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 

--- a/docs/plugins/codecs/graphite.asciidoc
+++ b/docs/plugins/codecs/graphite.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.5
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-graphite/blob/v3.0.5/CHANGELOG.md
+:version: v3.0.6
+:release_date: 2021-08-12
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-graphite/blob/v3.0.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/codecs/netflow.asciidoc
+++ b/docs/plugins/codecs/netflow.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.2.1
-:release_date: 2018-12-30
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.2.1/CHANGELOG.md
+:version: v4.2.2
+:release_date: 2021-08-01
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.2.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/elasticsearch.asciidoc
+++ b/docs/plugins/filters/elasticsearch.asciidoc
@@ -5,9 +5,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.9.3
-:release_date: 2021-01-26
-:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.9.3/CHANGELOG.md
+:version: v3.9.5
+:release_date: 2021-08-20
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v3.9.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/jdbc_static.asciidoc
+++ b/docs/plugins/filters/jdbc_static.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.4
-:release_date: 2021-07-09
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.4/CHANGELOG.md
+:version: v5.1.5
+:release_date: 2021-08-04
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/filters/jdbc_streaming.asciidoc
+++ b/docs/plugins/filters/jdbc_streaming.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.4
-:release_date: 2021-07-09
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.4/CHANGELOG.md
+:version: v5.1.5
+:release_date: 2021-08-04
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -102,6 +102,15 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
+//Content for Elastic Agent
+ifeval::["{plugin}"!="beats"]
+[id="plugins-{type}s-{plugin}-limitations"]
+===== Elastic Agent and Fleet limitations
+
+Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
+For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
+endif::[]
+
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]

--- a/docs/plugins/inputs/beats.asciidoc
+++ b/docs/plugins/inputs/beats.asciidoc
@@ -102,15 +102,6 @@ plugin] to handle multiline events. Doing so will result in the failure to start
 Logstash.
 endif::[]
 
-//Content for Elastic Agent
-ifeval::["{plugin}"!="beats"]
-[id="plugins-{type}s-{plugin}-limitations"]
-===== Elastic Agent and Fleet limitations
-
-Early releases of Elastic Agent and Fleet have some limitations, including support for advanced Beats settings like multiline, processors, and so forth. 
-For more information, see {fleet-guide}/fleet-limitations.html[Limitations of this release]. 
-endif::[]
-
 //Content for Beats
 ifeval::["{plugin}"=="beats"]
 [id="plugins-{type}s-{plugin}-versioned-indexes"]

--- a/docs/plugins/inputs/elasticsearch.asciidoc
+++ b/docs/plugins/inputs/elasticsearch.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v4.9.1
-:release_date: 2021-01-21
-:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.9.1/CHANGELOG.md
+:version: v4.9.3
+:release_date: 2021-08-20
+:changelog_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.9.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/inputs/jdbc.asciidoc
+++ b/docs/plugins/inputs/jdbc.asciidoc
@@ -7,9 +7,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.4
-:release_date: 2021-07-09
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.4/CHANGELOG.md
+:version: v5.1.5
+:release_date: 2021-08-04
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/integrations/jdbc.asciidoc
+++ b/docs/plugins/integrations/jdbc.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v5.1.4
-:release_date: 2021-07-09
-:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.4/CHANGELOG.md
+:version: v5.1.5
+:release_date: 2021-08-04
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.1.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -6,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v11.0.2
-:release_date: 2021-05-10
-:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v11.0.2/CHANGELOG.md
+:version: v11.0.3
+:release_date: 2021-08-20
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v11.0.3/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Starts with generated docs in #1140 
Removed input-beats doc that would introduce regressions and cause downstream issues when we switch the attributes for input-elastic_agent. 

TIP: Note that the `docs/plugins/inputs/beats.asciidoc` file in #1140 contains content updates, but no version bump. That's a red flag that this file might require further investigation. 
