### PR TITLE
VPR: Reimplement plugin headers for SNMP integration at v4.0.0

### DIFF
--- a/docs/versioned-plugins/inputs/snmp-v4.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/snmp-v4.0.0.asciidoc
@@ -18,8 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === SNMP input plugin {version}
 
-// Uncomment after generated the initial versions of the target file
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/inputs/snmptrap-v4.0.0.asciidoc
+++ b/docs/versioned-plugins/inputs/snmptrap-v4.0.0.asciidoc
@@ -18,8 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === SNMP trap input plugin {version}
 
-//Uncomment after generated the initial versions of the target file
-//include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/versioned-plugins/integrations/snmp-v4.0.0.asciidoc
+++ b/docs/versioned-plugins/integrations/snmp-v4.0.0.asciidoc
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === SNMP Integration Plugin {version}
 
-// include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 experimental[]
 


### PR DESCRIPTION
Now that all generated files are present, we can reimplement plugin headers.  This change gives us short names (essentially version numbers in this case) in the left nav, and generated plugin info at the top of each plugin doc. 

Fixes: https://github.com/elastic/logstash/issues/16319

### Before
<img width="1116" alt="Screen Shot 2024-07-10 at 4 31 29 PM" src="https://github.com/elastic/logstash-docs/assets/35154725/db3c4954-847e-439b-bb49-661d666f4111">

### After
<img width="1835" alt="Screen Shot 2024-07-10 at 5 53 03 PM" src="https://github.com/elastic/logstash-docs/assets/35154725/eed1d3a2-0612-467e-9d4a-310fedd6cd32">

Note that activating the plugin headers substitutes the short title in the left nav, and adds generated plugin info at the top of the page. 

