### PR TITLE
TEST: Validate docs for 54-aws-intg

### DIFF
--- a/docs/plugins/outputs/cloudwatch.asciidoc
+++ b/docs/plugins/outputs/cloudwatch.asciidoc
@@ -326,7 +326,6 @@ If provided, this must be a string which can be converted to a float, for exampl
 If you set this option you should probably set the `unit` option along with it
 
 
-
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 


### PR DESCRIPTION
## DO NOT MERGE

This is a TEST PR to validate updated doc content for: 
- https://github.com/logstash-plugins/logstash-integration-aws/pull/54

## Test status
~TEST IN PROGRESS. DO NOT MERGE~
TEST COMPLETE. 

### Notes
- This PR tests removal of content and links introduced in https://github.com/logstash-plugins/logstash-integration-aws/pull/52. That's why the diff doesn't contain much.  
- To set up the PR, I copied content from both asciidoc source files and pasted it into current versions of the generated files, leaving generated header info in place.  (Note that the version plugin version number reflects the earlier generated version--but that's not what we're testing.)
- More detailed instructions are in [this issue](https://github.com/elastic/ingest-dev/issues/3243), waiting to be turned into internal docs. 