### PR TITLE
VPR: Add branch attr to prevent broken links at 8.0 cutover

### DIFF
--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.3.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.3.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.10
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -970,4 +971,5 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-in
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch: current
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.7.3.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.7.3.asciidoc
@@ -30,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -106,7 +106,7 @@ Example:
 
 You can use the `mutate` filter and conditionals to add a `[@metadata]` field
 (see
-https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata)
+https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata)
 to set the destination index for each event. The `[@metadata]` fields will not
 be sent to Elasticsearch.
 
@@ -167,7 +167,7 @@ The Index Lifecycle Management feature requires plugin version `9.3.1` or higher
 [NOTE]
 This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
 
-Logstash can use {ref}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
+Logstash can use https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
 
 The use of Index Lifecycle Management is controlled by the `ilm_enabled`
 setting. By default, this setting detects whether the Elasticsearch instance
@@ -183,7 +183,7 @@ a default policy will also be created. The default policy is configured to rollo
 The default rollover alias is called `logstash`, with a default pattern for the rollover index of `{now/d}-00001`,
 which will name indices on the date that the index is rolled over, followed by an incrementing number. Note that the pattern must end with a dash and a number that will be incremented.
 
-See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
+See the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
 
 The rollover alias, ilm pattern and policy can be modified.
 
@@ -228,7 +228,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -336,7 +336,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -346,7 +346,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -373,7 +373,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -383,7 +383,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -481,7 +481,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -492,7 +492,7 @@ Examples:
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
 Exclude
-http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated
+http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated
 master nodes] from the `hosts` list to prevent Logstash from sending bulk
 requests to the master nodes. This parameter should reference only data or
 client nodes in Elasticsearch.
@@ -532,14 +532,14 @@ NOTE: This feature requires a Basic License or above to be installed on an Elast
 Pattern used for generating indices managed by Index Lifecycle Management. The value specified in the pattern will be appended to
 the write alias, and incremented automatically when a new index is created by ILM.
 
-Date Math can be used when specifying an ilm pattern, see {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
+Date Math can be used when specifying an ilm pattern, see https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
 
 NOTE: Updating the pattern will require the index template to be rewritten
 
 NOTE: The pattern must finish with a dash and a number that will be automatically incremented when indices rollover.
 
 NOTE: The pattern is a 6-digit string padded by zeros, regardless of prior index name. Example: 000001.
-See {ref}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
+See https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
 
 [id="{version}-plugins-{type}s-{plugin}-ilm_policy"]
 ===== `ilm_policy`
@@ -964,7 +964,7 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.8.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.8.0.asciidoc
@@ -30,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -106,7 +106,7 @@ Example:
 
 You can use the `mutate` filter and conditionals to add a `[@metadata]` field
 (see
-https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata)
+https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata)
 to set the destination index for each event. The `[@metadata]` fields will not
 be sent to Elasticsearch.
 
@@ -167,7 +167,7 @@ The Index Lifecycle Management feature requires plugin version `9.3.1` or higher
 [NOTE]
 This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
 
-Logstash can use {ref}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
+Logstash can use https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
 
 The use of Index Lifecycle Management is controlled by the `ilm_enabled`
 setting. By default, this setting detects whether the Elasticsearch instance
@@ -183,7 +183,7 @@ a default policy will also be created. The default policy is configured to rollo
 The default rollover alias is called `logstash`, with a default pattern for the rollover index of `{now/d}-00001`,
 which will name indices on the date that the index is rolled over, followed by an incrementing number. Note that the pattern must end with a dash and a number that will be incremented.
 
-See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
+See the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
 
 The rollover alias, ilm pattern and policy can be modified.
 
@@ -228,7 +228,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -336,7 +336,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -346,7 +346,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -373,7 +373,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -383,7 +383,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -481,7 +481,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -492,7 +492,7 @@ Examples:
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
 Exclude
-http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated
+http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated
 master nodes] from the `hosts` list to prevent Logstash from sending bulk
 requests to the master nodes. This parameter should reference only data or
 client nodes in Elasticsearch.
@@ -532,14 +532,14 @@ NOTE: This feature requires a Basic License or above to be installed on an Elast
 Pattern used for generating indices managed by Index Lifecycle Management. The value specified in the pattern will be appended to
 the write alias, and incremented automatically when a new index is created by ILM.
 
