### PR TITLE
Change master to main in output edit_urls 8.0

### DIFF
--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -68,175 +68,175 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-zabbix,zabbix>> | Sends events to a Zabbix server | https://github.com/logstash-plugins/logstash-output-zabbix[logstash-output-zabbix]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/main/docs/index.asciidoc
 include::outputs/boundary.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/main/docs/index.asciidoc
 include::outputs/circonus.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/main/docs/index.asciidoc
 include::outputs/cloudwatch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/main/docs/index.asciidoc
 include::outputs/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/main/docs/index.asciidoc
 include::outputs/datadog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/main/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
 
 :edit_url: 
 include::outputs/dynatrace.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/main/docs/output-elastic_app_search.asciidoc
 include::outputs/elastic_app_search.asciidoc[]
 
-:edit_url: 
+:edit_url: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/edit/main/docs/output-elastic_workplace_search.asciidoc
 include::outputs/elastic_workplace_search.asciidoc[]
 
-:edit_url: 
+:edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/main/docs/index.asciidoc
 include::outputs/elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/main/docs/index.asciidoc
 include::outputs/email.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/main/docs/index.asciidoc
 include::outputs/exec.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/main/docs/index.asciidoc
 include::outputs/file.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/main/docs/index.asciidoc
 include::outputs/ganglia.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/main/docs/index.asciidoc
 include::outputs/gelf.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/main/docs/index.asciidoc
 include::outputs/google_bigquery.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/edit/main/docs/index.asciidoc
 include::outputs/google_cloud_storage.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/edit/main/docs/index.asciidoc
 include::outputs/google_pubsub.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/main/docs/index.asciidoc
 include::outputs/graphite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/main/docs/index.asciidoc
 include::outputs/graphtastic.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/main/docs/index.asciidoc
 include::outputs/http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/main/docs/index.asciidoc
 include::outputs/influxdb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/main/docs/index.asciidoc
 include::outputs/irc.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/outputs/java_stdout.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/outputs/java_stdout.asciidoc
 include::../../../logstash/docs/static/core-plugins/outputs/java_stdout.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/main/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/master/docs/output-kafka.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/main/docs/output-kafka.asciidoc
 include::outputs/kafka.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/main/docs/index.asciidoc
 include::outputs/librato.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/main/docs/index.asciidoc
 include::outputs/loggly.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/main/docs/index.asciidoc
 include::outputs/lumberjack.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/main/docs/index.asciidoc
 include::outputs/metriccatcher.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/main/docs/index.asciidoc
 include::outputs/mongodb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/main/docs/index.asciidoc
 include::outputs/nagios.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/main/docs/index.asciidoc
 include::outputs/nagios_nsca.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/main/docs/index.asciidoc
 include::outputs/opentsdb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/main/docs/index.asciidoc
 include::outputs/pagerduty.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/main/docs/index.asciidoc
 include::outputs/pipe.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/master/docs/output-rabbitmq.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/main/docs/output-rabbitmq.asciidoc
 include::outputs/rabbitmq.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/main/docs/index.asciidoc
 include::outputs/redis.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/main/docs/index.asciidoc
 include::outputs/redmine.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/main/docs/index.asciidoc
 include::outputs/riak.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/main/docs/index.asciidoc
 include::outputs/riemann.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/main/docs/index.asciidoc
 include::outputs/s3.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/blob/master/docs/static/core-plugins/outputs/java_sink.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/main/docs/static/core-plugins/outputs/java_sink.asciidoc
 include::../../../logstash/docs/static/core-plugins/outputs/java_sink.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/main/docs/index.asciidoc
 include::outputs/sns.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/main/docs/index.asciidoc
 include::outputs/solr_http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/main/docs/index.asciidoc
 include::outputs/sqs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/main/docs/index.asciidoc
 include::outputs/statsd.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/main/docs/index.asciidoc
 include::outputs/stdout.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/main/docs/index.asciidoc
 include::outputs/stomp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/main/docs/index.asciidoc
 include::outputs/syslog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/main/docs/index.asciidoc
 include::outputs/tcp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-timber/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-timber/edit/main/docs/index.asciidoc
 include::outputs/timber.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/main/docs/index.asciidoc
 include::outputs/udp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/main/docs/index.asciidoc
 include::outputs/webhdfs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/main/docs/index.asciidoc
 include::outputs/websocket.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/main/docs/index.asciidoc
 include::outputs/xmpp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/main/docs/index.asciidoc
 include::outputs/zabbix.asciidoc[]
 
 


### PR DESCRIPTION
Backports #1270 to 8.0:
- Replace view links with edit links for java core plugins
- Replace edit_urls for elasticsearch and workplace search
- Set edit_url for elastic_app_search to point to integration repo