### PR TITLE
VPR: Remove conditionals from plugin headers

### DIFF
--- a/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc
@@ -1,35 +1,18 @@
-ifeval::["{versioned_docs}"!="true"]
-[subs="attributes"]
-++++
-<titleabbrev>{plugin}</titleabbrev>
-++++
-endif::[]
-ifeval::["{versioned_docs}"=="true"]
 [subs="attributes"]
 ++++
 <titleabbrev>{version}</titleabbrev>
 ++++
-endif::[]
 
 * A component of the <<integration-{integration}-index,{integration} integration plugin>>  
 * Integration version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]
 
-ifeval::["{versioned_docs}"!="true"]
-
-For other plugin versions, see the
-{lsplugindocs}/{type}-{plugin}-index.html[Versioned {plugin} {type} plugin docs].
-
-endif::[]
-
-ifeval::["{versioned_docs}"=="true"]
 
 For other versions, see the <<{type}-{plugin}-index,overview list>>.
 
 To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
 
-endif::[]
 
 ==== Getting Help
 

--- a/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
+++ b/docs/versioned-plugins/include/6.x/plugin_header.asciidoc
@@ -1,44 +1,16 @@
-ifeval::["{versioned_docs}"!="true"]
-[subs="attributes"]
-++++
-<titleabbrev>{plugin}</titleabbrev>
-++++
-endif::[]
-ifeval::["{versioned_docs}"=="true"]
 [subs="attributes"]
 ++++
 <titleabbrev>{version}</titleabbrev>
 ++++
-endif::[]
 
 * Plugin version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]
 
-ifeval::["{versioned_docs}"!="true"]
-
-For other plugin versions, see the
-{lsplugindocs}/{type}-{plugin}-index.html[Versioned {plugin} {type} plugin docs].
-
-endif::[]
-
-ifeval::["{versioned_docs}"=="true"]
-
 For other versions, see the <<{type}-{plugin}-index,overview list>>.
 
 To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
 
-endif::[]
-
-ifeval::["{default_plugin}"=="0"]
-ifeval::["{versioned_docs}"!="true"]
-
-==== Installation
-
-For plugins not bundled by default, it is easy to install by running +bin/logstash-plugin install logstash-{type}-{plugin}+. See {logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
-
-endif::[]
-endif::[]
 
 ==== Getting Help
 


### PR DESCRIPTION
The plugin headers (for both standalone and integration plugins) contain conditional processing to support both Versioned Plugin Reference (VPR) plugins and the Logstash Reference (LSR). No conditional processing is needed because the VPR header files live in the `logstash-docs` repo and the LSR header files live in the `logstash` repo.  Because of the separate locations, we can use purpose-built header files for each guide and remove the conditionals that may be confusing to people. 

This PR: 
* Removes conditional statements and content that applies only to the Logstash Reference plugins. 
* Removes conditional statements surrounding content for the Versioned Plugin Reference so that it is always present. 

Related: https://github.com/elastic/logstash/pull/14352