### PR TITLE
VPR: Activate integration docs with headers and file lists

### DIFF
--- a/docs/versioned-plugins/codecs/cloudfront-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/codecs/cloudfront-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudfront
 :type: codec
 
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudfront codec plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/codecs/cloudtrail-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/codecs/cloudtrail-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudtrail
 :type: codec
 
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudtrail codec plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/cloudwatch-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/cloudwatch-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudwatch
 :type: input
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudwatch input plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/s3-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/s3-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: s3
 :type: input
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === S3 input plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/sqs-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/sqs-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sqs
 :type: input
 :default_codec: json
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sqs input plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/integrations/aws-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/integrations/aws-v7.0.0.asciidoc
@@ -17,13 +17,13 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === AWS Integration Plugin {version}
 
-// include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
 The AWS Integration Plugin provides integrated plugins for working with Amazon Web Services:
 
-////
+
  - {logstash-ref}/plugins-codecs-cloudfront.html[Cloudfront Codec Plugin]
  - {logstash-ref}/plugins-codecs-cloudtrail.html[Cloudtrail Codec Plugin]
  - {logstash-ref}/plugins-inputs-cloudwatch.html[Cloudwatch Input Plugin]
@@ -33,6 +33,6 @@ The AWS Integration Plugin provides integrated plugins for working with Amazon W
  - {logstash-ref}/plugins-outputs-s3.html[S3 Output Plugin]
  - {logstash-ref}/plugins-outputs-sns.html[Sns Output Plugin]
  - {logstash-ref}/plugins-outputs-sqs.html[Sqs Output Plugin]
-////
+
 
 :no_codec!:

--- a/docs/versioned-plugins/outputs/cloudwatch-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/outputs/cloudwatch-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudwatch
 :type: output
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudwatch output plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/outputs/s3-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/outputs/s3-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: s3
 :type: output
 :default_codec: line
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === S3 output plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/outputs/sns-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/outputs/sns-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sns
 :type: output
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sns output plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/outputs/sqs-v7.0.0.asciidoc
+++ b/docs/versioned-plugins/outputs/sqs-v7.0.0.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sqs
 :type: output
 :default_codec: json
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sqs output plugin {version}
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 


### PR DESCRIPTION
Complete the final steps to activate the AWS integration docs:
- Activate integration header files (by removing comment slashes)
- Activate included plugin list (by removing comment slashes) 

**PREVIEW:** https://logstash-docs_1396.docs-preview.app.elstc.co/guide/en/logstash-versioned-plugins/current/index.html