### PR TITLE
LSR: Add files and structure for new integration (#1545)

### DIFF
--- a/docs/plugins/inputs.asciidoc
+++ b/docs/plugins/inputs.asciidoc
@@ -36,6 +36,7 @@ The following input plugins are available below. For a list of Elastic supported
 | <<plugins-inputs-jmx,jmx>> | Retrieves metrics from remote Java applications over JMX | https://github.com/logstash-plugins/logstash-input-jmx[logstash-input-jmx]
 | <<plugins-inputs-kafka,kafka>> | Reads events from a Kafka topic | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-inputs-kinesis,kinesis>> | Receives events through an AWS Kinesis stream | https://github.com/logstash-plugins/logstash-input-kinesis[logstash-input-kinesis]
+| <<plugins-inputs-logstash,logstash>> | Reads from {ls} output of another {ls} instance | https://github.com/logstash-plugins/logstash-integration-logstash[logstash-integration-logstash]
 | <<plugins-inputs-log4j,log4j>> | Reads events over a TCP socket from a Log4j `SocketAppender` object | https://github.com/logstash-plugins/logstash-input-log4j[logstash-input-log4j]
 | <<plugins-inputs-lumberjack,lumberjack>> | Receives events using the Lumberjack protocl | https://github.com/logstash-plugins/logstash-input-lumberjack[logstash-input-lumberjack]
 | <<plugins-inputs-meetup,meetup>> | Captures the output of command line tools as an event | https://github.com/logstash-plugins/logstash-input-meetup[logstash-input-meetup]
@@ -151,6 +152,9 @@ include::inputs/kafka.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-kinesis/edit/main/docs/index.asciidoc
 include::inputs/kinesis.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-logstash/edit/main/docs/input-logstash.asciidoc
+include::inputs/logstash.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-input-log4j/edit/main/docs/index.asciidoc
 include::inputs/log4j.asciidoc[]

--- a/docs/plugins/inputs/logstash.asciidoc
+++ b/docs/plugins/inputs/logstash.asciidoc
@@ -1,0 +1,22 @@
+:integration: logstash
+:plugin: logstash
+:type: input
+:default_plugin: 0
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v0.0.3
+:release_date: 2023-11-01
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-logstash/blob/v0.0.3/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Logstash input plugin
+
+include::{include_path}/plugin_header-integration.asciidoc[]
+

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -10,6 +10,7 @@ filters and codecs--into one package.
 | <<plugins-integrations-elastic_enterprise_search,elastic_enterprise_search>> | Plugins for use with https://www.elastic.co/enterprise-search[Elastic Enterprise Search]. | https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search[logstash-integration-elastic_enterprise_search]
 | <<plugins-integrations-jdbc,jdbc>> | Plugins for use with databases that provide JDBC drivers. | https://github.com/logstash-plugins/logstash-integration-jdbc[logstash-integration-jdbc]
 | <<plugins-integrations-kafka,kafka>> | Plugins for use with the Kafka distributed streaming platform. | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
+| <<plugins-integrations-logstash,logstash>> | Plugins to enable {ls}-to-{ls} communication. | https://github.com/logstash-plugins/logstash-integration-logstash[logstash-integration-logstash]
 | <<plugins-integrations-rabbitmq,rabbitmq>> | Plugins for processing events to or from a RabbitMQ broker. | https://github.com/logstash-plugins/logstash-integration-rabbitmq[logstash-integration-rabbitmq]
 |=======================================================================
 
@@ -24,6 +25,9 @@ include::integrations/jdbc.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-kafka/edit/main/docs/index.asciidoc
 include::integrations/kafka.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-integration-logstash/edit/main/docs/index.asciidoc
+include::integrations/logstash.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-integration-rabbitmq/edit/main/docs/index.asciidoc
 include::integrations/rabbitmq.asciidoc[]

--- a/docs/plugins/integrations/logstash.asciidoc
+++ b/docs/plugins/integrations/logstash.asciidoc
@@ -1,0 +1,21 @@
+:plugin: logstash
+:type: integration
+:default_plugin: 0
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v0.0.3
+:release_date: 2023-11-01
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-logstash/blob/v0.0.3/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Logstash integration plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+

--- a/docs/plugins/outputs.asciidoc
+++ b/docs/plugins/outputs.asciidoc
@@ -36,6 +36,7 @@ The following output plugins are available below. For a list of Elastic supporte
 | <<plugins-outputs-kafka,kafka>> | Writes events to a Kafka topic | https://github.com/logstash-plugins/logstash-integration-kafka[logstash-integration-kafka]
 | <<plugins-outputs-librato,librato>> | Sends metrics, annotations, and alerts to Librato based on Logstash events | https://github.com/logstash-plugins/logstash-output-librato[logstash-output-librato]
 | <<plugins-outputs-loggly,loggly>> | Ships logs to Loggly | https://github.com/logstash-plugins/logstash-output-loggly[logstash-output-loggly]
+| <<plugins-outputs-logstash,logstash>> | Ships data to {ls} input on another {ls} instance | https://github.com/logstash-plugins/logstash-integration-logstash[logstash-integration-logstash]
 | <<plugins-outputs-lumberjack,lumberjack>> | Sends events using the `lumberjack` protocol | https://github.com/logstash-plugins/logstash-output-lumberjack[logstash-output-lumberjack]
 | <<plugins-outputs-metriccatcher,metriccatcher>> | Writes metrics to MetricCatcher | https://github.com/logstash-plugins/logstash-output-metriccatcher[logstash-output-metriccatcher]
 | <<plugins-outputs-mongodb,mongodb>> | Writes events to MongoDB | https://github.com/logstash-plugins/logstash-output-mongodb[logstash-output-mongodb]
@@ -148,6 +149,9 @@ include::outputs/kafka.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-librato/edit/main/docs/index.asciidoc
 include::outputs/librato.asciidoc[]
+
+:edit_url: https://github.com/logstash-plugins/logstash-output-logstash/edit/main/docs/output-logstash.asciidoc
+include::outputs/logstash.asciidoc[]
 
 :edit_url: https://github.com/logstash-plugins/logstash-output-loggly/edit/main/docs/index.asciidoc
 include::outputs/loggly.asciidoc[]

--- a/docs/plugins/outputs/logstash.asciidoc
+++ b/docs/plugins/outputs/logstash.asciidoc
@@ -1,0 +1,22 @@
+:integration: logstash
+:plugin: logstash
+:type: output
+:default_plugin: 0
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v0.0.3
+:release_date: 2023-1101
+:changelog_url: https://github.com/logstash-plugins/logstash-integration-logstash/blob/0.0.3/CHANGELOG.md
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Logstash output plugin
+
+include::{include_path}/plugin_header-integration.asciidoc[]
+


### PR DESCRIPTION
We need these files in 8.10 (`current`) for the VPR links to target.  (The VPR is not versioned, and therefore we always point to `current`.