### PR TITLE
ManualProcess: Update elastic_agent to v6.2.5 for 7.16

### DIFF
--- a/docs/plugins/inputs/elastic_agent.asciidoc
+++ b/docs/plugins/inputs/elastic_agent.asciidoc
@@ -8,9 +8,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.4
-:release_date: 2021-12-18
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.4/CHANGELOG.md
+:version: v6.2.5
+:release_date: 2022-01-04
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.5/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!


### PR DESCRIPTION
Update input-elastic_agent with latest content (v6.2.5)
Copies generated input-beats content from #1262 to aliased input-elastic_agent