### PR TITLE
Change master to main in codec edit_urls

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -75,13 +75,13 @@ include::codecs/graphite.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/main/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_dots.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/codecs/java_dots.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_dots.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_line.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/codecs/java_line.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_line.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_plain.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/codecs/java_plain.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_plain.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/main/docs/index.asciidoc

--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -36,82 +36,82 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-rubydebug,rubydebug>> | Applies the Ruby Awesome Print library to Logstash events | https://github.com/logstash-plugins/logstash-codec-rubydebug[logstash-codec-rubydebug]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/main/docs/index.asciidoc
 include::codecs/avro.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/main/docs/index.asciidoc
 include::codecs/cef.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/main/docs/index.asciidoc
 include::codecs/cloudfront.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/main/docs/index.asciidoc
 include::codecs/cloudtrail.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/main/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-csv/edit/main/docs/index.asciidoc
 include::codecs/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/main/docs/index.asciidoc
 include::codecs/dots.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/main/docs/index.asciidoc
 include::codecs/edn.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/main/docs/index.asciidoc
 include::codecs/edn_lines.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/main/docs/index.asciidoc
 include::codecs/es_bulk.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/main/docs/index.asciidoc
 include::codecs/fluent.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/main/docs/index.asciidoc
 include::codecs/graphite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/main/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_dots.asciidoc
+:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_dots.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_dots.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_line.asciidoc
+:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_line.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_line.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/codecs/java_plain.asciidoc
+:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/codecs/java_plain.asciidoc
 include::../../../logstash/docs/static/core-plugins/codecs/java_plain.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/main/docs/index.asciidoc
 include::codecs/json.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/main/docs/index.asciidoc
 include::codecs/json_lines.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/main/docs/index.asciidoc
 include::codecs/line.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/main/docs/index.asciidoc
 include::codecs/msgpack.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/main/docs/index.asciidoc
 include::codecs/multiline.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/main/docs/index.asciidoc
 include::codecs/netflow.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/main/docs/index.asciidoc
 include::codecs/nmap.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/main/docs/index.asciidoc
 include::codecs/plain.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-protobuf/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-protobuf/edit/main/docs/index.asciidoc
 include::codecs/protobuf.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/main/docs/index.asciidoc
 include::codecs/rubydebug.asciidoc[]
 
 


### PR DESCRIPTION
The `Edit` links on each page in our documentation send the user to our source files in github. We value contributions from our community, and want to make contributing as easy as possible.

Renaming `master` branch to `main` in several repos (including _all_ plugin repos) means that `Edit` links for plugin docs don't resolve correctly.  This PR makes the fix for all codec plugins.

Related: https://github.com/elastic/logstash/issues/13619

**PREVIEW:** https://logstash-docs_1267.docs-preview.app.elstc.co/diff
