### PR TITLE
Add include statement for integration

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -17,6 +17,9 @@ filters and codecs--into one package.
 :edit_url: https://github.com/logstash-plugins/logstash-integration-aws/edit/main/docs/index.asciidoc
 include::integrations/aws.asciidoc[]
 
+include::integrations/elastic_enterprise_search.asciidoc[]
+:edit_url:
+
 :edit_url: https://github.com/logstash-plugins/logstash-integration-jdbc/edit/main/docs/index.asciidoc
 include::integrations/jdbc.asciidoc[]
 


### PR DESCRIPTION
This integration no longer appears in the integrations list, but the file must be present for a successful local build. 
We're no longer building ADOC files for `main` and `9.0` so this change has no effect other than for local builds. 