### PR TITLE
Change master to main in integration edit_urls

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -12,14 +12,16 @@ filters and codecs--into one package.
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/main/docs/index.asciidoc
 include::integrations/elastic_enterprise_search.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/main/docs/index.asciidoc
 include::integrations/jdbc.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/main/docs/index.asciidoc
 include::integrations/kafka.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/main/docs/index.asciidoc
 include::integrations/rabbitmq.asciidoc[]
+
+:edit_url: 


### PR DESCRIPTION
The `Edit` links on each page in our documentation send the user to our source files in github. We value contributions from our community, and want to make contributing as easy as possible.

Renaming `master` branch to `main` in several repos (including _all_ plugin repos) means that `Edit` links for plugin docs don't resolve correctly.  This PR makes the fix for all integration plugins. 

Related: https://github.com/elastic/logstash/issues/13619


**PREVIEW:** https://logstash-docs_1271.docs-preview.app.elstc.co/diff