### PR TITLE
Change  to  in filter edit_urls

### DIFF
--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -30,7 +30,7 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-grok,grok>> | Parses unstructured event data into fields | https://github.com/logstash-plugins/logstash-filter-grok[logstash-filter-grok]
 | <<plugins-filters-http,http>> | Provides integration with external web services/REST APIs | https://github.com/logstash-plugins/logstash-filter-http[logstash-filter-http]
 | <<plugins-filters-i18n,i18n>> | Removes special characters from a field | https://github.com/logstash-plugins/logstash-filter-i18n[logstash-filter-i18n]
-| <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
+| <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/edit/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
 | <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-filters-json,json>> | Parses JSON events | https://github.com/logstash-plugins/logstash-filter-json[logstash-filter-json]
@@ -124,7 +124,7 @@ include::filters/http.asciidoc[]
 :edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/main/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/filters/java_uuid.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/filters/java_uuid.asciidoc
 include::../../../logstash/docs/static/core-plugins/filters/java_uuid.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/main/docs/filter-jdbc_static.asciidoc

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -30,7 +30,7 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-grok,grok>> | Parses unstructured event data into fields | https://github.com/logstash-plugins/logstash-filter-grok[logstash-filter-grok]
 | <<plugins-filters-http,http>> | Provides integration with external web services/REST APIs | https://github.com/logstash-plugins/logstash-filter-http[logstash-filter-http]
 | <<plugins-filters-i18n,i18n>> | Removes special characters from a field | https://github.com/logstash-plugins/logstash-filter-i18n[logstash-filter-i18n]
-| <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/edit/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
+| <<plugins-filters-java_uuid,java_uuid>> | Generates a UUID and adds it to each processed event | https://github.com/elastic/logstash/blob/{branch}/logstash-core/src/main/java/org/logstash/plugins/filters/Uuid.java[core plugin]
 | <<plugins-filters-jdbc_static>> | Enriches events with data pre-loaded from a remote database  | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-filters-jdbc_streaming,jdbc_streaming>> | Enrich events with your database data | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-filters-json,json>> | Parses JSON events | https://github.com/logstash-plugins/logstash-filter-json[logstash-filter-json]

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -58,148 +58,148 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-xml,xml>> | Parses XML into fields | https://github.com/logstash-plugins/logstash-filter-xml[logstash-filter-xml]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-age/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-age/edit/main/docs/index.asciidoc
 include::filters/age.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/main/docs/index.asciidoc
 include::filters/aggregate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/main/docs/index.asciidoc
 include::filters/alter.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-bytes/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-bytes/edit/main/docs/index.asciidoc
 include::filters/bytes.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/main/docs/index.asciidoc
 include::filters/cidr.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/main/docs/index.asciidoc
 include::filters/cipher.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/main/docs/index.asciidoc
 include::filters/clone.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/main/docs/index.asciidoc
 include::filters/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/main/docs/index.asciidoc
 include::filters/date.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/main/docs/index.asciidoc
 include::filters/de_dot.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/main/docs/index.asciidoc
 include::filters/dissect.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/main/docs/index.asciidoc
 include::filters/dns.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/main/docs/index.asciidoc
 include::filters/drop.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/main/docs/index.asciidoc
 include::filters/elapsed.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/main/docs/index.asciidoc
 include::filters/elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/main/docs/index.asciidoc
 include::filters/environment.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/main/docs/index.asciidoc
 include::filters/extractnumbers.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/main/docs/index.asciidoc
 include::filters/fingerprint.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/main/docs/index.asciidoc
 include::filters/geoip.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/main/docs/index.asciidoc
 include::filters/grok.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-http/edit/main/docs/index.asciidoc
 include::filters/http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/main/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/filters/java_uuid.asciidoc
+:edit_url: https://github.com/elastic/logstash/blob/main/docs/static/core-plugins/filters/java_uuid.asciidoc
 include::../../../logstash/docs/static/core-plugins/filters/java_uuid.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/filter-jdbc_static.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/main/docs/filter-jdbc_static.asciidoc
 include::filters/jdbc_static.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/filter-jdbc_streaming.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/main/docs/filter-jdbc_streaming.asciidoc
 include::filters/jdbc_streaming.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/main/docs/index.asciidoc
 include::filters/json.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/main/docs/index.asciidoc
 include::filters/json_encode.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/main/docs/index.asciidoc
 include::filters/kv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-memcached/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-memcached/edit/main/docs/index.asciidoc
 include::filters/memcached.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/main/docs/index.asciidoc
 include::filters/metricize.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/main/docs/index.asciidoc
 include::filters/metrics.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/main/docs/index.asciidoc
 include::filters/mutate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/main/docs/index.asciidoc
 include::filters/prune.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/main/docs/index.asciidoc
 include::filters/range.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/main/docs/index.asciidoc
 include::filters/ruby.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/main/docs/index.asciidoc
 include::filters/sleep.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/main/docs/index.asciidoc
 include::filters/split.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/main/docs/index.asciidoc
 include::filters/syslog_pri.asciidoc[]
 
 :edit_url: 
 include::filters/threats_classifier.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/main/docs/index.asciidoc
 include::filters/throttle.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/main/docs/index.asciidoc
 include::filters/tld.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/main/docs/index.asciidoc
 include::filters/translate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-truncate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-truncate/edit/main/docs/index.asciidoc
 include::filters/truncate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/main/docs/index.asciidoc
 include::filters/urldecode.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/main/docs/index.asciidoc
 include::filters/useragent.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/main/docs/index.asciidoc
 include::filters/uuid.asciidoc[]
 
 :edit_url: 
 include::filters/wurfl_device_detection.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/main/docs/index.asciidoc
 include::filters/xml.asciidoc[]
 
 


### PR DESCRIPTION
The `Edit` links on each page in our documentation send the user to our source files in github. We value contributions from our community, and want to make contributing as easy as possible.

Renaming `master` branch to `main` in several repos (including _all_ plugin repos) means that `Edit` links for plugin docs don't resolve correctly.  This PR makes the fix for all filter plugins. 

Related: https://github.com/elastic/logstash/issues/13619


**PREVIEW:** https://logstash-docs_1268.docs-preview.app.elstc.co/diff