### PR TITLE
Change master to main for plugin edit_urls 6.8

### DIFF
--- a/docs/plugins/codecs.asciidoc
+++ b/docs/plugins/codecs.asciidoc
@@ -33,73 +33,73 @@ The following codec plugins are available below. For a list of Elastic supported
 | <<plugins-codecs-rubydebug,rubydebug>> | Applies the Ruby Awesome Print library to Logstash events | https://github.com/logstash-plugins/logstash-codec-rubydebug[logstash-codec-rubydebug]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-avro/edit/main/docs/index.asciidoc
 include::codecs/avro.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cef/edit/main/docs/index.asciidoc
 include::codecs/cef.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/edit/main/docs/index.asciidoc
 include::codecs/cloudfront.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/edit/main/docs/index.asciidoc
 include::codecs/cloudtrail.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-collectd/edit/main/docs/index.asciidoc
 include::codecs/collectd.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-csv/edit/main/docs/index.asciidoc
 include::codecs/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-dots/edit/main/docs/index.asciidoc
 include::codecs/dots.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn/edit/main/docs/index.asciidoc
 include::codecs/edn.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-edn_lines/edit/main/docs/index.asciidoc
 include::codecs/edn_lines.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-es_bulk/edit/main/docs/index.asciidoc
 include::codecs/es_bulk.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-fluent/edit/main/docs/index.asciidoc
 include::codecs/fluent.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-graphite/edit/main/docs/index.asciidoc
 include::codecs/graphite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-gzip_lines/edit/main/docs/index.asciidoc
 include::codecs/gzip_lines.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json/edit/main/docs/index.asciidoc
 include::codecs/json.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-json_lines/edit/main/docs/index.asciidoc
 include::codecs/json_lines.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-line/edit/main/docs/index.asciidoc
 include::codecs/line.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-msgpack/edit/main/docs/index.asciidoc
 include::codecs/msgpack.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-multiline/edit/main/docs/index.asciidoc
 include::codecs/multiline.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-netflow/edit/main/docs/index.asciidoc
 include::codecs/netflow.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-nmap/edit/main/docs/index.asciidoc
 include::codecs/nmap.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-plain/edit/main/docs/index.asciidoc
 include::codecs/plain.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-protobuf/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-protobuf/edit/main/docs/index.asciidoc
 include::codecs/protobuf.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-codec-rubydebug/edit/main/docs/index.asciidoc
 include::codecs/rubydebug.asciidoc[]
 
 

