### PR TITLE
Add a workflow to create an empty plugin placeholder in VPR.

### DIFF
--- a/.github/workflows/add_plugin_placeholder_in_vpr.yml
+++ b/.github/workflows/add_plugin_placeholder_in_vpr.yml
@@ -1,7 +1,18 @@
-name: Version Plugin Reference
+name: Adds an empty plugin placeholder in VPR
 
 on:
   workflow_dispatch:
+    inputs:
+      plugin_type:
+        description: 'Type of plugin: input, filter, output or integration'
+        required: true
+        default: 'input'
+        type: string
+      plugin_name:
+        description: 'Name for the plugin being created'
+        required: true
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -38,9 +49,9 @@ jobs:
           git config --global user.name logstashmachine
       - run: bundle install
         working-directory: ./docs-tools
-      - name: Generate plugin versions
+      - name: Create an empty placeholder
         working-directory: ./docs-tools
-        run: bundle exec ruby versioned_plugins.rb --repair --skip-existing --output-path=../
+        run: bundle exec ruby create_plugin_placeholder.rb --output-path=../ --plugin-type=${{ github.event.inputs.plugin_type }} --plugin-name=${{ github.event.inputs.plugin_name }}
         env:
           JRUBY_OPTS: "-J-Xmx4g"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reference_docs.yml
+++ b/.github/workflows/reference_docs.yml
@@ -1,3 +1,5 @@
+name: "Reference Documentation generation for specified version"
+
 run-name: "Reference Documentation generation for ${{ github.event.inputs.branch }}"
 
 on:
@@ -24,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Clone elastic/docs-tools
         uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/html_docs
+.idea


### PR DESCRIPTION
### Description
We need an automation to create an empty index page when we introduce new plugin, especially `integration` type is complex in docs. This PR create a workflow which executes https://github.com/elastic/docs-tools/pull/97 newly introduced placeholder create script.