### PR TITLE
Update the calling script name for generating placeholder.

### DIFF
--- a/.github/workflows/add_plugin_placeholder_in_vpr.yml
+++ b/.github/workflows/add_plugin_placeholder_in_vpr.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: ./docs-tools
       - name: Create an empty placeholder
         working-directory: ./docs-tools
-        run: bundle exec ruby create_plugin_placeholder.rb --output-path=../ --plugin-type=${{ github.event.inputs.plugin_type }} --plugin-name=${{ github.event.inputs.plugin_name }}
+        run: bundle exec ruby generate_plugin_placeholder.rb --output-path=../ --plugin-type=${{ github.event.inputs.plugin_type }} --plugin-name=${{ github.event.inputs.plugin_name }}
         env:
           JRUBY_OPTS: "-J-Xmx4g"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_plugin_placeholder_in_vpr.yml
+++ b/.github/workflows/add_plugin_placeholder_in_vpr.yml
@@ -6,7 +6,7 @@ on:
       plugin_type:
         description: 'Type of plugin: input, filter, output or integration'
         required: true
-        default: 'input'
+        default: ''
         type: string
       plugin_name:
         description: 'Name for the plugin being created'


### PR DESCRIPTION
### Description
- The `create_plugin_placeholder.rb` script name was changed to `generate_plugin_placeholder.rb` but it wasn't updated in workflow. This PR updates the script name.
- It also intentionally changes the plugin type input to empty to encourage users to type plugin type.