--- a/docs/plugins/filters.asciidoc
+++ b/docs/plugins/filters.asciidoc
@@ -54,136 +54,136 @@ The following filter plugins are available below. For a list of Elastic supporte
 | <<plugins-filters-xml,xml>> | Parses XML into fields | https://github.com/logstash-plugins/logstash-filter-xml[logstash-filter-xml]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-aggregate/edit/main/docs/index.asciidoc
 include::filters/aggregate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-alter/edit/main/docs/index.asciidoc
 include::filters/alter.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cidr/edit/main/docs/index.asciidoc
 include::filters/cidr.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-cipher/edit/main/docs/index.asciidoc
 include::filters/cipher.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-clone/edit/main/docs/index.asciidoc
 include::filters/clone.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-csv/edit/main/docs/index.asciidoc
 include::filters/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-date/edit/main/docs/index.asciidoc
 include::filters/date.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-de_dot/edit/main/docs/index.asciidoc
 include::filters/de_dot.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dissect/edit/main/docs/index.asciidoc
 include::filters/dissect.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-dns/edit/main/docs/index.asciidoc
 include::filters/dns.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-drop/edit/main/docs/index.asciidoc
 include::filters/drop.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elapsed/edit/main/docs/index.asciidoc
 include::filters/elapsed.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-elasticsearch/edit/main/docs/index.asciidoc
 include::filters/elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-environment/edit/main/docs/index.asciidoc
 include::filters/environment.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-extractnumbers/edit/main/docs/index.asciidoc
 include::filters/extractnumbers.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-fingerprint/edit/main/docs/index.asciidoc
 include::filters/fingerprint.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-geoip/edit/main/docs/index.asciidoc
 include::filters/geoip.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-grok/edit/main/docs/index.asciidoc
 include::filters/grok.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-http/edit/main/docs/index.asciidoc
 include::filters/http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-i18n/edit/main/docs/index.asciidoc
 include::filters/i18n.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_static/edit/main/docs/index.asciidoc
 include::filters/jdbc_static.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/edit/main/docs/index.asciidoc
 include::filters/jdbc_streaming.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json/edit/main/docs/index.asciidoc
 include::filters/json.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-json_encode/edit/main/docs/index.asciidoc
 include::filters/json_encode.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-kv/edit/main/docs/index.asciidoc
 include::filters/kv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-memcached/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-memcached/edit/main/docs/index.asciidoc
 include::filters/memcached.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metricize/edit/main/docs/index.asciidoc
 include::filters/metricize.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-metrics/edit/main/docs/index.asciidoc
 include::filters/metrics.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-mutate/edit/main/docs/index.asciidoc
 include::filters/mutate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-prune/edit/main/docs/index.asciidoc
 include::filters/prune.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-range/edit/main/docs/index.asciidoc
 include::filters/range.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-ruby/edit/main/docs/index.asciidoc
 include::filters/ruby.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-sleep/edit/main/docs/index.asciidoc
 include::filters/sleep.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-split/edit/main/docs/index.asciidoc
 include::filters/split.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-syslog_pri/edit/main/docs/index.asciidoc
 include::filters/syslog_pri.asciidoc[]
 
 :edit_url: 
 include::filters/threats_classifier.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-throttle/edit/main/docs/index.asciidoc
 include::filters/throttle.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-tld/edit/main/docs/index.asciidoc
 include::filters/tld.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-translate/edit/main/docs/index.asciidoc
 include::filters/translate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-truncate/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-truncate/edit/main/docs/index.asciidoc
 include::filters/truncate.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-urldecode/edit/main/docs/index.asciidoc
 include::filters/urldecode.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-useragent/edit/main/docs/index.asciidoc
 include::filters/useragent.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-uuid/edit/main/docs/index.asciidoc
 include::filters/uuid.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-filter-xml/edit/main/docs/index.asciidoc
 include::filters/xml.asciidoc[]
 
 

