### PR TITLE
Add branch to workflow job summary and git commit.

### DIFF
--- a/.github/workflows/reference_docs.yml
+++ b/.github/workflows/reference_docs.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Branch to update plugin docs'
         required: true
-        default: '8.1' 
+        default: '8.1'
         type: string
 
 permissions:
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    name: "Update docs for ${{ github.event.inputs.branch }}"
     runs-on: ubuntu-latest
     steps:
       - uses: ruby/setup-ruby@v1
@@ -74,8 +75,9 @@ jobs:
           git add .
           git status
           if [[ -z $(git status --porcelain) ]]; then echo "No changes. We're done."; exit 0; fi
-          git commit -m "updated docs for ${branch_specifier}" -a
+          git commit -m "updated docs for ${{ github.event.inputs.branch }}" -a
           git push origin $BRANCH
       - name: Create Pull Request
         run: |
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X POST -d "{\"title\": \"updated docs for ${{ github.event.inputs.branch }}\",\"head\": \"${BRANCH}\",\"base\": \"${{ github.event.inputs.branch }}\"}" https://api.github.com/repos/elastic/logstash-docs/pulls
+      - run: echo "### Updated docs for ${{ github.event.inputs.branch }} :rocket:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Description
- [**67**](https://github.com/elastic/docs-tools/issues/67) - when we take a look at workflow runs, it is hard to figure out on which branch/version we generated the docs. Since it is impossible to attach branch to workflow name at run time, this PR improves visibility of the branch by adding to job name and summary.
- [**71**](https://github.com/elastic/docs-tools/issues/71) - sometimes there are cases we take a look at commits to find out the branch. With this change, we add branch to commit message to make this visibility better.

Closes https://github.com/elastic/docs-tools/issues/67
Closes https://github.com/elastic/docs-tools/issues/71


### Test
- Run the job by replicating on my own environment: *[Test job](https://github.com/mashhurs/logstash-docs/actions/runs/2973329287)*
- Result
<img width="1479" alt="Screen Shot 2022-09-01 at 10 02 30 AM" src="https://user-images.githubusercontent.com/99575341/187971397-e7609a86-0478-44af-b4db-95bc50300cfe.png">
