### PR TITLE
ManualProcess: Update input-elastic_agent to v6.2.4 for main

### DIFF
--- a/docs/plugins/inputs/elastic_agent.asciidoc
+++ b/docs/plugins/inputs/elastic_agent.asciidoc
@@ -8,9 +8,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.2
-:release_date: 2021-11-11
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.2/CHANGELOG.md
+:version: v6.2.4
+:release_date: 2021-11-18
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.4/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Update input-elastic_agent with latest content (v6.2.2) from input-beats

Input-elastic_agent is an alias of input-beats. Updating docs for elastic_agent is a manual process, consisting of copying content from the generated input-beats output to the input-elastic_agent output in logstash-docs.

IMPORTANT

Copy only from the :version: section (Line 11) to the bottom of the file. The custom variables for input-elastic_agent are different from input-beats, and must be preserved.

NOTE: The only docs change this time was the version bump/date. Rather than copying over the whole file, I just updated that info. 