### PR TITLE
Catch missed es-output changes.

### DIFF
--- a/docs/versioned-plugins/codecs/protobuf-index.asciidoc
+++ b/docs/versioned-plugins/codecs/protobuf-index.asciidoc
@@ -5,6 +5,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v1.3.0-plugins-codecs-protobuf,v1.3.0>> | 2023-09-20
 | <<v1.2.9-plugins-codecs-protobuf,v1.2.9>> | 2023-04-11
 | <<v1.2.8-plugins-codecs-protobuf,v1.2.8>> | 2023-03-28
 | <<v1.2.5-plugins-codecs-protobuf,v1.2.5>> | 2021-02-08
@@ -16,6 +17,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 | <<v1.0.2-plugins-codecs-protobuf,v1.0.2>> | 2017-06-23
 |=======================================================================
 
+include::protobuf-v1.3.0.asciidoc[]
 include::protobuf-v1.2.9.asciidoc[]
 include::protobuf-v1.2.8.asciidoc[]
 include::protobuf-v1.2.5.asciidoc[]

--- a/docs/versioned-plugins/codecs/protobuf-v1.3.0.asciidoc
+++ b/docs/versioned-plugins/codecs/protobuf-v1.3.0.asciidoc
@@ -1,0 +1,241 @@
+:plugin: protobuf
+:type: codec
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v1.3.0
+:release_date: 2023-09-20
+:changelog_url: https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.3.0/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Protobuf codec plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This codec converts protobuf encoded messages into logstash events and vice versa. It supports the protobuf versions 2 and 3.
+
+The plugin requires the protobuf definitions to be compiled to ruby files. +
+For protobuf 2 use the https://github.com/codekitchen/ruby-protocol-buffers[ruby-protoc compiler]. +
+For protobuf 3 use the https://developers.google.com/protocol-buffers/docs/reference/ruby-generated[official google protobuf compiler].
+
+The following shows a usage example (protobuf v2) for decoding events from a kafka stream:
+[source,ruby]
+kafka
+{
+  topic_id => "..."
+  key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  codec => protobuf
+  {
+    class_name => "Animals::Mammals::Unicorn"
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn.pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
+  }
+}
+
+Decoder usage example for protobuf v3:
+[source,ruby]
+kafka
+{
+  topic_id => "..."
+  key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+  codec => protobuf
+  {
+    class_name => "Animals.Mammals.Unicorn"
+    class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+    protobuf_root_directory => "/path/to/pb_definitions/"
+    protobuf_version => 3
+  }
+}
+
+
+The codec can be used in input and output plugins. +
+When using the codec in the kafka input plugin please set the deserializer classes as shown above. +
+When using the codec in an output plugin:
+
+* make sure to include all the desired fields in the protobuf definition, including timestamp.
+  Remove fields that are not part of the protobuf definition from the event by using the mutate filter. Encoding will fail if the event has fields which are not in the protobuf definition.
+* the `@` symbol is currently not supported in field names when loading the protobuf definitions for encoding. Make sure to call the timestamp field `timestamp`
+  instead of `@timestamp` in the protobuf file. Logstash event fields will be stripped of the leading `@` before conversion.
+* fields with a nil value will automatically be removed from the event. Empty fields will not be removed.
+* it is recommended to set the config option `pb3_encoder_autoconvert_types` to true. Otherwise any type mismatch between your data and the protobuf definition will cause an event to be lost. The auto typeconversion does not alter your data. It just tries to convert obviously identical data into the expected datatype, such as converting integers to floats where floats are expected, or "true" / "false" strings into booleans where booleans are expected.
+* When writing to Kafka: set the serializer class: `value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"`
+
+Encoder usage example (protobufg v3):
+
+[source,ruby]
+kafka
+  {
+    codec => protobuf
+    {
+      class_name => "Animals.Mammals.Unicorn"
+      class_file => '/path/to/pb_definitions/some_folder/Unicorn_pb.rb'
+      protobuf_root_directory => "/path/to/pb_definitions/"
+      protobuf_version => 3
+    }
+    value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"
+  }
+}
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Protobuf Codec Configuration Options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-class_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-class_file>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-protobuf_root_directory>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-include_path>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-protobuf_version>> |{logstash-ref}/configuration-file-structure.html#number[number]|Yes
+| <<{version}-plugins-{type}s-{plugin}-stop_on_error>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+|=======================================================================
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-class_name"]
+===== `class_name`
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Fully qualified name of the class to decode.
+Please note that the module delimiter is different depending on the protobuf version. For protobuf v2, use double colons:
+[source,ruby]
+class_name => "Animals::Mammals::Unicorn"
+
+For protobuf v3, use single dots:
+[source,ruby]
+class_name => "Animals.Mammals.Unicorn"
+
+For protobuf v3, you can copy the class name from the Descriptorpool registrations at the bottom of the generated protobuf ruby file. It contains lines like this:
+[source,ruby]
+Animals.Mammals.Unicorn = Google::Protobuf::DescriptorPool.generated_pool.lookup("Animals.Mammals.Unicorn").msgclass
+
+If your class references other definitions: you only have to add the name of the main class here.
+
+[id="{version}-plugins-{type}s-{plugin}-class_file"]
+===== `class_file`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Absolute path to the directory that contains all compiled protobuf files. If the protobuf definitions are spread across multiple folders, this needs to point to the folder containing all those folders.
+
+[id="{version}-plugins-{type}s-{plugin}-protobuf_root_directory"]
+===== `protobuf_root_directory`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Absolute path to the root directory that contains all referenced/used dependencies of the main class (`class_name`) or any of its dependencies. Must be used in combination with the `class_file` setting, and can not be used in combination with the legacy loading mechanism `include_path`.
+
+Example:
+
+[source,shell]
+ pb3
+   ├── header
+   │   └── header_pb.rb
+   ├── messageA_pb.rb
+
+In this case `messageA_pb.rb` has an embedded message from `header/header_pb.rb`.
+If `class_file` is set to `messageA_pb.rb`, and `class_name` to `MessageA`, `protobuf_root_directory` must be set to `/path/to/pb3`, which includes both definitions.
+
+
+[id="{version}-plugins-{type}s-{plugin}-include_path"]
+===== `include_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * There is no default value for this setting.
+
+Legacy protobuf definition loading mechanism for backwards compatibility:
+List of absolute pathes to files with protobuf definitions.
+When using more than one file, make sure to arrange the files in reverse order of dependency so that each class is loaded before it is
+refered to by another.
+
+Example: a class _Unicorn_ referencing another protobuf class _Wings_
+[source,ruby]
+module Animal
+  module Mammal
+    class Unicorn
+      set_fully_qualified_name "Animal.Mammal.Unicorn"
+      optional ::Bodypart::Wings, :wings, 1
+      optional :string, :name, 2
+      ...
+
+would be configured as
+[source,ruby]
+include_path => ['/path/to/pb_definitions/wings.pb.rb','/path/to/pb_definitions/unicorn.pb.rb']
+
+Please note that protobuf v2 files have the ending `.pb.rb` whereas files compiled for protobuf v3 end in `_pb.rb`.
+
+Cannot be used together with `protobuf_root_directory` or `class_file`.
+
+[id="{version}-plugins-{type}s-{plugin}-protobuf_version"]
+===== `protobuf_version`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is 2
+
+Protocol buffers version. Valid settings are 2, 3.
+
+[id="{version}-plugins-{type}s-{plugin}-stop_on_error"]
+===== `stop_on_error`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is false
+
+Stop entire pipeline when encountering a non decodable message.
+
+[id="{version}-plugins-{type}s-{plugin}-pb3_encoder_autoconvert_types"]
+===== `pb3_encoder_autoconvert_types`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is true
+
+Convert data types to match the protobuf definition (if possible).
+The protobuf encoder library is very strict with regards to data types. Example: an event has an integer field but the protobuf definition expects a float. This would lead to an exception and the event would be lost.
+
+This feature tries to convert the datatypes to the expectations of the protobuf definitions, without modifying the data whatsoever. Examples of conversions it might attempt:
+
+  `"true" :: string => true :: boolean`
+
+  `17 :: int => 17.0 :: float`
+
+  `12345 :: number => "12345" :: string`
+
+Available only for protobuf version 3.
+
+[id="{version}-plugins-{type}s-{plugin}-pb3_set_oneof_metainfo"]
+===== `pb3_set_oneof_metainfo`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is false
+
+Add meta information to `[@metadata][pb_oneof]` about which classes were chosen
+for https://developers.google.com/protocol-buffers/docs/proto3#oneof[oneof]
+fields. A new field of name `[@metadata][pb_oneof][FOO]` will be added, where
+`FOO` is the name of the `oneof` field.
+
+Example values: for the protobuf definition
+[source,ruby]
+    oneof :horse_type do
+      optional :unicorn, :message, 2, "UnicornType"
+      optional :pegasus, :message, 3, "PegasusType"
+    end
+
+the field `[@metadata][pb_oneof][horse_type]` will be set to either `pegasus` or `unicorn`.
+Available only for protobuf version 3.
+

--- a/docs/versioned-plugins/filters/useragent-index.asciidoc
+++ b/docs/versioned-plugins/filters/useragent-index.asciidoc
@@ -5,6 +5,8 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v3.3.5-plugins-filters-useragent,v3.3.5>> | 2023-09-19
+| <<v3.3.4-plugins-filters-useragent,v3.3.4>> | 2023-03-13
 | <<v3.3.3-plugins-filters-useragent,v3.3.3>> | 2021-12-22
 | <<v3.3.2-plugins-filters-useragent,v3.3.2>> | 2021-11-10
 | <<v3.3.1-plugins-filters-useragent,v3.3.1>> | 2021-05-05
@@ -18,6 +20,8 @@ include::{include_path}/version-list-intro.asciidoc[]
 | <<v3.1.0-plugins-filters-useragent,v3.1.0>> | 2017-05-10
 |=======================================================================
 
+include::useragent-v3.3.5.asciidoc[]
+include::useragent-v3.3.4.asciidoc[]
 include::useragent-v3.3.3.asciidoc[]
 include::useragent-v3.3.2.asciidoc[]
 include::useragent-v3.3.1.asciidoc[]

--- a/docs/versioned-plugins/filters/useragent-v3.3.4.asciidoc
+++ b/docs/versioned-plugins/filters/useragent-v3.3.4.asciidoc
@@ -1,0 +1,204 @@
+:plugin: useragent
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.3.4
+:release_date: 2023-03-13
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.3.4/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Useragent filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Parse user agent strings into structured data based on BrowserScope data
+
+UserAgent filter, adds information about user agent like name, version, operating
+system, and device.
+
+The plugin ships with the *regexes.yaml* database made available from ua-parser
+with an Apache 2.0 license. For more details on ua-parser, see
+<https://github.com/ua-parser/uap-core/>.
+
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin can be used to parse user-agent (UA) _into_ fields compliant with the Elastic Common Schema.
+Here's how
+<<{version}-plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> affects
+output.
+
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|ECS disabled |ECS v1, v8 |Description |Notes
+
+|[name]        |[user_agent][name]                                  |Detected UA name |
+|[version]*    |[user_agent][version]                               |Detected UA version |Only available in ECS mode
+|[major]       |[@metadata][filter][user_agent][version][major]     |UA major version |Only as meta-data in ECS mode
+|[minor]       |[@metadata][filter][user_agent][version][minor]     |UA minor version |Only as meta-data in ECS mode
+|[patch]       |[@metadata][filter][user_agent][version][patch]     |UA patch version |Only as meta-data in ECS mode
+|[os_name]     |[user_agent][os][name]                              |Detected operating-system name |
+|[os_version]* |[user_agent][os][version]                           |Detected OS version |Only available in ECS mode
+|[os_major]    |[@metadata][filter][user_agent][os][version][major] |OS major version |Only as meta-data in ECS mode
+|[os_minor]    |[@metadata][filter][user_agent][os][version][minor] |OS minor version |Only as meta-data in ECS mode
+|[os_patch]    |[@metadata][filter][user_agent][os][version][patch] |OS patch version |Only as meta-data in ECS mode
+|[os_full]     |[user_agent][os][full]                              |Full operating-system name |
+|[device]      |[user_agent][device][name]                          |Device name |
+|=======================================================================
+
+NOTE: `[version]` and `[os_version]` fields were added in Logstash **7.14** and are not available by default in earlier versions.
+
+Example:
+[source,ruby]
+    filter {
+      useragent {
+        source => 'message'
+      }
+    }
+
+Given an event with the `message` field set as: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0`
+produces the following fields:
+
+[source,ruby]
+-----
+    {
+        "name"=>"Firefox",
+        "version"=>"45.0", # since plugin version 3.3.0
+        "major"=>"45",
+        "minor"=>"0",
+        "os_name"=>"Mac OS X",
+        "os_version"=>"10.11", # since plugin version 3.3.0
+        "os_full"=>"Mac OS X 10.11",
+        "os_major"=>"10",
+        "os_minor"=>"11",
+        "device"=>"Mac"
+    }
+-----
+
+**and with ECS enabled:**
+[source,ruby]
+-----
+    {
+        "user_agent"=>{
+            "name"=>"Firefox",
+            "version"=>"45.0",
+            "os"=>{
+                "name"=>"Mac OS X",
+                "version"=>"10.11",
+                "full"=>"Mac OS X 10.11"
+            },
+            "device"=>{"name"=>"Mac"},
+        }
+    }
+-----
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Useragent Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-lru_cache_size>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-prefix>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-regexes>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-source>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-target>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+** `v1`, `v8`: uses fields that are compatible with Elastic Common Schema (for example, `[user_agent][version]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<{version}-plugins-{type}s-{plugin}-target>>.
+
+[id="{version}-plugins-{type}s-{plugin}-lru_cache_size"]
+===== `lru_cache_size`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100000`
+
+UA parsing is surprisingly expensive. This filter uses an LRU cache to take advantage of the fact that
+user agents are often found adjacent to one another in log files and rarely have a random distribution.
+The higher you set this the more likely an item is to be in the cache and the faster this filter will run.
+However, if you set this too high you can use more memory than desired.
+
+Experiment with different values for this option to find the best performance for your dataset.
+
+This MUST be set to a value > 0. There is really no reason to not want this behavior, the overhead is minimal
+and the speed gains are large.
+
+It is important to note that this config value is global. That is to say all instances of the user agent filter
+share the same cache. The last declared cache size will 'win'. The reason for this is that there would be no benefit
+to having multiple caches for different instances at different points in the pipeline, that would just increase the
+number of cache misses and waste memory.
+
+[id="{version}-plugins-{type}s-{plugin}-prefix"]
+===== `prefix`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+A string to prepend to all of the extracted keys
+
+[id="{version}-plugins-{type}s-{plugin}-regexes"]
+===== `regexes`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+If not specified, this will default to the `regexes.yaml` that ships
+with logstash. Otherwise use the provided `regexes.yaml` file.
+
+You can find the latest version of this here:
+<https://github.com/ua-parser/uap-core/blob/master/regexes.yaml>
+
+[id="{version}-plugins-{type}s-{plugin}-source"]
+===== `source`
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The field containing the user agent string. If this field is an
+array, only the first value will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value depends on whether <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"user_agent"`
+
+The name of the field to assign user agent data into.
+
+If not specified user agent data will be stored in the root of the event.
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/filters/useragent-v3.3.5.asciidoc
+++ b/docs/versioned-plugins/filters/useragent-v3.3.5.asciidoc
@@ -1,0 +1,204 @@
+:plugin: useragent
+:type: filter
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v3.3.5
+:release_date: 2023-09-19
+:changelog_url: https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.3.5/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Useragent filter plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Parse user agent strings into structured data based on BrowserScope data
+
+UserAgent filter, adds information about user agent like name, version, operating
+system, and device.
+
+The plugin ships with the *regexes.yaml* database made available from ua-parser
+with an Apache 2.0 license. For more details on ua-parser, see
+<https://github.com/ua-parser/uap-core/>.
+
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin can be used to parse user-agent (UA) _into_ fields compliant with the Elastic Common Schema.
+Here's how
+<<{version}-plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> affects
+output.
+
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|ECS disabled |ECS v1, v8 |Description |Notes
+
+|[name]        |[user_agent][name]                                  |Detected UA name |
+|[version]*    |[user_agent][version]                               |Detected UA version |Only available in ECS mode
+|[major]       |[@metadata][filter][user_agent][version][major]     |UA major version |Only as meta-data in ECS mode
+|[minor]       |[@metadata][filter][user_agent][version][minor]     |UA minor version |Only as meta-data in ECS mode
+|[patch]       |[@metadata][filter][user_agent][version][patch]     |UA patch version |Only as meta-data in ECS mode
+|[os_name]     |[user_agent][os][name]                              |Detected operating-system name |
+|[os_version]* |[user_agent][os][version]                           |Detected OS version |Only available in ECS mode
+|[os_major]    |[@metadata][filter][user_agent][os][version][major] |OS major version |Only as meta-data in ECS mode
+|[os_minor]    |[@metadata][filter][user_agent][os][version][minor] |OS minor version |Only as meta-data in ECS mode
+|[os_patch]    |[@metadata][filter][user_agent][os][version][patch] |OS patch version |Only as meta-data in ECS mode
+|[os_full]     |[user_agent][os][full]                              |Full operating-system name |
+|[device]      |[user_agent][device][name]                          |Device name |
+|=======================================================================
+
+NOTE: `[version]` and `[os_version]` fields were added in Logstash **7.14** and are not available by default in earlier versions.
+
+Example:
+[source,ruby]
+    filter {
+      useragent {
+        source => 'message'
+      }
+    }
+
+Given an event with the `message` field set as: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0`
+produces the following fields:
+
+[source,ruby]
+-----
+    {
+        "name"=>"Firefox",
+        "version"=>"45.0", # since plugin version 3.3.0
+        "major"=>"45",
+        "minor"=>"0",
+        "os_name"=>"Mac OS X",
+        "os_version"=>"10.11", # since plugin version 3.3.0
+        "os_full"=>"Mac OS X 10.11",
+        "os_major"=>"10",
+        "os_minor"=>"11",
+        "device"=>"Mac"
+    }
+-----
+
+**and with ECS enabled:**
+[source,ruby]
+-----
+    {
+        "user_agent"=>{
+            "name"=>"Firefox",
+            "version"=>"45.0",
+            "os"=>{
+                "name"=>"Mac OS X",
+                "version"=>"10.11",
+                "full"=>"Mac OS X 10.11"
+            },
+            "device"=>{"name"=>"Mac"},
+        }
+    }
+-----
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Useragent Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<{version}-plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-lru_cache_size>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-prefix>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-regexes>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-source>> |{logstash-ref}/configuration-file-structure.html#string[string]|Yes
+| <<{version}-plugins-{type}s-{plugin}-target>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+** `v1`, `v8`: uses fields that are compatible with Elastic Common Schema (for example, `[user_agent][version]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<{version}-plugins-{type}s-{plugin}-target>>.
+
+[id="{version}-plugins-{type}s-{plugin}-lru_cache_size"]
+===== `lru_cache_size`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100000`
+
+UA parsing is surprisingly expensive. This filter uses an LRU cache to take advantage of the fact that
+user agents are often found adjacent to one another in log files and rarely have a random distribution.
+The higher you set this the more likely an item is to be in the cache and the faster this filter will run.
+However, if you set this too high you can use more memory than desired.
+
+Experiment with different values for this option to find the best performance for your dataset.
+
+This MUST be set to a value > 0. There is really no reason to not want this behavior, the overhead is minimal
+and the speed gains are large.
+
+It is important to note that this config value is global. That is to say all instances of the user agent filter
+share the same cache. The last declared cache size will 'win'. The reason for this is that there would be no benefit
+to having multiple caches for different instances at different points in the pipeline, that would just increase the
+number of cache misses and waste memory.
+
+[id="{version}-plugins-{type}s-{plugin}-prefix"]
+===== `prefix`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+A string to prepend to all of the extracted keys
+
+[id="{version}-plugins-{type}s-{plugin}-regexes"]
+===== `regexes`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+If not specified, this will default to the `regexes.yaml` that ships
+with logstash. Otherwise use the provided `regexes.yaml` file.
+
+You can find the latest version of this here:
+<https://github.com/ua-parser/uap-core/blob/master/regexes.yaml>
+
+[id="{version}-plugins-{type}s-{plugin}-source"]
+===== `source`
+
+  * This is a required setting.
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The field containing the user agent string. If this field is an
+array, only the first value will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value depends on whether <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"user_agent"`
+
+The name of the field to assign user agent data into.
+
+If not specified user agent data will be stored in the root of the event.
+
+
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/versioned-plugins/outputs/elasticsearch-index.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-index.asciidoc
@@ -5,6 +5,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 
 |=======================================================================
 | Version | Release Date
+| <<v11.18.0-plugins-outputs-elasticsearch,v11.18.0>> | 2023-09-25
 | <<v11.17.0-plugins-outputs-elasticsearch,v11.17.0>> | 2023-09-14
 | <<v11.16.0-plugins-outputs-elasticsearch,v11.16.0>> | 2023-08-09
 | <<v11.15.9-plugins-outputs-elasticsearch,v11.15.9>> | 2023-07-18
@@ -112,6 +113,7 @@ include::{include_path}/version-list-intro.asciidoc[]
 | <<v7.3.2-plugins-outputs-elasticsearch,v7.3.2>> | 2017-05-26
 |=======================================================================
 
+include::elasticsearch-v11.18.0.asciidoc[]
 include::elasticsearch-v11.17.0.asciidoc[]
 include::elasticsearch-v11.16.0.asciidoc[]
 include::elasticsearch-v11.15.9.asciidoc[]

--- a/docs/versioned-plugins/outputs/elasticsearch-v11.18.0.asciidoc
+++ b/docs/versioned-plugins/outputs/elasticsearch-v11.18.0.asciidoc
@@ -1,0 +1,1382 @@
+:plugin: elasticsearch
+:type: output
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: v11.18.0
+:release_date: 2023-09-25
+:changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v11.18.0/CHANGELOG.md
+:include_path: ../include/6.x
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="{version}-plugins-{type}s-{plugin}"]
+
+=== Elasticsearch output plugin {version}
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Elasticsearch provides near real-time search and analytics for all types of
+data. The Elasticsearch output plugin can store both time series datasets (such
+as logs, events, and metrics) and non-time series data in Elasticsearch.
+
+You can https://www.elastic.co/elasticsearch/[learn more about Elasticsearch] on
+the website landing page or in the {ref}[Elasticsearch documentation].
+
+.Compatibility Note
+[NOTE]
+================================================================================
+When connected to Elasticsearch 7.x, modern versions of this plugin
+don't use the document-type when inserting documents, unless the user
+explicitly sets <<{version}-plugins-{type}s-{plugin}-document_type>>.
+
+If you are using an earlier version of Logstash and wish to connect to
+Elasticsearch 7.x, first upgrade Logstash to version 6.8 to ensure it
+picks up changes to the Elasticsearch index template.
+
+If you are using a custom <<{version}-plugins-{type}s-{plugin}-template>>,
+ensure your template uses the `_doc` document-type before
+connecting to Elasticsearch 7.x.
+================================================================================
+
+===== Hosted {es} Service on Elastic Cloud
+
+{ess-leadin}
+
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin will persist events to Elasticsearch in the shape produced by
+your pipeline, and _cannot_ be used to re-shape the event structure into a
+shape that complies with ECS. To produce events that fully comply with ECS,
+you will need to populate ECS-defined fields throughout your pipeline
+definition.
+
+However, the Elasticsearch Index Templates it manages can be configured to
+be ECS-compatible by setting <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>>.
+By having an ECS-compatible template in place, we can ensure that Elasticsearch
+is prepared to create and index fields in a way that is compatible with ECS,
+and will correctly reject events with fields that conflict and cannot be coerced.
+
+[id="{version}-plugins-{type}s-{plugin}-data-streams"]
+==== Data streams
+
+The {es} output plugin can store both time series datasets (such
+as logs, events, and metrics) and non-time series data in Elasticsearch.
+
+The data stream options are recommended for indexing time series datasets (such
+as logs, metrics, and events) into {es}:
+
+* <<{version}-plugins-{type}s-{plugin}-data_stream>>
+* <<{version}-plugins-{type}s-{plugin}-data_stream_auto_routing>>
+* <<{version}-plugins-{type}s-{plugin}-data_stream_dataset>>
+* <<{version}-plugins-{type}s-{plugin}-data_stream_namespace>>
+* <<{version}-plugins-{type}s-{plugin}-data_stream_sync_fields>>
+* <<{version}-plugins-{type}s-{plugin}-data_stream_type>>
+
+[id="{version}-plugins-{type}s-{plugin}-ds-examples"]
+===== Data stream configuration examples
+
+**Example: Basic default configuration**
+
+[source,sh]
+-----
+output {
+    elasticsearch {
+        hosts => "hostname"
+        data_stream => "true"
+    }
+}
+-----
+
+This example shows the minimal settings for processing data streams. Events
+with `data_stream.*`` fields are routed to the appropriate data streams. If the
+fields are missing, routing defaults to `logs-generic-logstash`.
+
+**Example: Customize data stream name**
+
+[source,sh]
+-----
+output {
+    elasticsearch {
+        hosts => "hostname"
+        data_stream => "true"
+        data_stream_type => "metrics"
+        data_stream_dataset => "foo"
+        data_stream_namespace => "bar"
+    }
+}
+-----
+
+
+
+
+==== Writing to different indices: best practices
+
+NOTE: You cannot use dynamic variable substitution when `ilm_enabled` is `true`
+and when using `ilm_rollover_alias`.
+
+If you're sending events to the same Elasticsearch cluster, but you're targeting different indices you can:
+
+ * use different Elasticsearch outputs, each one with a different value for the `index` parameter
+ * use one Elasticsearch output and use the dynamic variable substitution for the `index` parameter
+
+Each Elasticsearch output is a new client connected to the cluster:
+
+ * it has to initialize the client and connect to Elasticsearch (restart time is longer if you have more clients)
+ * it has an associated connection pool
+
+In order to minimize the number of open connections to Elasticsearch, maximize
+the bulk size and reduce the number of "small" bulk requests (which could easily
+fill up the queue), it is usually more efficient to have a single Elasticsearch
+output.
+
+Example:
+[source,ruby]
+    output {
+      elasticsearch {
+        index => "%{[some_field][sub_field]}-%{+YYYY.MM.dd}"
+      }
+    }
+
+**What to do in case there is no field in the event containing the destination index prefix?**
+
+You can use the `mutate` filter and conditionals to add a
+{logstash-ref}/event-dependent-configuration.html#metadata[`[@metadata]` field]
+to set the destination index for each event. The `[@metadata]` fields will not
+be sent to Elasticsearch.
+
+Example:
+[source,ruby]
+    filter {
+      if [log_type] in [ "test", "staging" ] {
+        mutate { add_field => { "[@metadata][target_index]" => "test-%{+YYYY.MM}" } }
+      } else if [log_type] == "production" {
+        mutate { add_field => { "[@metadata][target_index]" => "prod-%{+YYYY.MM.dd}" } }
+      } else {
+        mutate { add_field => { "[@metadata][target_index]" => "unknown-%{+YYYY}" } }
+      }
+    }
+    output {
+      elasticsearch {
+        index => "%{[@metadata][target_index]}"
+      }
+    }
+
+
+==== Retry Policy
+
+The retry policy has changed significantly in the 8.1.1 release.
+This plugin uses the Elasticsearch bulk API to optimize its imports into Elasticsearch. These requests may experience
+either partial or total failures. The bulk API sends batches of requests to an HTTP endpoint. Error codes for the HTTP
+request are handled differently than error codes for individual documents.
+
+HTTP requests to the bulk API are expected to return a 200 response code. All other response codes are retried indefinitely.
+
+The following document errors are handled as follows:
+
+  * 400 and 404 errors are sent to the dead letter queue (DLQ), if enabled. If a DLQ is not enabled, a log message will be emitted, and the event will be dropped. See <<{version}-plugins-{type}s-{plugin}-dlq-policy>> for more info.
+  * 409 errors (conflict) are logged as a warning and dropped.
+
+Note that 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
+It is more performant for Elasticsearch to retry these exceptions than this plugin.
+
+[id="{version}-plugins-{type}s-{plugin}-dlq-policy"]
+==== DLQ Policy
+
+Mapping (404) errors from Elasticsearch can lead to data loss. Unfortunately
+mapping errors cannot be handled without human intervention and without looking
+at the field that caused the mapping mismatch. If the DLQ is enabled, the
+original events causing the mapping errors are stored in a file that can be
+processed at a later time. Often times, the offending field can be removed and
+re-indexed to Elasticsearch. If the DLQ is not enabled, and a mapping error
+happens, the problem is logged as a warning, and the event is dropped. See
+{logstash-ref}/dead-letter-queues.html[dead-letter-queues] for more information about processing events in the DLQ.
+The list of error codes accepted for DLQ could be customized with <<{version}-plugins-{type}s-{plugin}-dlq_custom_codes>>
+but should be used only in motivated cases.
+
+[id="{version}-plugins-{type}s-{plugin}-ilm"]
+==== Index Lifecycle Management
+
+[NOTE]
+The Index Lifecycle Management feature requires plugin version `9.3.1` or higher.
+
+[NOTE]
+This feature requires an Elasticsearch instance of 6.6.0 or higher with at least a Basic license
+
+Logstash can use {ref}/index-lifecycle-management.html[Index Lifecycle
+Management] to automate the management of indices over time.
+
+The use of Index Lifecycle Management is controlled by the `ilm_enabled`
+setting. By default, this setting detects whether the Elasticsearch instance
+supports ILM, and uses it if it is available. `ilm_enabled` can also be set to
+`true` or `false` to override the automatic detection, or disable ILM.
+
+This will overwrite the index settings and adjust the Logstash template to write
+the necessary settings for the template to support index lifecycle management,
+including the index policy and rollover alias to be used.
+
+Logstash will create a rollover alias for the indices to be written to,
+including a pattern for how the actual indices will be named, and unless an ILM
+policy that already exists has been specified, a default policy will also be
+created. The default policy is configured to rollover an index when it reaches
+either 50 gigabytes in size, or is 30 days old, whichever happens first.
+
+The default rollover alias is called `logstash`, with a default pattern for the
+rollover index of `{now/d}-00001`, which will name indices on the date that the
+index is rolled over, followed by an incrementing number. Note that the pattern
+must end with a dash and a number that will be incremented.
+
+See the {ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
+API documentation] for more details on naming.
+
+The rollover alias, ilm pattern and policy can be modified.
+
+See config below for an example:
+[source,ruby]
+    output {
+      elasticsearch {
+        ilm_rollover_alias => "custom"
+        ilm_pattern => "000001"
+        ilm_policy => "custom_policy"
+      }
+    }
+
+NOTE: Custom ILM policies must already exist on the Elasticsearch cluster before they can be used.
+
+NOTE: If the rollover alias or pattern is modified, the index template will need to be
+overwritten as the settings `index.lifecycle.name` and
+`index.lifecycle.rollover_alias` are automatically written to the template
+
+NOTE: If the index property is supplied in the output definition, it will be overwritten by the rollover alias.
+
+
+==== Batch Sizes
+
+This plugin attempts to send batches of events to the {ref}/docs-bulk.html[{es}
+Bulk API] as a single request. However, if a batch exceeds 20MB we break it up
+into multiple bulk requests. If a single document exceeds 20MB it is sent as a
+single request.
+
+==== DNS Caching
+
+This plugin uses the JVM to lookup DNS entries and is subject to the value of
+https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html[networkaddress.cache.ttl],
+a global setting for the JVM.
+
+As an example, to set your DNS TTL to 1 second you would set
+the `LS_JAVA_OPTS` environment variable to `-Dnetworkaddress.cache.ttl=1`.
+
+Keep in mind that a connection with keepalive enabled will
+not reevaluate its DNS value while the keepalive is in effect.
+
+==== HTTP Compression
+
+This plugin always reads compressed responses from {es}.
+By default, it sends compressed bulk requests to {es}.
+
+If you are concerned about bandwidth, you can set a higher <<{version}-plugins-{type}s-{plugin}-compression_level>> to trade CPU capacity for a reduction in network IO.
+
+==== Authentication
+
+Authentication to a secure Elasticsearch cluster is possible using one of the
+`user`/`password`, `cloud_auth` or `api_key` options.
+
+[id="{version}-plugins-{type}s-{plugin}-autz"]
+==== Authorization
+
+Authorization to a secure Elasticsearch cluster requires `read` permission at
+index level and `monitoring` permissions at cluster level. The `monitoring`
+permission at cluster level is necessary to perform periodic connectivity
+checks.
+
+
+[id="{version}-plugins-{type}s-{plugin}-options"]
+==== Elasticsearch Output Configuration Options
+
+This plugin supports the following configuration options plus the
+<<{version}-plugins-{type}s-{plugin}-common-options>> and the <<{version}-plugins-{type}s-{plugin}-deprecated-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<{version}-plugins-{type}s-{plugin}-action>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-api_key>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-bulk_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ca_trusted_fingerprint>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-cloud_auth>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-cloud_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-compression_level>> |{logstash-ref}/configuration-file-structure.html#number[number], one of `[0 ~ 9]`|No
+| <<{version}-plugins-{type}s-{plugin}-custom_headers>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["true", "false", "auto"]`|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream_auto_routing>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream_dataset>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream_namespace>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream_sync_fields>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-data_stream_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-dlq_custom_codes>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-dlq_on_failed_indexname_interpolation>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-doc_as_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-document_id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-document_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> | {logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-healthcheck_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-hosts>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-http_compression>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ilm_enabled>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["true", "false", "auto"]`|No
+| <<{version}-plugins-{type}s-{plugin}-ilm_pattern>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ilm_policy>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ilm_rollover_alias>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-index>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-silence_errors_in_log>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
+| <<{version}-plugins-{type}s-{plugin}-manage_template>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-parameters>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+| <<{version}-plugins-{type}s-{plugin}-parent>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pipeline>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-pool_max_per_route>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-proxy>> |{logstash-ref}/configuration-file-structure.html#uri[uri]|No
+| <<{version}-plugins-{type}s-{plugin}-resurrect_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_initial_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_max_interval>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-retry_on_conflict>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-routing>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_lang>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-script_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["inline", "indexed", "file"]`|No
+| <<{version}-plugins-{type}s-{plugin}-script_var_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-scripted_upsert>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_delay>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-sniffing_path>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> |{logstash-ref}/configuration-file-structure.html#path[path]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of {logstash-ref}/configuration-file-structure.html#path[path]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of {logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_enabled>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_key>> |{logstash-ref}/configuration-file-structure.html#path[path]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_keystore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_keystore_path>> |{logstash-ref}/configuration-file-structure.html#path[path]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_keystore_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_supported_protocols>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_truststore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_truststore_path>> |{logstash-ref}/configuration-file-structure.html#path[path]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_truststore_type>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-ssl_verification_mode>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["full", "none"]`|No
+| <<{version}-plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
+| <<{version}-plugins-{type}s-{plugin}-template_api>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["auto", "legacy", "composable"]`|No
+| <<{version}-plugins-{type}s-{plugin}-template_name>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-template_overwrite>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<{version}-plugins-{type}s-{plugin}-timeout>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-upsert>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-user>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-validate_after_inactivity>> |{logstash-ref}/configuration-file-structure.html#number[number]|No
+| <<{version}-plugins-{type}s-{plugin}-version>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
+| <<{version}-plugins-{type}s-{plugin}-version_type>> |{logstash-ref}/configuration-file-structure.html#string[string], one of `["internal", "external", "external_gt", "external_gte", "force"]`|No
+|=======================================================================
+
+Also see <<{version}-plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="{version}-plugins-{type}s-{plugin}-action"]
+===== `action`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `create` for data streams, and `index` for non-time series data.
+
+The Elasticsearch action to perform. Valid actions are:
+
+- `index`: indexes a document (an event from Logstash).
+- `delete`: deletes a document by id (An id is required for this action)
+- `create`: indexes a document, fails if a document by that id already exists in the index.
+- `update`: updates a document by id. Update has a special case where you can upsert -- update a
+  document if not already present. See the `doc_as_upsert` option. NOTE: This does not work and is not supported
+  in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
+- A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
+  would use the foo field for the action.
+  If resolved action is not in [`index`, `delete`, `create`, `update`], the event will not be sent to {es}.
+  Instead the event will be sent to the pipeline's {logstash-ref}/dead-letter-queues.html[dead-letter-queue (DLQ)] (if enabled), or it will be logged and dropped.
+
+For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bulk API documentation].
+
+[id="{version}-plugins-{type}s-{plugin}-api_key"]
+===== `api_key`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Authenticate using Elasticsearch API key.
+Note that this option also requires SSL/TLS, which can be enabled by supplying a <<{version}-plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<{version}-plugins-{type}s-{plugin}-hosts>>, or by setting <<{version}-plugins-{type}s-{plugin}-ssl,`ssl_enabled => true`>>.
+
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
+
+[id="{version}-plugins-{type}s-{plugin}-bulk_path"]
+===== `bulk_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to perform the _bulk requests to
+this defaults to a concatenation of the path parameter and "_bulk"
+
+[id="{version}-plugins-{type}s-{plugin}-ca_trusted_fingerprint"]
+===== `ca_trusted_fingerprint`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string], and must contain exactly 64 hexadecimal characters.
+* There is no default value for this setting.
+* Use of this option _requires_ Logstash 8.3+
+
+The SHA-256 fingerprint of an SSL Certificate Authority to trust, such as the autogenerated self-signed CA for an Elasticsearch cluster.
+
+[id="{version}-plugins-{type}s-{plugin}-cloud_auth"]
+===== `cloud_auth`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Cloud authentication string ("<username>:<password>" format) is an alternative
+for the `user`/`password` pair.
+
+For more details, check out the
+{logstash-ref}/connecting-to-cloud.html[Logstash-to-Cloud documentation].
+
+[id="{version}-plugins-{type}s-{plugin}-cloud_id"]
+===== `cloud_id`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
+
+For more details, check out the
+{logstash-ref}/connecting-to-cloud.html[Logstash-to-Cloud documentation].
+
+[id="{version}-plugins-{type}s-{plugin}-compression_level"]
+===== `compression_level`
+
+  * Value can be any of: `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
+  * Default value is `1`
+
+The gzip compression level. Setting this value to `0` disables compression.
+The compression level must be in the range of `1` (best speed) to `9` (best compression).
+
+Increasing the compression level will reduce the network usage but will increase the CPU usage.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream"]
+===== `data_stream`
+
+* Value can be any of: `true`, `false` and `auto`
+* Default is `false` in Logstash 7.x and `auto` starting in Logstash 8.0.
+
+Defines whether data will be indexed into an Elasticsearch data stream.
+The other `data_stream_*` settings will be used only if this setting is enabled.
+
+Logstash handles the output as a data stream when the supplied configuration
+is compatible with data streams and this value is set to `auto`.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream_auto_routing"]
+===== `data_stream_auto_routing`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+* Default value is `true`.
+
+Automatically routes events by deriving the data stream name using specific event
+fields with the `%{[data_stream][type]}-%{[data_stream][dataset]}-%{[data_stream][namespace]}` format.
+
+If enabled, the `data_stream.*` event fields will take precedence over the
+`data_stream_type`, `data_stream_dataset`, and `data_stream_namespace` settings,
+but will fall back to them if any of the fields are missing from the event.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream_dataset"]
+===== `data_stream_dataset`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Default value is `generic`.
+
+The data stream dataset used to construct the data stream at index time.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream_namespace"]
+===== `data_stream_namespace`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Default value is `default`.
+
+The data stream namespace used to construct the data stream at index time.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream_sync_fields"]
+===== `data_stream_sync_fields`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+* Default value is `true`
+
+Automatically adds and syncs the `data_stream.*` event fields if they are missing from the
+event. This ensures that fields match the name of the data stream that is receiving events.
+
+NOTE: If existing `data_stream.*` event fields do not match the data stream name
+and `data_stream_auto_routing` is disabled, the event fields will be
+overwritten with a warning.
+
+[id="{version}-plugins-{type}s-{plugin}-data_stream_type"]
+===== `data_stream_type`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Default value is `logs`.
+
+The data stream type used to construct the data stream at index time.
+Currently, only `logs`, `metrics`, `synthetics` and `traces` are supported.
+
+[id="{version}-plugins-{type}s-{plugin}-dlq_custom_codes"]
+===== `dlq_custom_codes`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+* Default value is `[]`.
+
+List single-action error codes from Elasticsearch's Bulk API that are considered valid to move the events into the dead letter queue.
+This list is an addition to the ordinary error codes considered for this feature, 400 and 404.
+It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
+The option accepts a list of natural numbers corresponding to HTTP errors codes.
+
+[id="{version}-plugins-{type}s-{plugin}-dlq_on_failed_indexname_interpolation"]
+===== `dlq_on_failed_indexname_interpolation`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+* Default value is `true`.
+
+If enabled, failed index name interpolation events go into dead letter queue.
+
+[id="{version}-plugins-{type}s-{plugin}-doc_as_upsert"]
+===== `doc_as_upsert`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Enable `doc_as_upsert` for update mode.
+Create a new document with source if `document_id` doesn't exist in Elasticsearch.
+
+[id="{version}-plugins-{type}s-{plugin}-document_id"]
+===== `document_id`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The document ID for the index. Useful for overwriting existing entries in
+Elasticsearch with the same ID.
+
+[id="{version}-plugins-{type}s-{plugin}-document_type"]
+===== `document_type`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+  * This option is deprecated
+
+NOTE: This option is deprecated due to the
+https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal
+of types in Elasticsearch 6.0]. It will be removed in the next major version of
+Logstash.
+
+NOTE: This value is ignored and has no effect for Elasticsearch clusters `8.x`.
+
+This sets the document type to write events to. Generally you should try to write only
+similar events to the same 'type'. String expansion `%{foo}` works here.
+If you don't set a value for this option:
+
+- for elasticsearch clusters 8.x: no value will be used;
+- for elasticsearch clusters 7.x: the value of '_doc' will be used;
+- for elasticsearch clusters 6.x: the value of 'doc' will be used;
+- for elasticsearch clusters 5.x and below: the event's 'type' field will be used, if the field is not present the value of 'doc' will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+* Supported values are:
+** `disabled`: does not provide ECS-compatible templates
+** `v1`,`v8`: Elastic Common Schema-compliant behavior
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema
+(ECS)], including the installation of ECS-compatible index templates. The value
+of this setting affects the _default_ values of:
+
+* <<{version}-plugins-{type}s-{plugin}-index>>
+* <<{version}-plugins-{type}s-{plugin}-template_name>>
+* <<{version}-plugins-{type}s-{plugin}-ilm_rollover_alias>>
+
+[id="{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist"]
+===== `failure_type_logging_whitelist`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+  * Default value is `[]`
+
+NOTE: Deprecated, refer to <<{version}-plugins-{type}s-{plugin}-silence_errors_in_log>>.
+
+[id="{version}-plugins-{type}s-{plugin}-custom_headers"]
+===== `custom_headers`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * There is no default value for this setting.
+
+Pass a set of key value pairs as the headers sent in each request to
+an elasticsearch node. The headers will be used for any kind of request
+(_bulk request, template installation, health checks and sniffing).
+These custom headers will be overidden by settings like `compression_level`.
+
+[id="{version}-plugins-{type}s-{plugin}-healthcheck_path"]
+===== `healthcheck_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path where a HEAD request is sent when a backend is marked down
+the request is sent in the background to see if it has come back again
+before it is once again eligible to service requests.
+If you have custom firewall rules you may need to change this
+
+[id="{version}-plugins-{type}s-{plugin}-hosts"]
+===== `hosts`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * Default value is `[//127.0.0.1]`
+
+Sets the host(s) of the remote instance. If given an array it will load balance
+requests across the hosts specified in the `hosts` parameter. Remember the
+`http` protocol uses the {ref}/modules-http.html#modules-http[http] address (eg.
+9200, not 9300).
+
+Examples:
+
+    `"127.0.0.1"`
+    `["127.0.0.1:9200","127.0.0.2:9200"]`
+    `["http://127.0.0.1"]`
+    `["https://127.0.0.1:9200"]`
+    `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+
+Exclude {ref}/modules-node.html[dedicated master nodes] from the `hosts` list to
+prevent Logstash from sending bulk requests to the master nodes. This parameter
+should reference only data or client nodes in Elasticsearch.
+
+Any special characters present in the URLs here MUST be URL escaped! This means
+`#` should be put in as `%23` for instance.
+
+[id="{version}-plugins-{type}s-{plugin}-http_compression"]
+===== `http_compression`
+deprecated[11.17.0, Replaced by <<{version}-plugins-{type}s-{plugin}-compression_level>>]
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+Setting `true` enables gzip compression level 1 on requests.
+
+This setting allows you to reduce this plugin's outbound network traffic by
+compressing each bulk _request_ to {es}.
+
+NOTE: This output plugin reads compressed _responses_ from {es} regardless
+      of the value of this setting.
+
+[id="{version}-plugins-{type}s-{plugin}-ilm_enabled"]
+===== `ilm_enabled`
+
+  * Value can be any of: `true`, `false`, `auto`
+  * Default value is `auto`
+
+The default setting of `auto` will automatically enable
+{ref}/index-lifecycle-management.html[Index Lifecycle Management], if the
+Elasticsearch cluster is running Elasticsearch version `7.0.0` or higher with
+the ILM feature enabled, and disable it otherwise.
+
+Setting this flag to `false` will disable the Index Lifecycle Management
+feature, even if the Elasticsearch cluster supports ILM.
+Setting this flag to `true` will enable Index Lifecycle Management feature, if
+the Elasticsearch cluster supports it. This is required to enable Index
+Lifecycle Management on a version of Elasticsearch earlier than version `7.0.0`.
+
+NOTE: This feature requires a Basic License or above to be installed on an
+Elasticsearch cluster version 6.6.0 or later.
+
+[id="{version}-plugins-{type}s-{plugin}-ilm_pattern"]
+===== `ilm_pattern`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `{now/d}-000001`
+
+Pattern used for generating indices managed by
+{ref}/index-lifecycle-management.html[Index Lifecycle Management]. The value
+specified in the pattern will be appended to the write alias, and incremented
+automatically when a new index is created by ILM.
+
+Date Math can be used when specifying an ilm pattern, see
+{ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Rollover
+API docs] for details.
+
+NOTE: Updating the pattern will require the index template to be rewritten.
+
+NOTE: The pattern must finish with a dash and a number that will be automatically
+incremented when indices rollover.
+
+NOTE: The pattern is a 6-digit string padded by zeros, regardless of prior index name.
+Example: 000001. See
+{ref}/indices-rollover-index.html#rollover-index-api-path-params[Rollover path
+parameters API docs] for details.
+
+[id="{version}-plugins-{type}s-{plugin}-ilm_policy"]
+===== `ilm_policy`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `logstash-policy`
+
+Modify this setting to use a custom Index Lifecycle Management policy, rather
+than the default. If this value is not set, the default policy will be
+automatically installed into Elasticsearch
+
+NOTE: If this setting is specified, the policy must already exist in Elasticsearch
+cluster.
+
+[id="{version}-plugins-{type}s-{plugin}-ilm_rollover_alias"]
+===== `ilm_rollover_alias`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value depends on whether <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+  ** ECS Compatibility disabled: `logstash`
+  ** ECS Compatibility enabled: `ecs-logstash`
+
+The rollover alias is the alias where indices managed using Index Lifecycle
+Management will be written to.
+
+NOTE: If both `index` and `ilm_rollover_alias` are specified,
+`ilm_rollover_alias` takes precedence.
+
+NOTE: Updating the rollover alias will require the index template to be
+rewritten.
+
+NOTE: `ilm_rollover_alias` does NOT support dynamic variable substitution as
+`index` does.
+
+[id="{version}-plugins-{type}s-{plugin}-index"]
+===== `index`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value depends on whether <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+  ** ECS Compatibility disabled: `"logstash-%{+yyyy.MM.dd}"`
+  ** ECS Compatibility enabled: `"ecs-logstash-%{+yyyy.MM.dd}"`
+
+The index to write events to. This can be dynamic using the `%{foo}` syntax.
+The default value will partition your indices by day so you can more easily
+delete old data or only search specific date ranges.
+Indexes may not contain uppercase characters.
+For weekly indexes ISO 8601 format is recommended, eg. logstash-%{+xxxx.ww}.
+Logstash uses
+http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[Joda
+formats] and the `@timestamp` field of each event is being used as source for the date.
+
+[id="{version}-plugins-{type}s-{plugin}-manage_template"]
+===== `manage_template`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true` for non-time series data, and `false` for data streams.
+
+From Logstash 1.3 onwards, a template is applied to Elasticsearch during
+Logstash's startup if one with the name <<{version}-plugins-{type}s-{plugin}-template_name>>
+does not already exist.
+By default, the contents of this template is the default template for
+`logstash-%{+YYYY.MM.dd}` which always matches indices based on the pattern
+`logstash-*`.  Should you require support for other index names, or would like
+to change the mappings in the template in general, a custom template can be
+specified by setting `template` to the path of a template file.
+
+Setting `manage_template` to false disables this feature.  If you require more
+control over template creation, (e.g. creating indices dynamically based on
+field names) you should set `manage_template` to false and use the REST
+API to apply your templates manually.
+
+[id="{version}-plugins-{type}s-{plugin}-parameters"]
+===== `parameters`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#hash[hash]
+  * There is no default value for this setting.
+
+Pass a set of key value pairs as the URL query string. This query string is added
+to every host listed in the 'hosts' configuration. If the 'hosts' list contains
+urls that already have query strings, the one specified here will be appended.
+
+[id="{version}-plugins-{type}s-{plugin}-parent"]
+===== `parent`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `nil`
+
+For child documents, ID of the associated parent.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-password"]
+===== `password`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Password to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-path"]
+===== `path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path at which the Elasticsearch server lives. Use this if you must run
+Elasticsearch behind a proxy that remaps the root path for the Elasticsearch
+HTTP API lives.
+Note that if you use paths as components of URLs in the 'hosts' field you may
+not also set this field. That will raise an error at startup
+
+[id="{version}-plugins-{type}s-{plugin}-pipeline"]
+===== `pipeline`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value.
+
+Set which ingest pipeline you wish to execute for an event. You can also use
+event dependent configuration here like `pipeline => "%{[@metadata][pipeline]}"`.
+The pipeline parameter won't be set if the value resolves to empty string ("").
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max"]
+===== `pool_max`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1000`
+
+While the output tries to reuse connections efficiently we have a maximum.
+This sets the maximum number of open connections the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-pool_max_per_route"]
+===== `pool_max_per_route`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `100`
+
+While the output tries to reuse connections efficiently we have a maximum per endpoint.
+This sets the maximum number of open connections per endpoint the output will create.
+Setting this too low may mean frequently closing / opening connections
+which is bad.
+
+[id="{version}-plugins-{type}s-{plugin}-proxy"]
+===== `proxy`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#uri[uri]
+  * There is no default value for this setting.
+
+Set the address of a forward HTTP proxy.
+This setting accepts only URI arguments to prevent leaking credentials.
+An empty string is treated as if proxy was not set. This is useful when using
+environment variables e.g. `proxy => '${LS_PROXY:}'`.
+
+[id="{version}-plugins-{type}s-{plugin}-resurrect_delay"]
+===== `resurrect_delay`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How frequently, in seconds, to wait between resurrection attempts.
+Resurrection is the process by which backend endpoints marked 'down' are checked
+to see if they have come back to life
+
+[id="{version}-plugins-{type}s-{plugin}-retry_initial_interval"]
+===== `retry_initial_interval`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `2`
+
+Set initial interval in seconds between bulk retries. Doubled on each retry up
+to `retry_max_interval`
+
+[id="{version}-plugins-{type}s-{plugin}-retry_max_interval"]
+===== `retry_max_interval`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `64`
+
+Set max interval in seconds between bulk retries.
+
+[id="{version}-plugins-{type}s-{plugin}-retry_on_conflict"]
+===== `retry_on_conflict`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `1`
+
+The number of times Elasticsearch should internally retry an update/upserted document.
+
+[id="{version}-plugins-{type}s-{plugin}-routing"]
+===== `routing`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+A routing override to be applied to all processed events.
+This can be dynamic using the `%{foo}` syntax.
+
+[id="{version}-plugins-{type}s-{plugin}-script"]
+===== `script`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set script name for scripted update mode
+
+Example:
+[source,ruby]
+    output {
+      elasticsearch {
+        script => "ctx._source.message = params.event.get('message')"
+      }
+    }
+
+[id="{version}-plugins-{type}s-{plugin}-script_lang"]
+===== `script_lang`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"painless"`
+
+Set the language of the used script.
+When using indexed (stored) scripts on Elasticsearch 6.0 and higher, you must set
+this parameter to `""` (empty string).
+
+[id="{version}-plugins-{type}s-{plugin}-script_type"]
+===== `script_type`
+
+  * Value can be any of: `inline`, `indexed`, `file`
+  * Default value is `["inline"]`
+
+Define the type of script referenced by "script" variable
+ inline : "script" contains inline script
+ indexed : "script" contains the name of script directly indexed in elasticsearch
+ file    : "script" contains the name of script stored in elasticsearch's config directory
+
+[id="{version}-plugins-{type}s-{plugin}-script_var_name"]
+===== `script_var_name`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `"event"`
+
+Set variable name passed to script (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-scripted_upsert"]
+===== `scripted_upsert`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+if enabled, script is in charge of creating non-existent document (scripted update)
+
+[id="{version}-plugins-{type}s-{plugin}-silence_errors_in_log"]
+===== `silence_errors_in_log`
+
+* Value type is {logstash-ref}/configuration-file-structure.html#array[array]
+* Default value is `[]`
+
+Defines the list of Elasticsearch errors that you don't want to log.
+A useful example is when you want to skip all 409 errors
+which are `document_already_exists_exception`.
+
+[source,ruby]
+    output {
+      elasticsearch {
+        silence_errors_in_log => ["document_already_exists_exception"]
+      }
+    }
+
+NOTE: Deprecates <<{version}-plugins-{type}s-{plugin}-failure_type_logging_whitelist>>.
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing"]
+===== `sniffing`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+This setting asks Elasticsearch for the list of all cluster nodes and adds them
+to the hosts list.
+For Elasticsearch 5.x and 6.x any nodes with `http.enabled` (on by default) will
+be added to the hosts list, excluding master-only nodes.
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_delay"]
+===== `sniffing_delay`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `5`
+
+How long to wait, in seconds, between sniffing attempts
+
+[id="{version}-plugins-{type}s-{plugin}-sniffing_path"]
+===== `sniffing_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+HTTP Path to be used for the sniffing requests
+the default value is computed by concatenating the path value and "_nodes/http"
+if sniffing_path is set it will be used as an absolute path
+do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+SSL certificate to use to authenticate the client. This certificate should be an OpenSSL-style X.509 certificate file.
+
+NOTE: This setting can be used only if <<{version}-plugins-{type}s-{plugin}-ssl_key>> is set.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+  * Value type is a list of {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting
+
+The .cer or .pem files to validate the server's certificate.
+
+NOTE: You cannot use this setting and <<{version}-plugins-{type}s-{plugin}-ssl_truststore_path>> at the same time.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_cipher_suites"]
+===== `ssl_cipher_suites`
+  * Value type is a list of {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting
+
+The list of cipher suites to use, listed by priorities.
+Supported cipher suites vary depending on the Java and protocol versions.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster.
+Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<{version}-plugins-{type}s-{plugin}-hosts>> or extracted from the <<{version}-plugins-{type}s-{plugin}-cloud_id>>.
+If no explicit protocol is specified plain HTTP will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+OpenSSL-style RSA private key that corresponds to the <<{version}-plugins-{type}s-{plugin}-ssl_certificate>>.
+
+NOTE: This setting can be used only if <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> is set.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_keystore_password"]
+===== `ssl_keystore_password`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the keystore password
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_keystore_path"]
+===== `ssl_keystore_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either `.jks` or `.p12`
+
+NOTE: You cannot use this setting and <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_keystore_type"]
+===== `ssl_keystore_type`
+
+  * Value can be any of: `jks`, `pkcs12`
+  * If not provided, the value will be inferred from the keystore filename.
+
+The format of the keystore file. It must be either `jks` or `pkcs12`.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_supported_protocols"]
+===== `ssl_supported_protocols`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Allowed values are: `'TLSv1.1'`, `'TLSv1.2'`, `'TLSv1.3'`
+  * Default depends on the JDK being used. With up-to-date Logstash, the default is `['TLSv1.2', 'TLSv1.3']`.
+    `'TLSv1.1'` is not considered secure and is only provided for legacy applications.
+
+List of allowed SSL/TLS versions to use when establishing a connection to the Elasticsearch cluster.
+
+For Java 8 `'TLSv1.3'` is supported only since **8u262** (AdoptOpenJDK), but requires that you set the
+`LS_JAVA_OPTS="-Djdk.tls.client.protocols=TLSv1.3"` system property in Logstash.
+
+NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as the one packaged with Logstash,
+the protocol is disabled by default and needs to be enabled manually by changing `jdk.tls.disabledAlgorithms` in
+the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_truststore_password"]
+===== `ssl_truststore_password`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+  * There is no default value for this setting.
+
+Set the truststore password
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_truststore_path"]
+===== `ssl_truststore_path`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+The truststore to validate the server's certificate.
+It can be either `.jks` or `.p12`.
+
+NOTE: You cannot use this setting and <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>> at the same time.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_truststore_type"]
+===== `ssl_truststore_type`
+
+* Value can be any of: `jks`, `pkcs12`
+* If not provided, the value will be inferred from the truststore filename.
+
+The format of the truststore file. It must be either `jks` or `pkcs12`.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+  * Value can be any of: `full`, `none`
+  * Default value is `full`
+
+Defines how to verify the certificates presented by another party in the TLS connection:
+
+`full` validates that the server certificate has an issue date that’s within
+the not_before and not_after dates; chains to a trusted Certificate Authority (CA), and
+has a hostname or IP address that matches the names within the certificate.
+
+`none` performs no certificate validation.
+
+WARNING: Setting certificate verification to `none` disables many security benefits of SSL/TLS, which is very dangerous. For more information on disabling certificate verification please read https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="{version}-plugins-{type}s-{plugin}-template"]
+===== `template`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+  * There is no default value for this setting.
+
+You can set the path to your own template here, if you so desire.
+If not set, the included template will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-template_api"]
+===== `template_api`
+
+  * Value can be any of: `auto`, `legacy`, `composable`
+  * Default value is `auto`
+
+The default setting of `auto` will use
+{ref}/index-templates.html[index template API] to create index template, if the
+Elasticsearch cluster is running Elasticsearch version `8.0.0` or higher,
+and use {ref}/indices-templates-v1.html[legacy template API] otherwise.
+
+Setting this flag to `legacy` will use legacy template API to create index template.
+Setting this flag to `composable` will use index template API to create index template.
+
+NOTE: The format of template provided to <<{version}-plugins-{type}s-{plugin}-template>> needs to match the template API being used.
+
+[id="{version}-plugins-{type}s-{plugin}-template_name"]
+===== `template_name`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value depends on whether <<{version}-plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `logstash`
+    ** ECS Compatibility enabled: `ecs-logstash`
+
+
+This configuration option defines how the template is named inside Elasticsearch.
+Note that if you have used the template management features and subsequently
+change this, you will need to prune the old template manually, e.g.
+
+`curl -XDELETE <http://localhost:9200/_template/OldTemplateName?pretty>`
+
+where `OldTemplateName` is whatever the former setting was.
+
+[id="{version}-plugins-{type}s-{plugin}-template_overwrite"]
+===== `template_overwrite`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `false`
+
+The template_overwrite option will always overwrite the indicated template
+in Elasticsearch with either the one indicated by template or the included one.
+This option is set to false by default. If you always want to stay up to date
+with the template provided by Logstash, this option could be very useful to you.
+Likewise, if you have your own template file managed by puppet, for example, and
+you wanted to be able to update it regularly, this option could help there as well.
+
+Please note that if you are using your own customized version of the Logstash
+template (logstash), setting this to true will make Logstash to overwrite
+the "logstash" template (i.e. removing all customized settings)
+
+[id="{version}-plugins-{type}s-{plugin}-timeout"]
+===== `timeout`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `60`
+
+Set the timeout, in seconds, for network operations and requests sent Elasticsearch. If
+a timeout occurs, the request will be retried.
+
+[id="{version}-plugins-{type}s-{plugin}-upsert"]
+===== `upsert`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * Default value is `""`
+
+Set upsert content for update mode.
+Create a new document with this parameter as json string if `document_id` doesn't exists
+
+[id="{version}-plugins-{type}s-{plugin}-user"]
+===== `user`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+Username to authenticate to a secure Elasticsearch cluster
+
+[id="{version}-plugins-{type}s-{plugin}-validate_after_inactivity"]
+===== `validate_after_inactivity`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
+  * Default value is `10000`
+
+How long to wait before checking for a stale connection to determine if a keepalive request is needed.
+Consider setting this value lower than the default, possibly to 0, if you get connection errors regularly.
+
+This client is based on Apache Commons. Here's how the
+https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[Apache
+Commons documentation] describes this option: "Defines period of inactivity in
+milliseconds after which persistent connections must be re-validated prior to
+being leased to the consumer. Non-positive value passed to this method disables
+connection validation. This check helps detect connections that have become
+stale (half-closed) while kept inactive in the pool."
+
+[id="{version}-plugins-{type}s-{plugin}-version"]
+===== `version`
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#string[string]
+  * There is no default value for this setting.
+
+The version to use for indexing. Use sprintf syntax like `%{my_version}` to use
+a field value here. See the
+https://www.elastic.co/blog/elasticsearch-versioning-support[versioning support
+blog] for more information.
+
+[id="{version}-plugins-{type}s-{plugin}-version_type"]
+===== `version_type`
+
+  * Value can be any of: `internal`, `external`, `external_gt`, `external_gte`, `force`
+  * There is no default value for this setting.
+
+The version_type to use for indexing. See the
+https://www.elastic.co/blog/elasticsearch-versioning-support[versioning support
+blog] and {ref}/docs-index_.html#_version_types[Version types] in the
+Elasticsearch documentation.
+
+[id="{version}-plugins-{type}s-{plugin}-deprecated-options"]
+==== Elasticsearch Output Deprecated Configuration Options
+
+This plugin supports the following deprecated configurations.
+
+WARNING: Deprecated options are subject to removal in future releases.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting|Input type|Replaced by
+| <<{version}-plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|<<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| <<{version}-plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|<<{version}-plugins-{type}s-{plugin}-ssl_keystore_path>>
+| <<{version}-plugins-{type}s-{plugin}-keystore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|<<{version}-plugins-{type}s-{plugin}-ssl_keystore_password>>
+| <<{version}-plugins-{type}s-{plugin}-ssl>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|<<{version}-plugins-{type}s-{plugin}-ssl_enabled>>
+| <<{version}-plugins-{type}s-{plugin}-ssl_certificate_verification>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|<<{version}-plugins-{type}s-{plugin}-ssl_verification_mode>>
+| <<{version}-plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|<<{version}-plugins-{type}s-{plugin}-ssl_truststore_path>>
+| <<{version}-plugins-{type}s-{plugin}-truststore_password>> |{logstash-ref}/configuration-file-structure.html#password[password]|<<{version}-plugins-{type}s-{plugin}-ssl_truststore_password>>
+|=======================================================================
+
+
+[id="{version}-plugins-{type}s-{plugin}-cacert"]
+===== `cacert`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
+
+* Value type is a list of {logstash-ref}/configuration-file-structure.html#path[path]
+* There is no default value for this setting.
+
+The .cer or .pem file to validate the server's certificate.
+
+[id="{version}-plugins-{type}s-{plugin}-keystore"]
+===== `keystore`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_keystore_path>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+* There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either .jks or .p12
+
+NOTE: You cannot use this setting and <<{version}-plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
+
+[id="{version}-plugins-{type}s-{plugin}-keystore_password"]
+===== `keystore_password`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_keystore_password>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+* There is no default value for this setting.
+
+Set the keystore password
+
+[id="{version}-plugins-{type}s-{plugin}-ssl"]
+===== `ssl`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_enabled>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+* There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster.
+Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<{version}-plugins-{type}s-{plugin}-hosts>> or extracted from the <<{version}-plugins-{type}s-{plugin}-cloud_id>>.
+If no explicit protocol is specified plain HTTP will be used.
+
+[id="{version}-plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_verification_mode>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+* Default value is `true`
+
+Option to validate the server's certificate. Disabling this severely compromises security.
+For more information on disabling certificate verification please read
+https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="{version}-plugins-{type}s-{plugin}-truststore"]
+===== `truststore`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_truststore_path>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#path[path]
+* There is no default value for this setting.
+
+The truststore to validate the server's certificate.
+It can be either `.jks` or `.p12`.
+Use either `:truststore` or `:cacert`.
+
+[id="{version}-plugins-{type}s-{plugin}-truststore_password"]
+===== `truststore_password`
+deprecated[11.14.0, Replaced by <<{version}-plugins-{type}s-{plugin}-ssl_truststore_password>>]
+
+* Value type is {logstash-ref}/configuration-file-structure.html#password[password]
+* There is no default value for this setting.
+
+Set the truststore password
+
+[id="{version}-plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:no_codec!:


### PR DESCRIPTION
### Description
We generated and added `logstash-integration-logstash` plugin placeholder to the repo. After that, when we generated VPR we witnessed that workflow couldn't catch es-output changes. The reason behind, when we generated VPR, we get the last commit date (`git log -1 --date=short --pretty=format:%cd`) and seek the new published gems after that date.

### Solution
I will create an issue and discuss expected behaviour with a team but this PR is a temporary unblock the doc process.