### PR TITLE
Add placeholder for integration-snmp page to LSR

### DIFF
--- a/docs/plugins/integrations/snmp.asciidoc
+++ b/docs/plugins/integrations/snmp.asciidoc
@@ -1,0 +1,21 @@
+:plugin: snmp
+:type: integration
+:default_plugin: 0
+:no_codec:
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: tbd
+:release_date: 2024-01-23
+:changelog_url: tbd
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== SNMP Integration Plugin
+
+include::{include_path}/plugin_header.asciidoc[]


### PR DESCRIPTION
When we publish the new integration plugin, the snmp-integration page will be created. This PR provides a target that we can link to for early validation.