### PR TITLE
Manual process: Update input-elastic_agent to v6.2.2

### DIFF
--- a/docs/plugins/inputs/elastic_agent.asciidoc
+++ b/docs/plugins/inputs/elastic_agent.asciidoc
@@ -8,9 +8,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.1
-:release_date: 2021-10-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.1/CHANGELOG.md
+:version: v6.2.2
+:release_date: 2021-11-11
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.2/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -233,14 +233,14 @@ Refer to <<plugins-{type}s-{plugin}-ecs_metadata,ECS mapping>> for detailed info
   * Default value is 1 executor thread per CPU core
 
 The number of threads to be used to process incoming beats requests.
-By default Beats input will create a number of threads equals to 2*CPU cores to handle incoming connections,
-reading from the established sockets and execute most of the tasks related to network connection managements, 
-except the parsing of Lumberjack protocol that's offloaded to a dedicated thread pool.
+By default the Beats input creates a number of threads equal to 2*CPU cores.
+These threads handle incoming connections, reading from established sockets, and executing most of the tasks related to network connection management. 
+Parsing the Lumberjack protocol is offloaded to a dedicated thread pool.
 
 Generally you don't need to touch this setting.
 In case you are sending very large events and observing "OutOfDirectMemory" exceptions,
 you may want to reduce this number to half or 1/4 of the CPU cores.
-This will reduce the number of threads decompressing batches of data into direct memory.
+This change reduces the number of threads decompressing batches of data into direct memory.
 However, this will only be a mitigating tweak, as the proper solution may require resizing your Logstash deployment,
 either by increasing number of Logstash nodes or increasing the JVM's Direct Memory.
 
@@ -375,3 +375,4 @@ The minimum TLS version allowed for the encrypted connections. The value must be
 include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:
+


### PR DESCRIPTION
Update input-elastic_agent with latest content (v6.2.2) from input-beats

Input-elastic_agent is an alias of input-beats. Updating docs for elastic_agent is a manual process, consisting of copying content from the generated input-beats output to the input-elastic_agent output in logstash-docs.

#### IMPORTANT
Copy only from the :version: section (Line 11) to the bottom of the file. The custom variables for input-elastic_agent are different from input-beats, and must be preserved.