### PR TITLE
Add intg elements for missing aws codecs

### DIFF
--- a/docs/plugins/codecs/cloudfront.asciidoc
+++ b/docs/plugins/codecs/cloudfront.asciidoc
@@ -1,3 +1,4 @@
+:integration: aws
 :plugin: cloudfront
 :type: codec
 :default_plugin: 0
@@ -5,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.3
-:release_date: 2017-11-07
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cloudfront/blob/v3.0.3/CHANGELOG.md
+:version: v7.0.0
+:release_date: 2022-07-25
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -17,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudfront codec plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/plugins/codecs/cloudtrail.asciidoc
+++ b/docs/plugins/codecs/cloudtrail.asciidoc
@@ -1,3 +1,4 @@
+:integration: aws
 :plugin: cloudtrail
 :type: codec
 :default_plugin: 0
@@ -5,9 +6,9 @@
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
-:version: v3.0.5
-:release_date: 2018-06-01
-:changelog_url: https://github.com/logstash-plugins/logstash-codec-cloudtrail/blob/v3.0.5/CHANGELOG.md
+:version: v7.0.0
+:release_date: 2022-07-25
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.0.0/CHANGELOG.md
 :include_path: ../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
@@ -17,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudtrail codec plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 


### PR DESCRIPTION
Cloudtrail and cloudwatch codecs weren't updated by docgen.  This PR brings existing plugin docs inline while we research the root cause.

Manual changes: 
* adds :Integration: attribute
*  updates version, releasedate. and changelog links
* replaces `plugin_header` with `plugin_header-integration`
