### PR TITLE
GH: Rename github workflow for pre-9.0 docgen

### DIFF
--- a/.github/workflows/reference_docs-pre90.yml
+++ b/.github/workflows/reference_docs-pre90.yml
@@ -1,6 +1,6 @@
-name: "Reference Documentation generation for specified version"
+name: "Plugin docgen for specified 8.x and earlier"
 
-run-name: "Reference Documentation generation for ${{ github.event.inputs.branch }}"
+run-name: "Plugin docgen for ${{ github.event.inputs.branch }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Rename original docgen GH workflow to disambiguate from new docgen workflow for 9.0 and later.  
