### PR TITLE
Add skip-existing option to LSR doc generator.

### DIFF
--- a/.github/workflows/reference_docs.yml
+++ b/.github/workflows/reference_docs.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ./docs-tools
         run: |
           bundle install --path=vendor/bundle
-          bundle exec ruby plugindocs.rb --output-path ../logstash-docs ../logstash/plugins_version_docs.json
+          bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
       - name: Build docs
         working-directory: ./logstash
         run: ../docs/build_docs --asciidoctor --respect_edit_url_overrides --doc docs/index.asciidoc --resource=../logstash-docs/docs/ --chunk 1


### PR DESCRIPTION
Currently, although there is no plugin version release, there might be a doc content change. For this case, we usually revert back to original version to avoid doc breakings  ([#45](https://github.com/elastic/docs-tools/issues/45)).
Examples: 
- https://github.com/elastic/logstash-docs/pull/1338/
- https://github.com/elastic/logstash-docs/pull/1339

To overcome, we introduced `skip-existing` option for LSR doc tool with [this PR](https://github.com/elastic/docs-tools/pull/72) and now we need add `skip-existing` flag when calling the doc generator.