### PR TITLE
TEST crossdoc links for output-elasticsearch

### DIFF
--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -326,8 +326,10 @@ When a string value on an event contains one or more byte sequences that are not
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Output Configuration Options
 
-This plugin supports the following configuration options plus the
-<<plugins-{type}s-{plugin}-common-options>> and the <<plugins-{type}s-{plugin}-deprecated-options>> described later.
+This plugin supports these configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+NOTE: As of version 12.0.0 of this plugin, a number of previously deprecated SSL settings have been removed.
+Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -442,7 +444,7 @@ For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bu
   * There is no default value for this setting.
 
 Authenticate using Elasticsearch API key.
-Note that this option also requires SSL/TLS, which can be enabled by supplying a <<plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<plugins-{type}s-{plugin}-hosts>>, or by setting <<plugins-{type}s-{plugin}-ssl,`ssl_enabled => true`>>.
+Note that this option also requires SSL/TLS, which can be enabled by supplying a <<plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<plugins-{type}s-{plugin}-hosts>>, or by setting <<plugins-{type}s-{plugin}-ssl_enabled,`ssl_enabled => true`>>.
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
 Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
@@ -1325,97 +1327,23 @@ https://www.elastic.co/blog/elasticsearch-versioning-support[versioning support
 blog] and {ref}/docs-index_.html#_version_types[Version types] in the
 Elasticsearch documentation.
 
-[id="plugins-{type}s-{plugin}-deprecated-options"]
-==== Elasticsearch Output Deprecated Configuration Options
+[id="plugins-{type}s-{plugin}-obsolete-options"]
+==== Elasticsearch Output Obsolete Configuration Options
 
-This plugin supports the following deprecated configurations.
+WARNING: As of version `12.0.0` of this plugin, some configuration options have been replaced.
+The plugin will fail to start if it contains any of these obsolete options.
 
-WARNING: Deprecated options are subject to removal in future releases.
-
-[cols="<,<,<",options="header",]
+[cols="<,<",options="header",]
 |=======================================================================
-|Setting|Input type|Replaced by
-| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_keystore_path>>
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|<<plugins-{type}s-{plugin}-ssl_keystore_password>>
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|<<plugins-{type}s-{plugin}-ssl_enabled>>
-| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|<<plugins-{type}s-{plugin}-ssl_verification_mode>>
-| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_truststore_path>>
-| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|<<plugins-{type}s-{plugin}-ssl_truststore_password>>
+|Setting|Replaced by
+| cacert | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| keystore | <<plugins-{type}s-{plugin}-ssl_keystore_path>>
+| keystore_password | <<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| ssl | <<plugins-{type}s-{plugin}-ssl_enabled>>
+| ssl_certificate_verification | <<plugins-{type}s-{plugin}-ssl_verification_mode>>
+| truststore | <<plugins-{type}s-{plugin}-ssl_truststore_path>>
+| truststore_password | <<plugins-{type}s-{plugin}-ssl_truststore_password>>
 |=======================================================================
-
-
-[id="plugins-{type}s-{plugin}-cacert"]
-===== `cacert`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
-
-* Value type is a list of <<path,path>>
-* There is no default value for this setting.
-
-The .cer or .pem file to validate the server's certificate.
-
-[id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-
-The keystore used to present a certificate to the server.
-It can be either .jks or .p12
-
-NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
-
-[id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-
-Set the keystore password
-
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
-
-* Value type is <<boolean,boolean>>
-* There is no default value for this setting.
-
-Enable SSL/TLS secured communication to Elasticsearch cluster.
-Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
-If no explicit protocol is specified plain HTTP will be used.
-
-[id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
-===== `ssl_certificate_verification`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
-
-* Value type is <<boolean,boolean>>
-* Default value is `true`
-
-Option to validate the server's certificate. Disabling this severely compromises security.
-For more information on disabling certificate verification please read
-https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
-
-[id="plugins-{type}s-{plugin}-truststore"]
-===== `truststore`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-
-The truststore to validate the server's certificate.
-It can be either `.jks` or `.p12`.
-Use either `:truststore` or `:cacert`.
-
-[id="plugins-{type}s-{plugin}-truststore_password"]
-===== `truststore_password`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-
-Set the truststore password
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
### TEST: DO NOT MERGE

Related:  https://github.com/elastic/docs-tools/issues/42

I've tested docs locally for https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1197. 
A local test can catch:
- some improper asciidoc formatting (if it's serious enough to prevent a successful build). 
   Example: Using the same anchor text in more than one place.
- missing `include` or referenced files or bad links (within the plugin doc or from the Logstash Reference)

After we get a successful build, we can PREVIEW the doc to spot other formatting errors--not bad enough to fail, but ugly. 
  Example: Tables or bulleted lists not rendering properly. 

A full doc build against all of elastic.co docs is the best way to be sure that we don't have any **_hidden cross-doc links_** coming from other docs. Example: Elasticsearch Reference linking to the elasticsearch output plugin.  Fortunately, CI can handle this test case, hence this PR. 

Obviously, if we have bad links coming from other docs, those links will need to be updated in the other doc(s). 

Note to self @karenzone:  Remind people that this ad hoc build strategy doesn't fully test docs generated with VPR builds.  That is, even with this testing, we could still have introduced potential failures.  

#### About this test

This PR is a result of manually copying the body of the plugin doc from https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1197, and pasting it into the existing generated output in `logstash-docs`.  Then I let CI do the testing against our full Elastic.co doc set. 