### PR TITLE
Add header for non-standard repo

### DIFF
--- a/docs/plugins/filters/elastic_integration.asciidoc
+++ b/docs/plugins/filters/elastic_integration.asciidoc
@@ -19,7 +19,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === {elastic-integration-name} filter plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-nonstandard.asciidoc[]
 
 .Elastic Enterprise License
 ****

--- a/docs/plugins/include/plugin_header-nonstandard.asciidoc
+++ b/docs/plugins/include/plugin_header-nonstandard.asciidoc
@@ -1,0 +1,25 @@
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+* Plugin version: {version}
+* Released on: {release_date}
+* {changelog_url}[Changelog]
+
+For other versions, see the
+{lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
+
+ifeval::["{default_plugin}"=="0"]
+
+==== Installation
+
+For plugins not bundled by default, it is easy to install by running +bin/logstash-plugin install logstash-{type}-{plugin}+. See {logstash-ref}/working-with-plugins.html[Working with plugins] for more details.
+
+endif::[]
+
+==== Getting help
+
+For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an issue in https://github.com/elastic/logstash-{type}-{plugin}[Github].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#logstash_plugins[Elastic Support Matrix].
+


### PR DESCRIPTION
Related: https://github.com/elastic/logstash-filter-elastic_integration/issues/286

Adds non-standard plugin header to allow for plugins outside of the `logstash-plugins` org.
For now, only `logstash-filter-elastic_integration`.  

Uses `https://github.com/elastic/logstash-{type}-{plugin}[Github]` link pattern instead of `https://github.com/logstash-plugins/logstash-{type}-{plugin}[Github]`