### PR TITLE
Realign include path for 9.0

### DIFF
--- a/docs/plugins/filters/xml.asciidoc
+++ b/docs/plugins/filters/xml.asciidoc
@@ -8,7 +8,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v4.3.1
 :release_date: 2025-04-22
 :changelog_url: https://github.com/logstash-plugins/logstash-filter-xml/blob/v4.3.1/CHANGELOG.md
-:include_path: ../../../../logstash/docs/include
+:include_path: ../include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/inputs/salesforce.asciidoc
+++ b/docs/plugins/inputs/salesforce.asciidoc
@@ -9,7 +9,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v3.3.0
 :release_date: 2025-05-14
 :changelog_url: https://github.com/logstash-plugins/logstash-input-salesforce/blob/v3.3.0/CHANGELOG.md
-:include_path: ../../../../logstash/docs/include
+:include_path: ../include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/outputs/elasticsearch.asciidoc
+++ b/docs/plugins/outputs/elasticsearch.asciidoc
@@ -9,7 +9,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v12.0.3
 :release_date: 2025-04-17
 :changelog_url: https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v12.0.3/CHANGELOG.md
-:include_path: ../../../../logstash/docs/include
+:include_path: ../include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////

--- a/docs/plugins/outputs/tcp.asciidoc
+++ b/docs/plugins/outputs/tcp.asciidoc
@@ -9,7 +9,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: v7.0.1
 :release_date: 2025-04-29
 :changelog_url: https://github.com/logstash-plugins/logstash-output-tcp/blob/v7.0.1/CHANGELOG.md
-:include_path: ../../../../logstash/docs/include
+:include_path: ../include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////


### PR DESCRIPTION
Related: https://github.com/elastic/logstash/issues/17695

Updates `:include_path`  from changes in #1861 

It's true that these docs aren't being published anywhere at the moment, but it's important to keep docs aligned for the next phase of docs migration: html -> MD in `logstash-docs-md` 