### PR TITLE
TEST: Support level test

### DIFF
--- a/docs/plugins/inputs/azure_event_hubs.asciidoc
+++ b/docs/plugins/inputs/azure_event_hubs.asciidoc
@@ -2,6 +2,7 @@
 :type: input
 :default_plugin: 1
 :default_codec: plain
+:support_level: t1
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -523,4 +524,5 @@ See <<plugins-{type}s-{plugin}-best-practices>> for more information.
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:support_level!:
 :default_codec!:

--- a/docs/plugins/inputs/couchdb_changes.asciidoc
+++ b/docs/plugins/inputs/couchdb_changes.asciidoc
@@ -2,6 +2,7 @@
 :type: input
 :default_plugin: 1
 :default_codec: plain
+:support_level: t2
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -221,4 +222,5 @@ CouchDB
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:support_level!:
 :default_codec!:

--- a/docs/plugins/inputs/imap.asciidoc
+++ b/docs/plugins/inputs/imap.asciidoc
@@ -2,6 +2,7 @@
 :type: input
 :default_plugin: 1
 :default_codec: plain
+:support_level: comm
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -262,4 +263,5 @@ processed mail and then switch `uid_tracking` to `true`.
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:support_level!:
 :default_codec!:


### PR DESCRIPTION
### DO NOT MERGE!

This PR adds support-level attributes to select plugin doc files for testing https://github.com/elastic/logstash/pull/16206.

Selected plugins and examples:
- `input-azure` to test `Tier 1`
- `input-couchdb` to test `Tier 2`
- `input-imap` to test `Community`

#### Notes
* The attribute must be set at the beginning of each file. It must be cleared (`:support_level!:`) at the end of each file to prevent the setting bleeding over into subsequent files. 
* I'm adding the attribute to generated files for testing.  To _implement_, we'll need to add (and reset) the variable in the plugin doc source file in each individual plugin repo, bump version and changelog, merge, and re-publish the plugin to rubygems.org.
* Decisions on how we'll support attributes are ongoing, and may impact this implementation. 