### PR TITLE
Research: Plugin docgen without docbuild

### DIFF
--- a/.github/workflows/reference_docs90.yml
+++ b/.github/workflows/reference_docs90.yml
@@ -63,11 +63,6 @@ jobs:
         run: |
           bundle install --path=vendor/bundle
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
-      - name: Build docs
-        working-directory: ./logstash-docs
-        run: ../docs/build_docs --asciidoctor --respect_edit_url_overrides --doc docs/plugins/index.asciidoc --chunk 1
-      - run: echo "T=$(date +%s)" >> $GITHUB_ENV
-      - run: echo "BRANCH=update_docs_${T}" >> $GITHUB_ENV
       - name: Commit and Push
         working-directory: ./logstash-docs
         run: |

--- a/.github/workflows/reference_docs90.yml
+++ b/.github/workflows/reference_docs90.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           bundle install --path=vendor/bundle
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
+      - name: Prepare doc updates 
+        - run: echo "T=$(date +%s)" >> $GITHUB_ENV
+        - run: echo "BRANCH=update_docs_${T}" >> $GITHUB_ENV
       - name: Commit and Push
         working-directory: ./logstash-docs
         run: |


### PR DESCRIPTION
What would happen if we skip the docbuild step in the GitHub action so that we can get output in a PR? 

Could we push the generated plugin output into a PR? Then the docs-ci on the PR would run and fail because the `include_path` variable would be over-written with the invalid path from plugin source. BUT, we'd have some output to work with!  We'd have a definitive list of changed plugins, and fixing the path using GitHub suggestions would be easy.  

**Micro goal:** Get a PR that contains doc output that I can adjust in order to avoid all of the manual steps required in https://github.com/elastic/logstash-docs-md/issues/16. 


