### PR TITLE
ManualProcess: Update elastic_agent to v6.2.6 [8.0]

### DIFF
--- a/docs/plugins/inputs/elastic_agent.asciidoc
+++ b/docs/plugins/inputs/elastic_agent.asciidoc
@@ -8,9 +8,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v6.2.4
-:release_date: 2021-12-18
-:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.4/CHANGELOG.md
+:version: v6.2.6
+:release_date: 2022-01-28
+:changelog_url: https://github.com/logstash-plugins/logstash-input-beats/blob/v6.2.6/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -314,8 +314,14 @@ Time in milliseconds for an incomplete ssl handshake to timeout
   * There is no default value for this setting.
 
 SSL key to use.
-NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
-for more information.
+This key must be in the PKCS8 format and PEM encoded. 
+You can use the https://www.openssl.org/docs/man1.1.1/man1/openssl-pkcs8.html[openssl pkcs8] command to complete the conversion.
+For example, the command to convert a PEM encoded PKCS1 private key to a PEM encoded, non-encrypted PKCS8 key is:
+
+[source,sh]
+-----
+openssl pkcs8 -inform PEM -in path/to/logstash.key -topk8 -nocrypt -outform PEM -out path/to/logstash.pkcs8.key
+-----
 
 [id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
 ===== `ssl_key_passphrase`


### PR DESCRIPTION
Update input-elastic_agent with latest content (v6.2.6)
Copies generated input-beats content from #1301 to aliased input-elastic_agent