### PR TITLE
Fix plugin docs actions

### DIFF
--- a/.github/workflows/reference_docs-pre90.yml
+++ b/.github/workflows/reference_docs-pre90.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Generate plugin docs
         working-directory: ./docs-tools
         run: |
-          bundle install --path=vendor/bundle
+          bundle config set path 'vendor/bundle'
+          bundle install
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
       - name: Build docs
         working-directory: ./logstash

--- a/.github/workflows/reference_docs-pre90.yml
+++ b/.github/workflows/reference_docs-pre90.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate plugin docs
         working-directory: ./docs-tools
         run: |
-          bundle config set path 'vendor/bundle'
+          bundle config set --local path 'vendor/bundle'
           bundle install
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
       - name: Build docs

--- a/.github/workflows/reference_docs90.yml
+++ b/.github/workflows/reference_docs90.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate plugin docs
         working-directory: ./docs-tools
         run: |
-          bundle config set path 'vendor/bundle'
+          bundle config set --local path 'vendor/bundle'
           bundle install
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV

--- a/.github/workflows/reference_docs90.yml
+++ b/.github/workflows/reference_docs90.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Generate plugin docs
         working-directory: ./docs-tools
         run: |
-          bundle install --path=vendor/bundle
+          bundle config set path 'vendor/bundle'
+          bundle install
           bundle exec ruby plugindocs.rb --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_docs_${T}" >> $GITHUB_ENV


### PR DESCRIPTION
Use udpated bundler config option in favor of deprecated `--path`.

Fixes:
- https://github.com/elastic/logstash-docs/actions/runs/24744416558
- https://github.com/elastic/logstash-docs/actions/runs/24744429979