-Date Math can be used when specifying an ilm pattern, see {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
+Date Math can be used when specifying an ilm pattern, see https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
 
 NOTE: Updating the pattern will require the index template to be rewritten
 
 NOTE: The pattern must finish with a dash and a number that will be automatically incremented when indices rollover.
 
 NOTE: The pattern is a 6-digit string padded by zeros, regardless of prior index name. Example: 000001.
-See {ref}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
+See https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
 
 [id="{version}-plugins-{type}s-{plugin}-ilm_policy"]
 ===== `ilm_policy`
@@ -964,7 +964,7 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.8.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.8.0.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.11
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -970,4 +971,5 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-in
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch: current
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.8.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.8.1.asciidoc
@@ -30,8 +30,8 @@ This output only speaks the HTTP protocol as it is the preferred protocol for
 interacting with Elasticsearch. In previous versions it was possible to
 communicate with Elasticsearch through the transport protocol, which is now
 reserved for internal cluster communication between nodes
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[communication between nodes].
-Using the https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html[transport protocol]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-transport.html[communication between nodes].
+Using the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/java-clients.html[transport protocol]
 to communicate with the cluster has been deprecated in Elasticsearch 7.0.0 and
 will be removed in 8.0.0
 
@@ -106,7 +106,7 @@ Example:
 
 You can use the `mutate` filter and conditionals to add a `[@metadata]` field
 (see
-https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata)
+https://www.elastic.co/guide/en/logstash/{branch}/event-dependent-configuration.html#metadata)
 to set the destination index for each event. The `[@metadata]` fields will not
 be sent to Elasticsearch.
 
@@ -167,7 +167,7 @@ The Index Lifecycle Management feature requires plugin version `9.3.1` or higher
 [NOTE]
 This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
 
-Logstash can use {ref}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
+Logstash can use https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle Management] to automate the management of indices over time.
 
 The use of Index Lifecycle Management is controlled by the `ilm_enabled`
 setting. By default, this setting detects whether the Elasticsearch instance
@@ -183,7 +183,7 @@ a default policy will also be created. The default policy is configured to rollo
 The default rollover alias is called `logstash`, with a default pattern for the rollover index of `{now/d}-00001`,
 which will name indices on the date that the index is rolled over, followed by an incrementing number. Note that the pattern must end with a dash and a number that will be incremented.
 
-See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
+See the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API documentation] for more details on naming.
 
 The rollover alias, ilm pattern and policy can be modified.
 
@@ -228,7 +228,7 @@ enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
 You don't have to set any configs in Elasticsearch for it to send back a
 compressed response. For versions before 5.0, or if HTTPS is enabled,
 `http.compression` must be set to `true`
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[in
 Elasticsearch] to take advantage of response compression when using this plugin.
 
 For requests compression, regardless of the Elasticsearch version, enable the
@@ -336,7 +336,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
+For more details on actions, check out the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -346,7 +346,7 @@ For more details on actions, check out the http://www.elastic.co/guide/en/elasti
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -373,7 +373,7 @@ The .cer or .pem file to validate the server's certificate
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -383,7 +383,7 @@ For more details, check out the https://www.elastic.co/guide/en/logstash/current
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more details, check out the https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`
@@ -481,7 +481,7 @@ If you have custom firewall rules you may need to change this
   * Default value is `[//127.0.0.1]`
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
-Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
+Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
 
 Examples:
 
@@ -492,7 +492,7 @@ Examples:
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
 Exclude
-http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated
+http://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated
 master nodes] from the `hosts` list to prevent Logstash from sending bulk
 requests to the master nodes. This parameter should reference only data or
 client nodes in Elasticsearch.
@@ -532,14 +532,14 @@ NOTE: This feature requires a Basic License or above to be installed on an Elast
 Pattern used for generating indices managed by Index Lifecycle Management. The value specified in the pattern will be appended to
 the write alias, and incremented automatically when a new index is created by ILM.
 
-Date Math can be used when specifying an ilm pattern, see {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
+Date Math can be used when specifying an ilm pattern, see https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover API docs] for details
 
 NOTE: Updating the pattern will require the index template to be rewritten
 
 NOTE: The pattern must finish with a dash and a number that will be automatically incremented when indices rollover.
 
 NOTE: The pattern is a 6-digit string padded by zeros, regardless of prior index name. Example: 000001.
-See {ref}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
+See https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path parameters API docs] for details.
 
 [id="{version}-plugins-{type}s-{plugin}-ilm_policy"]
 ===== `ilm_policy`
@@ -964,7 +964,7 @@ See https://www.elastic.co/blog/elasticsearch-versioning-support.
 
 The version_type to use for indexing.
 See https://www.elastic.co/blog/elasticsearch-versioning-support.
-See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+See also https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types
 
 
 

--- a/docs/versioned-plugins/outputs/elasticsearch-v10.8.1.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v10.8.1.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: output
 :no_codec:
+:branch: 7.11
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -970,4 +971,5 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-in
 [id="{version}-plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch: current
 :no_codec!:

--- a/docs/versioned-plugins/outputs/elasticsearch-v11.4.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v11.4.0.asciidoc
@@ -26,7 +26,7 @@ data. The Elasticsearch output plugin can store both time series datasets (such
 as logs, events, and metrics) and non-time series data in Elasticsearch.
 
 You can https://www.elastic.co/elasticsearch/[learn more about Elasticsearch] on
-the website landing page or in the {ref}[Elasticsearch documentation].
+the website landing page or in the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}[Elasticsearch documentation].
 
 .Compatibility Note
 [NOTE]
