### PR TITLE
TEST ONLY - DO NOT MERGE: Validate ECS attribute for LSR plugins

### DIFF
--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -32,6 +32,14 @@ Many Azure services integrate with the Azure Event Hubs.
 https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-overview-azure-monitor[Azure
 Monitor], for example, integrates with Azure Event Hubs to provide infrastructure metrics. 
 
+===== Test attribute HERE
+
+{ecs-default}
+
+NOTE: {ecs-default}
+
+
+
 ===== Event Hub connection string
 
 The plugin uses the connection string to access Azure Events Hubs. Find the


### PR DESCRIPTION
**DO NOT MERGE**

Test set to accompany https://github.com/elastic/logstash/pull/13083/files
This PR adds the {ecs-default} attribute to input-azure-event-hubs.asciidoc to validate that the attribute works as expected.

**PREVIEW:** https://logstash-docs_1163.docs-preview.app.elstc.co/guide/en/logstash/master/plugins-inputs-azure_event_hubs.html

Note that the PR preview won't render properly because #13083 has not been merged. Here's what it looks like when I build locally with both PRs checked out. 

<img width="870" alt="Screen Shot 2021-09-27 at 4 37 18 PM" src="https://user-images.githubusercontent.com/35154725/134981665-bafd96c3-81b7-4a16-ab28-8a43cf724f2e.png">
