### PR TITLE
LSR: Add age filter to filters index

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -8,6 +8,7 @@ The following filter plugins are available below. For a list of Elastic supporte
 
 |=======================================================================
 | Plugin | Description | Github repository
+| <<plugins-filters-age,age>> | Calculates the age of an event by subtracting the event timestamp from the current timestamp | https://github.com/logstash-plugins/logstash-filter-age[logstash-filter-age]
 | <<plugins-filters-aggregate,aggregate>> | Aggregates information from several events originating with a single task | https://github.com/logstash-plugins/logstash-filter-aggregate[logstash-filter-aggregate]
 | <<plugins-filters-alter,alter>> | Performs general alterations to fields that the `mutate` filter does not handle | https://github.com/logstash-plugins/logstash-filter-alter[logstash-filter-alter]
 | <<plugins-filters-bytes,bytes>> | Parses string representations of computer storage sizes, such as "123 MB" or "5.6gb", into their numeric value in bytes | https://github.com/logstash-plugins/logstash-filter-bytes[logstash-filter-bytes]
@@ -56,6 +57,9 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-wurfl_device_detection,wurfl_device_detection>> | Enriches logs with device information such as brand, model, OS | https://github.com/WURFL/logstash-filter-wurfl_device_detection[logstash-filter-wurfl_device_detection]
 | <<plugins-filters-xml,xml>> | Parses XML into fields | https://github.com/logstash-plugins/logstash-filter-xml[logstash-filter-xml]
 |=======================================================================
+
+:edit_url: https://github.com/logstash-plugins/logstash-filter-age/edit/master/docs/index.asciidoc
+include::filters/age.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/docs/index.asciidoc
 include::filters/aggregate.asciidoc[]


### PR DESCRIPTION
Doc file for `age` filter has been generated and is present in the `logstash-docs` repo. This PR adds the file to the [filters index](https://www.elastic.co/guide/en/logstash/current/filter-plugins.html) and pulls the file into the Logstash Reference (LSR). 

**PREVIEW:** https://logstash-docs_1190.docs-preview.app.elstc.co/guide/en/logstash/master/filter-plugins.html