@@ -206,7 +206,7 @@ The Index Lifecycle Management feature requires plugin version `9.3.1` or higher
 [NOTE]
 This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
 
-Logstash can use {ref}/index-lifecycle-management.html[Index Lifecycle
+Logstash can use https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle
 Management] to automate the management of indices over time.
 
 The use of Index Lifecycle Management is controlled by the `ilm_enabled`
@@ -229,7 +229,7 @@ rollover index of `{now/d}-00001`, which will name indices on the date that the
 index is rolled over, followed by an incrementing number. Note that the pattern
 must end with a dash and a number that will be incremented.
 
-See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
+See the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
 API documentation] for more details on naming.
 
 The rollover alias, ilm pattern and policy can be modified.
@@ -255,7 +255,7 @@ NOTE: If the index property is supplied in the output definition, it will be ove
 
 ==== Batch Sizes
 
-This plugin attempts to send batches of events to the {ref}/docs-bulk.html[{es}
+This plugin attempts to send batches of events to the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[{es}
 Bulk API] as a single request. However, if a batch exceeds 20MB we break it up
 into multiple bulk requests. If a single document exceeds 20MB it is sent as a
 single request.
@@ -390,7 +390,7 @@ The Elasticsearch action to perform. Valid actions are:
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action
 
-For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bulk API documentation].
+For more details on actions, check out the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html[Elasticsearch bulk API documentation].
 
 [id="{version}-plugins-{type}s-{plugin}-api_key"]
 ===== `api_key`
@@ -402,7 +402,7 @@ Authenticate using Elasticsearch API key. Note that this option also requires
 enabling the `ssl` option.
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
-Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
+Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create API key API].
 
 [id="{version}-plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`
@@ -607,7 +607,7 @@ If you have custom firewall rules you may need to change this
 
 Sets the host(s) of the remote instance. If given an array it will load balance
 requests across the hosts specified in the `hosts` parameter. Remember the
-`http` protocol uses the {ref}/modules-http.html#modules-http[http] address (eg.
+`http` protocol uses the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-http.html#modules-http[http] address (eg.
 9200, not 9300).
 
 Examples:
@@ -618,7 +618,7 @@ Examples:
     `["https://127.0.0.1:9200"]`
     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
-Exclude {ref}/modules-node.html[dedicated master nodes] from the `hosts` list to
+Exclude https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html[dedicated master nodes] from the `hosts` list to
 prevent Logstash from sending bulk requests to the master nodes. This parameter
 should reference only data or client nodes in Elasticsearch.
 
@@ -646,7 +646,7 @@ NOTE: This output plugin reads compressed _responses_ from {es} regardless
   * Default value is `auto`
 
 The default setting of `auto` will automatically enable
-{ref}/index-lifecycle-management.html[Index Lifecycle Management], if the
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle Management], if the
 Elasticsearch cluster is running Elasticsearch version `7.0.0` or higher with
 the ILM feature enabled, and disable it otherwise.
 
@@ -666,12 +666,12 @@ Elasticsearch cluster version 6.6.0 or later.
   * Default value is `{now/d}-000001`
 
 Pattern used for generating indices managed by
-{ref}/index-lifecycle-management.html[Index Lifecycle Management]. The value
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-lifecycle-management.html[Index Lifecycle Management]. The value
 specified in the pattern will be appended to the write alias, and incremented
 automatically when a new index is created by ILM.
 
 Date Math can be used when specifying an ilm pattern, see
-{ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
 API docs] for details.
 
 NOTE: Updating the pattern will require the index template to be rewritten.
@@ -681,7 +681,7 @@ incremented when indices rollover.
 
 NOTE: The pattern is a 6-digit string padded by zeros, regardless of prior index name.
 Example: 000001. See
-{ref}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path
 parameters API docs] for details.
 
 [id="{version}-plugins-{type}s-{plugin}-ilm_policy"]
@@ -1127,7 +1127,7 @@ blog] for more information.
 
 The version_type to use for indexing. See the
 https://www.elastic.co/blog/elasticsearch-versioning-support[versioning support
-blog] and {ref}/docs-index_.html#_version_types[Version types] in the
+blog] and https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html#_version_types[Version types] in the
 Elasticsearch documentation.
 
 


### PR DESCRIPTION
Plugin versioning is independent of Logstash/stack versioning. This PR sets (and then resets) an attribute to define a stack version that is appropriate for each particular version of the elasticsearch output plugin. 

We updated the content source at v10.8.2 and removed the offending link. Therefore, the broken link isn't a problem beyond v10.8.1. 

**PREVIEW** https://logstash-docs_1289.docs-preview.app.elstc.co/diff