### PR TITLE
TEST ONLY - DO NOT MERGE: Validate ECS attr for LSR

### DIFF
--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -560,9 +560,7 @@ If you don't set a value for this option:
 * Supported values are:
 ** `disabled`: does not provide ECS-compatible templates
 ** `v1`: provides defaults that are compatible with v1 of the Elastic Common Schema
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`.
+* {ecs-default}
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema
 (ECS)], including the installation of ECS-compatible index templates. The value

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -560,7 +560,7 @@ If you don't set a value for this option:
 * Supported values are:
 ** `disabled`: does not provide ECS-compatible templates
 ** `v1`: provides defaults that are compatible with v1 of the Elastic Common Schema
-* {ecs-default}
+* {ecs-default} For more information about ECS compatibility settings and defaults in Logstash and plugins, see {logstash-ref}/ls-ecs[ECS in Logstash].
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema
 (ECS)], including the installation of ECS-compatible index templates. The value

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -560,7 +560,7 @@ If you don't set a value for this option:
 * Supported values are:
 ** `disabled`: does not provide ECS-compatible templates
 ** `v1`: provides defaults that are compatible with v1 of the Elastic Common Schema
-* {ecs-default} For more information about ECS compatibility settings and defaults in Logstash and plugins, see {logstash-ref}/ls-ecs[ECS in Logstash].
+* {ecs-default} 
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema
 (ECS)], including the installation of ECS-compatible index templates. The value


### PR DESCRIPTION
### DO NOT MERGE

Test set to accompany ~https://github.com/elastic/logstash/pull/13427~ https://github.com/elastic/logstash/pull/13462
This PR adds the {ecs-default} attribute to output-elasticsearch.asciidoc to validate that the attribute works as expected.

### TEST NOTES 
* Broken cross-ref. This PR will fail docs CI because the {logstash-ref} attribute used in the default attribute is looking for the `master` branch, which has been renamed to `main`.  ToDo: Find out why and fix it. 
(I'm putting up the PR anyway to have a place to put notes and findings.) 
* The attribute text also needs to be updated to display link text instead of url. 
* Here's how the attribute is rendering locally: 

  <img width="821" alt="Screen Shot 2021-11-19 at 6 17 47 PM" src="https://user-images.githubusercontent.com/35154725/142703027-2e29b005-d42f-4cee-ac5b-de5f9e0c6692.png">
  
  I formatted it as a bullet to match the default format for other config options. I might reconsider that. 
  