--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -60,157 +60,157 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-xmpp,xmpp>> | Receives events over the XMPP/Jabber protocol | https://github.com/logstash-plugins/logstash-input-xmpp[logstash-input-xmpp]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-azure_event_hubs/edit/main/docs/index.asciidoc
 include::inputs/azure_event_hubs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-beats/edit/main/docs/index.asciidoc
 include::inputs/beats.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-cloudwatch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-cloudwatch/edit/main/docs/index.asciidoc
 include::inputs/cloudwatch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-couchdb_changes/edit/main/docs/index.asciidoc
 include::inputs/couchdb_changes.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-dead_letter_queue/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-dead_letter_queue/edit/main/docs/index.asciidoc
 include::inputs/dead_letter_queue.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-elasticsearch/edit/main/docs/index.asciidoc
 include::inputs/elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-exec/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-exec/edit/main/docs/index.asciidoc
 include::inputs/exec.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-file/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-file/edit/main/docs/index.asciidoc
 include::inputs/file.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-ganglia/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-ganglia/edit/main/docs/index.asciidoc
 include::inputs/ganglia.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-gelf/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-gelf/edit/main/docs/index.asciidoc
 include::inputs/gelf.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-generator/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-generator/edit/main/docs/index.asciidoc
 include::inputs/generator.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-github/edit/main/docs/index.asciidoc
 include::inputs/github.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-google_cloud_storage/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-google_cloud_storage/edit/main/docs/index.asciidoc
 include::inputs/google_cloud_storage.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-google_pubsub/edit/main/docs/index.asciidoc
 include::inputs/google_pubsub.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-graphite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-graphite/edit/main/docs/index.asciidoc
 include::inputs/graphite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-heartbeat/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-heartbeat/edit/main/docs/index.asciidoc
 include::inputs/heartbeat.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-http/edit/main/docs/index.asciidoc
 include::inputs/http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-http_poller/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-http_poller/edit/main/docs/index.asciidoc
 include::inputs/http_poller.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-imap/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-imap/edit/main/docs/index.asciidoc
 include::inputs/imap.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-irc/edit/main/docs/index.asciidoc
 include::inputs/irc.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-jdbc/edit/main/docs/index.asciidoc
 include::inputs/jdbc.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-jms/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-jms/edit/main/docs/index.asciidoc
 include::inputs/jms.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-jmx/edit/main/docs/index.asciidoc
 include::inputs/jmx.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-kafka/edit/main/docs/index.asciidoc
 include::inputs/kafka.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/main/docs/index.asciidoc
 include::inputs/kinesis.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/main/docs/index.asciidoc
 include::inputs/log4j.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-lumberjack/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-lumberjack/edit/main/docs/index.asciidoc
 include::inputs/lumberjack.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-meetup/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-meetup/edit/main/docs/index.asciidoc
 include::inputs/meetup.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-pipe/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-pipe/edit/main/docs/index.asciidoc
 include::inputs/pipe.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-puppet_facter/edit/main/docs/index.asciidoc
 include::inputs/puppet_facter.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-rabbitmq/edit/main/docs/index.asciidoc
 include::inputs/rabbitmq.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-redis/edit/main/docs/index.asciidoc
 include::inputs/redis.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-relp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-relp/edit/main/docs/index.asciidoc
 include::inputs/relp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-rss/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-rss/edit/main/docs/index.asciidoc
 include::inputs/rss.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-s3/edit/main/docs/index.asciidoc
 include::inputs/s3.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-salesforce/edit/main/docs/index.asciidoc
 include::inputs/salesforce.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-snmp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-snmp/edit/main/docs/index.asciidoc
 include::inputs/snmp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-snmptrap/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-snmptrap/edit/main/docs/index.asciidoc
 include::inputs/snmptrap.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-sqlite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-sqlite/edit/main/docs/index.asciidoc
 include::inputs/sqlite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-sqs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-sqs/edit/main/docs/index.asciidoc
 include::inputs/sqs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-stdin/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-stdin/edit/main/docs/index.asciidoc
 include::inputs/stdin.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-stomp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-stomp/edit/main/docs/index.asciidoc
 include::inputs/stomp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-syslog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-syslog/edit/main/docs/index.asciidoc
 include::inputs/syslog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-tcp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-tcp/edit/main/docs/index.asciidoc
 include::inputs/tcp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-twitter/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-twitter/edit/main/docs/index.asciidoc
 include::inputs/twitter.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-udp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-udp/edit/main/docs/index.asciidoc
 include::inputs/udp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-unix/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-unix/edit/main/docs/index.asciidoc
 include::inputs/unix.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-varnishlog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-varnishlog/edit/main/docs/index.asciidoc
 include::inputs/varnishlog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-websocket/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-websocket/edit/main/docs/index.asciidoc
 include::inputs/websocket.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-wmi/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-wmi/edit/main/docs/index.asciidoc
 include::inputs/wmi.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-input-xmpp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-input-xmpp/edit/main/docs/index.asciidoc
 include::inputs/xmpp.asciidoc[]
 
 

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -61,160 +61,160 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-zabbix,zabbix>> | Sends events to a Zabbix server | https://github.com/logstash-plugins/logstash-output-zabbix[logstash-output-zabbix]
 |=======================================================================
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-boundary/edit/main/docs/index.asciidoc
 include::outputs/boundary.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-circonus/edit/main/docs/index.asciidoc
 include::outputs/circonus.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-cloudwatch/edit/main/docs/index.asciidoc
 include::outputs/cloudwatch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-csv/edit/main/docs/index.asciidoc
 include::outputs/csv.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog/edit/main/docs/index.asciidoc
 include::outputs/datadog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-datadog_metrics/edit/main/docs/index.asciidoc
 include::outputs/datadog_metrics.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-elastic_app_search/edit/main/docs/index.asciidoc
 include::outputs/elastic_app_search.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/edit/main/docs/index.asciidoc
 include::outputs/elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-email/edit/main/docs/index.asciidoc
 include::outputs/email.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-exec/edit/main/docs/index.asciidoc
 include::outputs/exec.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-file/edit/main/docs/index.asciidoc
 include::outputs/file.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-ganglia/edit/main/docs/index.asciidoc
 include::outputs/ganglia.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-gelf/edit/main/docs/index.asciidoc
 include::outputs/gelf.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_bigquery/edit/main/docs/index.asciidoc
 include::outputs/google_bigquery.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-google_pubsub/edit/main/docs/index.asciidoc
 include::outputs/google_pubsub.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphite/edit/main/docs/index.asciidoc
 include::outputs/graphite.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-graphtastic/edit/main/docs/index.asciidoc
 include::outputs/graphtastic.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-http/edit/main/docs/index.asciidoc
 include::outputs/http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-influxdb/edit/main/docs/index.asciidoc
 include::outputs/influxdb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-irc/edit/main/docs/index.asciidoc
 include::outputs/irc.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-juggernaut/edit/main/docs/index.asciidoc
 include::outputs/juggernaut.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-kafka/edit/main/docs/index.asciidoc
 include::outputs/kafka.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/main/docs/index.asciidoc
 include::outputs/librato.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/main/docs/index.asciidoc
 include::outputs/loggly.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-lumberjack/edit/main/docs/index.asciidoc
 include::outputs/lumberjack.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-metriccatcher/edit/main/docs/index.asciidoc
 include::outputs/metriccatcher.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-mongodb/edit/main/docs/index.asciidoc
 include::outputs/mongodb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios/edit/main/docs/index.asciidoc
 include::outputs/nagios.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-nagios_nsca/edit/main/docs/index.asciidoc
 include::outputs/nagios_nsca.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-opentsdb/edit/main/docs/index.asciidoc
 include::outputs/opentsdb.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-pagerduty/edit/main/docs/index.asciidoc
 include::outputs/pagerduty.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-pipe/edit/main/docs/index.asciidoc
 include::outputs/pipe.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-rabbitmq/edit/main/docs/index.asciidoc
 include::outputs/rabbitmq.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-redis/edit/main/docs/index.asciidoc
 include::outputs/redis.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-redmine/edit/main/docs/index.asciidoc
 include::outputs/redmine.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-riak/edit/main/docs/index.asciidoc
 include::outputs/riak.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-riemann/edit/main/docs/index.asciidoc
 include::outputs/riemann.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-s3/edit/main/docs/index.asciidoc
 include::outputs/s3.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-sns/edit/main/docs/index.asciidoc
 include::outputs/sns.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-solr_http/edit/main/docs/index.asciidoc
 include::outputs/solr_http.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-sqs/edit/main/docs/index.asciidoc
 include::outputs/sqs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-statsd/edit/main/docs/index.asciidoc
 include::outputs/statsd.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-stdout/edit/main/docs/index.asciidoc
 include::outputs/stdout.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-stomp/edit/main/docs/index.asciidoc
 include::outputs/stomp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-syslog/edit/main/docs/index.asciidoc
 include::outputs/syslog.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-tcp/edit/main/docs/index.asciidoc
 include::outputs/tcp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-timber/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-timber/edit/main/docs/index.asciidoc
 include::outputs/timber.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-udp/edit/main/docs/index.asciidoc
 include::outputs/udp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-webhdfs/edit/main/docs/index.asciidoc
 include::outputs/webhdfs.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-websocket/edit/main/docs/index.asciidoc
 include::outputs/websocket.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-xmpp/edit/main/docs/index.asciidoc
 include::outputs/xmpp.asciidoc[]
 
-:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/master/docs/index.asciidoc
+:edit_url: https://github.com/logstash-plugins/logstash-output-zabbix/edit/main/docs/index.asciidoc
 include::outputs/zabbix.asciidoc[]
 
 


### PR DESCRIPTION
The Edit links on each page in our documentation send the user to our source files in github. We value contributions from our community, and want to make contributing as easy as possible.

Renaming master branch to main in several repos (including all plugin repos) means that Edit links for plugin docs don't resolve correctly. This PR makes the fix for all plugins in the 6.8 branch.

Related: elastic/logstash#13619